### PR TITLE
Convert custom CSS classes to Tailwind

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -358,7 +358,7 @@ function App() {
             path="/app/recipes"
             element={
               <div className="space-y-6">
-                <div className="flex flex-col sm:flex-row justify-between items-center gap-4 section-card">
+                <div className="flex flex-col sm:flex-row justify-between items-center gap-4 bg-pastel-card p-6 rounded-xl shadow-pastel-soft">
                   <h2 className="text-2xl sm:text-3xl font-bold text-pastel-primary">
                     {recipePageTitle}
                   </h2>

--- a/src/components/AccountPage.jsx
+++ b/src/components/AccountPage.jsx
@@ -8,7 +8,7 @@ export default function AccountPage({ session, userProfile, onProfileUpdate }) {
   if (!session || !userProfile) {
     return (
       <div className="flex justify-center items-center h-screen">
-        <p className="section-card text-center p-8">
+        <p className="bg-pastel-card p-6 rounded-xl shadow-pastel-soft text-center p-8">
           Chargement des informations du compte...
         </p>
       </div>

--- a/src/components/FriendsTab.jsx
+++ b/src/components/FriendsTab.jsx
@@ -159,7 +159,7 @@ export default function FriendsTab({ session, userProfile }) {
   return (
     <div className="space-y-6 mt-6">
       {friendRequests.length > 0 && (
-        <div className="section-card p-6">
+        <div className="bg-pastel-card p-6 rounded-xl shadow-pastel-soft">
           <h3 className="text-xl font-semibold text-pastel-text/80 mb-4 flex items-center">
             <MailQuestion className="w-5 h-5 mr-2 text-pastel-accent" />
             Demandes d'amis en attente ({friendRequests.length})
@@ -222,7 +222,7 @@ export default function FriendsTab({ session, userProfile }) {
       )}
 
       {friends.length > 0 && (
-        <div className="section-card p-6">
+        <div className="bg-pastel-card p-6 rounded-xl shadow-pastel-soft">
           <h3 className="text-xl font-semibold text-pastel-text/80 mb-4 flex items-center">
             <Users className="w-5 h-5 mr-2 text-pastel-tertiary" />
             Mes Amis ({friends.length})
@@ -298,7 +298,7 @@ export default function FriendsTab({ session, userProfile }) {
       )}
 
       {friendRequests.length === 0 && friends.length === 0 && (
-        <div className="text-center py-10 section-card">
+        <div className="text-center py-10 px-6 bg-pastel-card rounded-xl shadow-pastel-soft">
           <MessageSquare className="w-12 h-12 mx-auto mb-3 text-pastel-border" />
           <p className="text-xl text-pastel-muted-foreground mb-2">
             Votre cercle d'amis est vide pour le moment.

--- a/src/components/MenuPlanner.jsx
+++ b/src/components/MenuPlanner.jsx
@@ -598,7 +598,7 @@ function MenuPlanner({
 
   return (
     <div className="space-y-8">
-      <div className="flex flex-col sm:flex-row justify-between items-center gap-4 section-card">
+      <div className="flex flex-col sm:flex-row justify-between items-center gap-4 bg-pastel-card p-6 rounded-xl shadow-pastel-soft">
         <h2 className="text-2xl sm:text-3xl font-bold text-pastel-primary">
           Menu de la semaine
         </h2>
@@ -616,7 +616,7 @@ function MenuPlanner({
                 Préférences
               </Button>
             </DialogTrigger>
-            <DialogContent className="max-w-3xl modal-content-custom">
+            <DialogContent className="max-w-3xl bg-pastel-card border border-pastel-border rounded-lg dark:bg-pastel-card dark:border-pastel-border">
               <DialogHeader>
                 <DialogTitle>Préférences du Menu</DialogTitle>
                 <DialogDescription>
@@ -663,7 +663,7 @@ function MenuPlanner({
         </div>
       </div>
 
-      <div className="menu-grid">
+      <div className="grid gap-3 sm:gap-4 grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xxl:grid-cols-7">
         {DAYS.map((day, dayIdx) => (
           <DailyMenu
             key={day}

--- a/src/components/MenuPreferences.jsx
+++ b/src/components/MenuPreferences.jsx
@@ -106,7 +106,7 @@ function MenuPreferences({ preferences, setPreferences, availableTags }) {
   };
 
   return (
-    <div className="section-card mb-8 space-y-6">
+    <div className="bg-pastel-card p-6 rounded-xl shadow-pastel-soft mb-8 space-y-6">
       <h3 className="text-xl font-semibold text-pastel-primary">
         Préférences du menu
       </h3>

--- a/src/components/MyPublicProfile.jsx
+++ b/src/components/MyPublicProfile.jsx
@@ -100,7 +100,7 @@ export default function MyPublicProfile({
 
   if (!profileData && !session?.user?.id) {
     return (
-      <div className="text-center py-12 section-card">
+      <div className="text-center py-12 px-6 bg-pastel-card rounded-xl shadow-pastel-soft">
         <h1 className="text-2xl font-bold text-pastel-primary mb-4">
           Non connecté
         </h1>
@@ -113,7 +113,7 @@ export default function MyPublicProfile({
 
   if (!profileData && session?.user?.id) {
     return (
-      <div className="text-center py-12 section-card">
+      <div className="text-center py-12 px-6 bg-pastel-card rounded-xl shadow-pastel-soft">
         <h1 className="text-2xl font-bold text-pastel-primary mb-4">
           Erreur de chargement
         </h1>
@@ -127,7 +127,7 @@ export default function MyPublicProfile({
   return (
     <>
       <div className="space-y-8 mt-6">
-        <div className="section-card p-6 sm:p-8">
+        <div className="bg-pastel-card p-6 sm:p-8 rounded-xl shadow-pastel-soft">
           <div className="flex flex-col sm:flex-row items-center sm:items-start gap-6 mb-8">
             {profileData.avatar_url ? (
               <img
@@ -182,7 +182,7 @@ export default function MyPublicProfile({
               onSelectRecipe={setSelectedRecipeForDetail}
             />
           ) : (
-            <div className="text-center py-10 section-card">
+            <div className="text-center py-10 px-6 bg-pastel-card rounded-xl shadow-pastel-soft">
               <p className="text-xl text-pastel-muted-foreground">
                 Vous n'avez pas encore partagé de recettes (ou elles sont toutes
                 privées).

--- a/src/components/RecipeDetailModal.jsx
+++ b/src/components/RecipeDetailModal.jsx
@@ -45,7 +45,7 @@ function RecipeDetailModal({ recipe, onClose, userProfile }) {
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         exit={{ opacity: 0 }}
-        className="recipe-detail-modal-overlay"
+        className="fixed inset-0 flex items-center justify-center z-[60] p-4 bg-pastel-background/70 dark:bg-black/70"
         onClick={onClose}
       >
         <motion.div
@@ -53,7 +53,7 @@ function RecipeDetailModal({ recipe, onClose, userProfile }) {
           animate={{ y: 0, opacity: 1, scale: 1 }}
           exit={{ y: 50, opacity: 0, scale: 0.9 }}
           transition={{ type: 'spring', stiffness: 300, damping: 30 }}
-          className="recipe-detail-modal-content bg-pastel-card text-pastel-text"
+          className="rounded-xl shadow-xl w-full max-w-2xl max-h-[90vh] flex flex-col bg-pastel-card text-pastel-text"
           onClick={(e) => e.stopPropagation()}
         >
           <header className="p-6 border-b border-pastel-border flex justify-between items-center sticky top-0 bg-pastel-card z-10">

--- a/src/components/RecipeList.jsx
+++ b/src/components/RecipeList.jsx
@@ -135,7 +135,7 @@ function RecipeList({ recipes, onEdit, onDelete, onSelectRecipe }) {
 
   if (!recipes || recipes.length === 0) {
     return (
-      <div className="text-center py-12 section-card">
+      <div className="text-center py-12 px-6 bg-pastel-card rounded-xl shadow-pastel-soft">
         <p className="text-xl text-pastel-muted-foreground">
           Aucune recette trouvée.
         </p>

--- a/src/components/ShoppingList.jsx
+++ b/src/components/ShoppingList.jsx
@@ -97,7 +97,7 @@ function ShoppingList({ weeklyMenu, recipes, userProfile }) {
   }, [shoppingList]);
 
   return (
-    <div className="section-card">
+    <div className="bg-pastel-card p-6 rounded-xl shadow-pastel-soft">
       <h2 className="text-2xl sm:text-3xl font-bold text-pastel-primary mb-6">
         Liste de courses
       </h2>

--- a/src/components/account/EmailForm.jsx
+++ b/src/components/account/EmailForm.jsx
@@ -60,7 +60,7 @@ export default function EmailForm({ session, onProfileUpdate }) {
   return (
     <form
       onSubmit={handleEmailChange}
-      className="section-card space-y-5 p-6 sm:p-8"
+      className="bg-pastel-card p-6 sm:p-8 rounded-xl shadow-pastel-soft space-y-5"
     >
       <h3 className="text-xl sm:text-2xl font-semibold text-pastel-text/90 border-b border-pastel-border pb-3 mb-5">
         Adresse Email

--- a/src/components/account/PasswordChangeForm.jsx
+++ b/src/components/account/PasswordChangeForm.jsx
@@ -62,7 +62,7 @@ export default function PasswordChangeForm() {
   return (
     <form
       onSubmit={handlePasswordChange}
-      className="section-card space-y-5 p-6 sm:p-8"
+      className="bg-pastel-card p-6 sm:p-8 rounded-xl shadow-pastel-soft space-y-5"
     >
       <h3 className="text-xl sm:text-2xl font-semibold text-pastel-text/90 border-b border-pastel-border pb-3 mb-5">
         Changer le mot de passe

--- a/src/components/account/ProfileInformationForm.jsx
+++ b/src/components/account/ProfileInformationForm.jsx
@@ -156,7 +156,7 @@ export default function ProfileInformationForm({
   return (
     <form
       onSubmit={handleSaveChanges}
-      className="section-card space-y-5 p-6 sm:p-8"
+      className="bg-pastel-card p-6 sm:p-8 rounded-xl shadow-pastel-soft space-y-5"
     >
       <h3 className="text-xl sm:text-2xl font-semibold text-pastel-text/90 border-b border-pastel-border pb-3 mb-5">
         Informations du profil

--- a/src/components/account/SubscriptionManagement.jsx
+++ b/src/components/account/SubscriptionManagement.jsx
@@ -146,7 +146,7 @@ export default function SubscriptionManagement({
   const isPremium = currentSubscriptionTier === 'premium';
 
   return (
-    <div className="section-card space-y-6 p-6 sm:p-8">
+    <div className="bg-pastel-card p-6 sm:p-8 rounded-xl shadow-pastel-soft space-y-6">
       <h3 className="text-xl sm:text-2xl font-semibold text-pastel-text/90 border-b border-pastel-border pb-3 mb-5">
         Gestion de l'Abonnement
       </h3>

--- a/src/components/form/RecipeIngredientsManager.jsx
+++ b/src/components/form/RecipeIngredientsManager.jsx
@@ -26,7 +26,7 @@ export default function RecipeIngredientsManager({
   };
 
   return (
-    <div className="space-y-4 section-card p-5">
+    <div className="space-y-4 bg-pastel-card p-5 rounded-xl shadow-pastel-soft">
       <Label className="text-lg font-semibold text-pastel-secondary">
         Ingrédients
       </Label>

--- a/src/components/form/RecipeInstructionsManager.jsx
+++ b/src/components/form/RecipeInstructionsManager.jsx
@@ -7,7 +7,7 @@ export default function RecipeInstructionsManager({
   handleInstructionsChange,
 }) {
   return (
-    <div className="space-y-2 section-card p-5">
+    <div className="space-y-2 bg-pastel-card p-5 rounded-xl shadow-pastel-soft">
       <Label
         htmlFor="instructions"
         className="text-lg font-semibold text-pastel-secondary"

--- a/src/components/menu_planner/MenuPreferencesPanel.jsx
+++ b/src/components/menu_planner/MenuPreferencesPanel.jsx
@@ -142,7 +142,7 @@ function MenuPreferencesPanel({
       animate={{ opacity: 1, height: 'auto' }}
       exit={{ opacity: 0, height: 0 }}
       transition={{ duration: 0.3 }}
-      className="section-card mb-8 space-y-6 overflow-hidden"
+      className="bg-pastel-card p-6 rounded-xl shadow-pastel-soft mb-8 space-y-6 overflow-hidden"
     >
       <h3 className="text-xl font-semibold text-pastel-primary">
         Préférences du menu
@@ -211,7 +211,7 @@ function MenuPreferencesPanel({
                 <Info className="h-4 w-4" />
               </Button>
             </DialogTrigger>
-            <DialogContent className="modal-content-custom">
+            <DialogContent className="bg-pastel-card border border-pastel-border rounded-lg dark:bg-pastel-card dark:border-pastel-border">
               <DialogHeader>
                 <DialogTitle>Menu Commun</DialogTitle>
                 <DialogDescription>

--- a/src/components/menu_planner/ReplaceRecipeModal.jsx
+++ b/src/components/menu_planner/ReplaceRecipeModal.jsx
@@ -23,7 +23,7 @@ function ReplaceRecipeModal({
 }) {
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[600px] modal-content-custom">
+      <DialogContent className="sm:max-w-[600px] bg-pastel-card border border-pastel-border rounded-lg dark:bg-pastel-card dark:border-pastel-border">
         <DialogHeader>
           <DialogTitle className="text-pastel-primary">
             Remplacer la recette

--- a/src/components/ui/dialog.jsx
+++ b/src/components/ui/dialog.jsx
@@ -16,7 +16,7 @@ const DialogOverlay = React.forwardRef(({ className, ...props }, ref) => (
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      'modal-overlay-custom',
+      'fixed inset-0 z-50 bg-pastel-background/70 dark:bg-black/70',
       'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
       className
     )}
@@ -32,7 +32,7 @@ const DialogContent = React.forwardRef(
       <DialogPrimitive.Content
         ref={ref}
         className={cn(
-          'modal-content-custom',
+          'bg-pastel-card border border-pastel-border rounded-lg dark:bg-pastel-card dark:border-pastel-border',
           'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 p-6 shadow-xl duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]',
           className
         )}

--- a/src/index.css
+++ b/src/index.css
@@ -144,35 +144,6 @@
   }
 }
 
-.menu-grid {
-  @apply grid gap-3 sm:gap-4;
-  grid-template-columns: 1fr;
-}
-
-@media (min-width: 640px) {
-  .menu-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-}
-
-@media (min-width: 768px) {
-  .menu-grid {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
-}
-
-@media (min-width: 1024px) {
-  .menu-grid {
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-  }
-}
-
-@media (min-width: 1366px) {
-  .menu-grid {
-    grid-template-columns: repeat(7, minmax(0, 1fr));
-  }
-}
-
 ::-webkit-scrollbar {
   width: 8px;
   height: 8px;
@@ -187,35 +158,4 @@
 }
 ::-webkit-scrollbar-thumb:hover {
   background: hsla(var(--pastel-muted-foreground), 0.8);
-}
-
-.section-card {
-  @apply bg-pastel-card p-6 rounded-xl shadow-pastel-soft;
-}
-
-.modal-overlay-custom {
-  @apply fixed inset-0 z-50;
-  background-color: hsla(var(--background), 0.7);
-}
-.dark .modal-overlay-custom {
-  background-color: rgba(0, 0, 0, 0.7);
-}
-
-.modal-content-custom {
-  @apply bg-pastel-card border border-pastel-border rounded-lg;
-}
-.dark .modal-content-custom {
-  @apply bg-pastel-card border-pastel-border;
-}
-
-.recipe-detail-modal-overlay {
-  @apply fixed inset-0 flex items-center justify-center z-[60] p-4;
-  background-color: hsla(var(--background), 0.7);
-}
-.dark .recipe-detail-modal-overlay {
-  background-color: rgba(0, 0, 0, 0.7);
-}
-
-.recipe-detail-modal-content {
-  @apply rounded-xl shadow-xl w-full max-w-2xl max-h-[90vh] flex flex-col;
 }

--- a/src/pages/CommunityPage.jsx
+++ b/src/pages/CommunityPage.jsx
@@ -134,7 +134,7 @@ export default function CommunityPage({ session, userProfile }) {
 
   return (
     <div className="space-y-8">
-      <div className="section-card p-6 sm:p-8">
+      <div className="bg-pastel-card p-6 sm:p-8 rounded-xl shadow-pastel-soft">
         <div className="flex flex-col items-center text-center">
           <Users className="w-16 h-16 text-pastel-secondary mb-4" />
           <h1 className="text-3xl sm:text-4xl font-bold text-pastel-primary mb-3 tracking-tight">
@@ -169,7 +169,7 @@ export default function CommunityPage({ session, userProfile }) {
 
         <TabsContent value="discover" className="mt-6">
           <div className="space-y-8">
-            <div className="section-card p-6">
+            <div className="bg-pastel-card p-6 rounded-xl shadow-pastel-soft">
               <form
                 onSubmit={handleSearch}
                 className="flex flex-col sm:flex-row gap-3 max-w-xl mx-auto"
@@ -198,7 +198,7 @@ export default function CommunityPage({ session, userProfile }) {
             </div>
 
             {searchResults.length > 0 && (
-              <div className="section-card p-6">
+              <div className="bg-pastel-card p-6 rounded-xl shadow-pastel-soft">
                 <h2 className="text-xl font-semibold text-pastel-primary mb-4">
                   Résultats de la recherche :
                 </h2>
@@ -240,14 +240,14 @@ export default function CommunityPage({ session, userProfile }) {
               </div>
             )}
             {searchTerm && !loadingSearch && searchResults.length === 0 && (
-              <div className="text-center py-8 section-card">
+              <div className="text-center py-8 px-6 bg-pastel-card rounded-xl shadow-pastel-soft">
                 <p className="text-lg text-pastel-muted-foreground">
                   Aucun utilisateur trouvé pour "{searchTerm}".
                 </p>
               </div>
             )}
 
-            <div className="section-card p-6">
+            <div className="bg-pastel-card p-6 rounded-xl shadow-pastel-soft">
               <h2 className="text-xl sm:text-2xl font-bold text-pastel-secondary mb-6 text-center">
                 Dernières Recettes Publiques
               </h2>

--- a/src/pages/UserProfilePage.jsx
+++ b/src/pages/UserProfilePage.jsx
@@ -238,7 +238,7 @@ export default function UserProfilePage({ session, currentUserProfile }) {
 
   if (!profileData) {
     return (
-      <div className="text-center py-12 section-card">
+      <div className="text-center py-12 px-6 bg-pastel-card rounded-xl shadow-pastel-soft">
         <h1 className="text-2xl font-bold text-pastel-primary mb-4">
           Profil introuvable
         </h1>
@@ -311,7 +311,7 @@ export default function UserProfilePage({ session, currentUserProfile }) {
   return (
     <>
       <div className="space-y-8">
-        <div className="section-card p-6 sm:p-8">
+        <div className="bg-pastel-card p-6 sm:p-8 rounded-xl shadow-pastel-soft">
           <div className="flex flex-col sm:flex-row items-center sm:items-start gap-6 mb-8">
             {profileData.avatar_url ? (
               <img
@@ -371,7 +371,7 @@ export default function UserProfilePage({ session, currentUserProfile }) {
               onSelectRecipe={setSelectedRecipeForDetail}
             />
           ) : (
-            <div className="text-center py-10 section-card">
+            <div className="text-center py-10 px-6 bg-pastel-card rounded-xl shadow-pastel-soft">
               <p className="text-xl text-pastel-muted-foreground">
                 {profileData.username} n&apos;a pas encore partagé de recettes.
               </p>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -16,6 +16,9 @@ export default {
       },
     },
     extend: {
+      screens: {
+        xxl: '1366px',
+      },
       colors: {
         border: "hsl(var(--border))",
         input: "hsl(var(--input))",


### PR DESCRIPTION
## Summary
- remove utility classes from `index.css`
- add `xxl` screen in Tailwind config
- replace custom modal and card styles with Tailwind classes

## Testing
- `npm run format`
- `npm run lint` *(fails: '__dirname' is not defined and many prop-types errors)*

------
https://chatgpt.com/codex/tasks/task_e_684edc5de11c832db16976e11d9206b0