### PR TITLE
Refactor recipe form logic into reusable hooks

### DIFF
--- a/src/components/RecipeForm.jsx
+++ b/src/components/RecipeForm.jsx
@@ -1,14 +1,14 @@
-import React, { useState, useEffect, useRef, useCallback } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { Button } from '@/components/ui/button';
 import { X, Loader2, Eye, EyeOff, Users, Globe } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import TagManager from '@/components/TagManager';
-import { generateTagSuggestions } from '@/lib/tagSuggestions';
-import { supabase } from '@/lib/supabase';
 import { useToast } from '@/components/ui/use-toast';
-import { useNavigate } from 'react-router-dom';
 import RecipeFormImageHandler from '@/components/RecipeFormImageHandler';
 import RecipeFormAIFeatures from '@/components/RecipeFormAIFeatures';
+import useTagHandling from '@/components/form/hooks/useTagHandling';
+import useImageUpload from '@/components/form/hooks/useImageUpload';
+import useAIGeneration from '@/components/form/hooks/useAIGeneration';
 import RecipeCoreFields from '@/components/form/RecipeCoreFields';
 import RecipeIngredientsManager from '@/components/form/RecipeIngredientsManager';
 import RecipeInstructionsManager from '@/components/form/RecipeInstructionsManager';
@@ -58,25 +58,47 @@ function RecipeForm({
   userProfile,
 }) {
   const [formData, setFormData] = useState(initialFormData);
-  const [showTagManager, setShowTagManager] = useState(false);
-  const [suggestedTags, setSuggestedTags] = useState([]);
-  const [isGeneratingDescription, setIsGeneratingDescription] = useState(false);
-  const [isGeneratingImage, setIsGeneratingImage] = useState(false);
-  const [isUploadingImage, setIsUploadingImage] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [selectedFile, setSelectedFile] = useState(null);
-  const [previewImage, setPreviewImage] = useState(null);
-
-  const [existingTags, setExistingTags] = useState(() => {
-    const saved = localStorage.getItem('existingTags');
-    return saved ? JSON.parse(saved) : [];
-  });
   const { toast } = useToast();
   const descriptionRef = useRef(null);
-  const fileInputRef = useRef(null);
-  const navigate = useNavigate();
 
-  const isPremiumUser = userProfile?.subscription_tier === 'premium';
+  const {
+    showTagManager,
+    setShowTagManager,
+    suggestedTags,
+    existingTags,
+    setExistingTags,
+    handleAddTag,
+    handleRemoveTag,
+  } = useTagHandling(formData, setFormData);
+
+  const {
+    fileInputRef,
+    handleFileChange,
+    uploadImage,
+    selectedFile,
+    previewImage,
+    isUploadingImage,
+    setPreviewImage,
+    setSelectedFile,
+  } = useImageUpload(session, toast, setFormData);
+
+  const {
+    generateWithAI,
+    isGeneratingDescription,
+    isGeneratingImage,
+    isPremiumUser,
+  } = useAIGeneration({
+    session,
+    userProfile,
+    formData,
+    setFormData,
+    descriptionRef,
+    setPreviewImage,
+    setSelectedFile,
+    toast,
+    onClose,
+  });
 
   useEffect(() => {
     if (recipe) {
@@ -117,36 +139,6 @@ function RecipeForm({
     setSelectedFile(null);
   }, [recipe]);
 
-  const updateSuggestedTags = useCallback(async () => {
-    const localExistingTags = JSON.parse(
-      localStorage.getItem('existingTags') || '[]'
-    );
-    let baseSuggestions = [];
-    if (
-      formData.ingredients.some((i) => i.name) ||
-      formData.meal_types.length > 0 ||
-      formData.name
-    ) {
-      baseSuggestions = await generateTagSuggestions(
-        { ...formData, mealTypes: formData.meal_types },
-        localExistingTags
-      );
-    }
-
-    const combinedSuggestions = Array.from(
-      new Set([...localExistingTags, ...baseSuggestions])
-    );
-    setSuggestedTags(
-      combinedSuggestions.filter((tag) => !formData.tags.includes(tag))
-    );
-  }, [formData.ingredients, formData.meal_types, formData.tags, formData.name]);
-
-  useEffect(() => {
-    const debounceTimer = setTimeout(() => {
-      updateSuggestedTags();
-    }, 500);
-    return () => clearTimeout(debounceTimer);
-  }, [updateSuggestedTags]);
 
   const handleInputChange = (e) => {
     const { name, value } = e.target;
@@ -197,29 +189,6 @@ function RecipeForm({
     }));
   };
 
-  const handleAddTag = (tag) => {
-    if (tag && tag.trim() && !formData.tags.includes(tag.trim())) {
-      const newTag = tag.trim();
-      setFormData((prev) => ({
-        ...prev,
-        tags: [...prev.tags, newTag],
-      }));
-      if (!existingTags.includes(newTag)) {
-        const updatedSystemTags = Array.from(
-          new Set([...existingTags, newTag])
-        );
-        setExistingTags(updatedSystemTags);
-        localStorage.setItem('existingTags', JSON.stringify(updatedSystemTags));
-      }
-    }
-  };
-
-  const handleRemoveTag = (tagToRemove) => {
-    setFormData((prev) => ({
-      ...prev,
-      tags: prev.tags.filter((tag) => tag !== tagToRemove),
-    }));
-  };
 
   const handleInstructionsChange = (e) => {
     setFormData((prev) => ({
@@ -232,70 +201,6 @@ function RecipeForm({
     setFormData((prev) => ({ ...prev, visibility: value }));
   };
 
-  const handleFileChange = (event) => {
-    const file = event.target.files[0];
-    if (file) {
-      if (file.size > 5 * 1024 * 1024) {
-        toast({
-          title: 'Fichier trop volumineux',
-          description: "L'image ne doit pas dépasser 5MB.",
-          variant: 'destructive',
-        });
-        return;
-      }
-      if (!['image/jpeg', 'image/png', 'image/webp'].includes(file.type)) {
-        toast({
-          title: 'Format de fichier non supporté',
-          description: 'Veuillez choisir une image JPEG, PNG, ou WEBP.',
-          variant: 'destructive',
-        });
-        return;
-      }
-      setSelectedFile(file);
-      const reader = new FileReader();
-      reader.onloadend = () => {
-        setPreviewImage(reader.result);
-      };
-      reader.readAsDataURL(file);
-      setFormData((prev) => ({ ...prev, image_url: '' }));
-    }
-  };
-
-  const uploadImage = async () => {
-    if (!selectedFile || !session?.user) return null;
-    setIsUploadingImage(true);
-    try {
-      const fileExt = selectedFile.name.split('.').pop();
-      const fileName = `${session.user.id}-${Date.now()}.${fileExt}`;
-      const filePath = `${fileName}`;
-
-      const { data, error: uploadError } = await supabase.storage
-        .from('recipe-images')
-        .upload(filePath, selectedFile);
-
-      if (uploadError) throw uploadError;
-
-      const { data: publicUrlData } = supabase.storage
-        .from('recipe-images')
-        .getPublicUrl(data.path);
-
-      setIsUploadingImage(false);
-      toast({
-        title: 'Image téléversée',
-        description: 'Votre image a été ajoutée à la recette.',
-      });
-      return publicUrlData.publicUrl;
-    } catch (error) {
-      console.error('Error uploading image:', error);
-      toast({
-        title: 'Erreur de téléversement',
-        description: error.message,
-        variant: 'destructive',
-      });
-      setIsUploadingImage(false);
-      return null;
-    }
-  };
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -407,123 +312,6 @@ function RecipeForm({
     setIsSubmitting(false);
   };
 
-  const handlePremiumFeatureClick = (featureName) => {
-    toast({
-      title: 'Fonctionnalité Premium',
-      description: (
-        <div className="flex flex-col gap-2">
-          <span>{`La génération IA ${featureName} est réservée aux membres Premium.`}</span>
-          <Button
-            size="sm"
-            variant="accent"
-            onClick={() => {
-              onClose();
-              navigate('/app/account');
-            }}
-            className="mt-2"
-          >
-            Passer à Premium
-          </Button>
-        </div>
-      ),
-      duration: 8000,
-    });
-  };
-
-  const generateWithAI = async (type) => {
-    if (!session) {
-      toast({
-        title: 'Connexion requise',
-        description:
-          'Veuillez vous connecter pour utiliser les fonctionnalités IA.',
-        variant: 'default',
-      });
-      return;
-    }
-
-    if (!isPremiumUser) {
-      handlePremiumFeatureClick(
-        type === 'description' ? 'de description' : "d'images"
-      );
-      return;
-    }
-
-    if (!formData.name || !formData.ingredients.some((i) => i.name)) {
-      toast({
-        title: 'Information manquante',
-        description: 'Veuillez remplir au moins le nom et un ingrédient.',
-        variant: 'destructive',
-      });
-      return;
-    }
-
-    if (type === 'description') setIsGeneratingDescription(true);
-    if (type === 'image') setIsGeneratingImage(true);
-
-    try {
-      const ingredientsList = formData.ingredients
-        .filter((i) => i.name)
-        .map((i) => `${i.quantity || ''} ${i.unit || ''} ${i.name}`.trim())
-        .join(', ');
-      const functionName =
-        type === 'description' ? 'generate-recipe' : 'generate-image';
-      const promptBase =
-        type === 'description'
-          ? `Génère une description courte (environ 150 caractères), engageante et appétissante pour une recette nommée "${formData.name}" avec les ingrédients: ${ingredientsList}. Instructions: ${formData.instructions.join(' ')}. Ton: chaleureux et invitant.`
-          : `Photographie culinaire professionnelle, très appétissante et réaliste de "${formData.name}", un plat préparé avec: ${ingredientsList}. Style: éclairage naturel vif, couleurs riches, mise au point sélective, arrière-plan subtilement flouté. Composition artistique. Haute résolution.`;
-
-      const response = await fetch(
-        `${supabase.functions.url}/${functionName}`,
-        {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${session.access_token}`,
-          },
-          body: JSON.stringify({ prompt: promptBase }),
-        }
-      );
-
-      if (!response.ok) {
-        const errorData = await response.json();
-        throw new Error(
-          errorData.error ||
-            `La génération ${type === 'description' ? 'de la description' : "de l'image"} a échoué.`
-        );
-      }
-
-      const data = await response.json();
-
-      if (type === 'description') {
-        const generatedDescription = data.choices[0].message.content;
-        setFormData((prev) => ({ ...prev, description: generatedDescription }));
-        if (descriptionRef.current)
-          descriptionRef.current.value = generatedDescription;
-        toast({
-          title: 'Description générée',
-          description: 'La description a été mise à jour.',
-        });
-      } else if (type === 'image') {
-        setFormData((prev) => ({ ...prev, image_url: data.url }));
-        setPreviewImage(data.url);
-        setSelectedFile(null);
-        toast({
-          title: 'Image générée',
-          description: "L'image a été mise à jour.",
-        });
-      }
-    } catch (error) {
-      console.error('Erreur IA:', error);
-      toast({
-        title: 'Erreur de génération',
-        description: error.message,
-        variant: 'destructive',
-      });
-    } finally {
-      if (type === 'description') setIsGeneratingDescription(false);
-      if (type === 'image') setIsGeneratingImage(false);
-    }
-  };
 
   return (
     <AnimatePresence>

--- a/src/components/form/hooks/useAIGeneration.js
+++ b/src/components/form/hooks/useAIGeneration.js
@@ -1,0 +1,140 @@
+import { useState, useCallback } from 'react';
+import { supabase } from '@/lib/supabase';
+import { useNavigate } from 'react-router-dom';
+import { Button } from '@/components/ui/button';
+
+export default function useAIGeneration({
+  session,
+  userProfile,
+  formData,
+  setFormData,
+  descriptionRef,
+  setPreviewImage,
+  setSelectedFile,
+  toast,
+  onClose,
+}) {
+  const [isGeneratingDescription, setIsGeneratingDescription] = useState(false);
+  const [isGeneratingImage, setIsGeneratingImage] = useState(false);
+  const navigate = useNavigate();
+
+  const isPremiumUser = userProfile?.subscription_tier === 'premium';
+
+  const handlePremiumFeatureClick = useCallback(
+    (featureName) => {
+      toast({
+        title: 'Fonctionnalité Premium',
+        description: (
+          <div className="flex flex-col gap-2">
+            <span>{`La génération IA ${featureName} est réservée aux membres Premium.`}</span>
+            <Button
+              size="sm"
+              variant="accent"
+              onClick={() => {
+                onClose();
+                navigate('/app/account');
+              }}
+              className="mt-2"
+            >
+              Passer à Premium
+            </Button>
+          </div>
+        ),
+        duration: 8000,
+      });
+    },
+    [navigate, onClose, toast]
+  );
+
+  const generateWithAI = useCallback(
+    async (type) => {
+      if (!session) {
+        toast({
+          title: 'Connexion requise',
+          description: 'Veuillez vous connecter pour utiliser les fonctionnalités IA.',
+          variant: 'default',
+        });
+        return;
+      }
+
+      if (!isPremiumUser) {
+        handlePremiumFeatureClick(type === 'description' ? 'de description' : "d'images");
+        return;
+      }
+
+      if (!formData.name || !formData.ingredients.some((i) => i.name)) {
+        toast({
+          title: 'Information manquante',
+          description: 'Veuillez remplir au moins le nom et un ingrédient.',
+          variant: 'destructive',
+        });
+        return;
+      }
+
+      if (type === 'description') setIsGeneratingDescription(true);
+      if (type === 'image') setIsGeneratingImage(true);
+
+      try {
+        const ingredientsList = formData.ingredients
+          .filter((i) => i.name)
+          .map((i) => `${i.quantity || ''} ${i.unit || ''} ${i.name}`.trim())
+          .join(', ');
+        const functionName = type === 'description' ? 'generate-recipe' : 'generate-image';
+        const promptBase =
+          type === 'description'
+            ? `Génère une description courte (environ 150 caractères), engageante et appétissante pour une recette nommée "${formData.name}" avec les ingrédients: ${ingredientsList}. Instructions: ${formData.instructions.join(' ')}. Ton: chaleureux et invitant.`
+            : `Photographie culinaire professionnelle, très appétissante et réaliste de "${formData.name}", un plat préparé avec: ${ingredientsList}. Style: éclairage naturel vif, couleurs riches, mise au point sélective, arrière-plan subtilement flouté. Composition artistique. Haute résolution.`;
+
+        const response = await fetch(`${supabase.functions.url}/${functionName}`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${session.access_token}`,
+          },
+          body: JSON.stringify({ prompt: promptBase }),
+        });
+
+        if (!response.ok) {
+          const errorData = await response.json();
+          throw new Error(
+            errorData.error ||
+              `La génération ${type === 'description' ? 'de la description' : "de l'image"} a échoué.`
+          );
+        }
+
+        const data = await response.json();
+
+        if (type === 'description') {
+          const generatedDescription = data.choices[0].message.content;
+          setFormData((prev) => ({ ...prev, description: generatedDescription }));
+          if (descriptionRef.current) descriptionRef.current.value = generatedDescription;
+          toast({
+            title: 'Description générée',
+            description: 'La description a été mise à jour.',
+          });
+        } else if (type === 'image') {
+          setFormData((prev) => ({ ...prev, image_url: data.url }));
+          setPreviewImage(data.url);
+          setSelectedFile(null);
+          toast({
+            title: 'Image générée',
+            description: "L'image a été mise à jour.",
+          });
+        }
+      } catch (error) {
+        console.error('Erreur IA:', error);
+        toast({
+          title: 'Erreur de génération',
+          description: error.message,
+          variant: 'destructive',
+        });
+      } finally {
+        if (type === 'description') setIsGeneratingDescription(false);
+        if (type === 'image') setIsGeneratingImage(false);
+      }
+    },
+    [session, isPremiumUser, formData, setFormData, descriptionRef, setPreviewImage, setSelectedFile, toast, handlePremiumFeatureClick]
+  );
+
+  return { generateWithAI, isGeneratingDescription, isGeneratingImage, isPremiumUser };
+}

--- a/src/components/form/hooks/useImageUpload.js
+++ b/src/components/form/hooks/useImageUpload.js
@@ -1,0 +1,87 @@
+import { useState, useRef } from 'react';
+import { supabase } from '@/lib/supabase';
+
+export default function useImageUpload(session, toast, setFormData) {
+  const [selectedFile, setSelectedFile] = useState(null);
+  const [previewImage, setPreviewImage] = useState(null);
+  const [isUploadingImage, setIsUploadingImage] = useState(false);
+  const fileInputRef = useRef(null);
+
+  const handleFileChange = (event) => {
+    const file = event.target.files[0];
+    if (file) {
+      if (file.size > 5 * 1024 * 1024) {
+        toast({
+          title: 'Fichier trop volumineux',
+          description: "L'image ne doit pas dépasser 5MB.",
+          variant: 'destructive',
+        });
+        return;
+      }
+      if (!['image/jpeg', 'image/png', 'image/webp'].includes(file.type)) {
+        toast({
+          title: 'Format de fichier non supporté',
+          description: 'Veuillez choisir une image JPEG, PNG, ou WEBP.',
+          variant: 'destructive',
+        });
+        return;
+      }
+      setSelectedFile(file);
+      const reader = new FileReader();
+      reader.onloadend = () => {
+        setPreviewImage(reader.result);
+      };
+      reader.readAsDataURL(file);
+      if (typeof setFormData === 'function') {
+        setFormData((prev) => ({ ...prev, image_url: '' }));
+      }
+    }
+  };
+
+  const uploadImage = async () => {
+    if (!selectedFile || !session?.user) return null;
+    setIsUploadingImage(true);
+    try {
+      const fileExt = selectedFile.name.split('.').pop();
+      const fileName = `${session.user.id}-${Date.now()}.${fileExt}`;
+      const filePath = `${fileName}`;
+
+      const { data, error: uploadError } = await supabase.storage
+        .from('recipe-images')
+        .upload(filePath, selectedFile);
+
+      if (uploadError) throw uploadError;
+
+      const { data: publicUrlData } = supabase.storage
+        .from('recipe-images')
+        .getPublicUrl(data.path);
+
+      setIsUploadingImage(false);
+      toast({
+        title: 'Image téléversée',
+        description: 'Votre image a été ajoutée à la recette.',
+      });
+      return publicUrlData.publicUrl;
+    } catch (error) {
+      console.error('Error uploading image:', error);
+      toast({
+        title: 'Erreur de téléversement',
+        description: error.message,
+        variant: 'destructive',
+      });
+      setIsUploadingImage(false);
+      return null;
+    }
+  };
+
+  return {
+    fileInputRef,
+    handleFileChange,
+    uploadImage,
+    selectedFile,
+    previewImage,
+    isUploadingImage,
+    setPreviewImage,
+    setSelectedFile,
+  };
+}

--- a/src/components/form/hooks/useTagHandling.js
+++ b/src/components/form/hooks/useTagHandling.js
@@ -1,0 +1,67 @@
+import { useState, useEffect, useCallback } from 'react';
+import { generateTagSuggestions } from '@/lib/tagSuggestions';
+
+export default function useTagHandling(formData, setFormData) {
+  const [showTagManager, setShowTagManager] = useState(false);
+  const [suggestedTags, setSuggestedTags] = useState([]);
+  const [existingTags, setExistingTags] = useState(() => {
+    const saved = localStorage.getItem('existingTags');
+    return saved ? JSON.parse(saved) : [];
+  });
+
+  const handleAddTag = useCallback(
+    (tag) => {
+      if (tag && tag.trim() && !formData.tags.includes(tag.trim())) {
+        const newTag = tag.trim();
+        setFormData((prev) => ({ ...prev, tags: [...prev.tags, newTag] }));
+        if (!existingTags.includes(newTag)) {
+          const updatedSystemTags = Array.from(new Set([...existingTags, newTag]));
+          setExistingTags(updatedSystemTags);
+          localStorage.setItem('existingTags', JSON.stringify(updatedSystemTags));
+        }
+      }
+    },
+    [formData.tags, existingTags, setFormData]
+  );
+
+  const handleRemoveTag = useCallback(
+    (tagToRemove) => {
+      setFormData((prev) => ({
+        ...prev,
+        tags: prev.tags.filter((tag) => tag !== tagToRemove),
+      }));
+    },
+    [setFormData]
+  );
+
+  const updateSuggestedTags = useCallback(async () => {
+    const localExistingTags = JSON.parse(localStorage.getItem('existingTags') || '[]');
+    let baseSuggestions = [];
+    if (formData.ingredients.some((i) => i.name) || formData.meal_types.length > 0 || formData.name) {
+      baseSuggestions = await generateTagSuggestions(
+        { ...formData, mealTypes: formData.meal_types },
+        localExistingTags
+      );
+    }
+
+    const combinedSuggestions = Array.from(new Set([...localExistingTags, ...baseSuggestions]));
+    setSuggestedTags(combinedSuggestions.filter((tag) => !formData.tags.includes(tag)));
+  }, [formData.ingredients, formData.meal_types, formData.tags, formData.name]);
+
+  useEffect(() => {
+    const debounceTimer = setTimeout(() => {
+      updateSuggestedTags();
+    }, 500);
+    return () => clearTimeout(debounceTimer);
+  }, [updateSuggestedTags]);
+
+  return {
+    showTagManager,
+    setShowTagManager,
+    suggestedTags,
+    existingTags,
+    setExistingTags,
+    handleAddTag,
+    handleRemoveTag,
+  };
+}


### PR DESCRIPTION
## Summary
- move tag management logic to `useTagHandling`
- extract AI generation helpers to `useAIGeneration`
- handle image uploads through `useImageUpload`
- update `RecipeForm` to use these hooks

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_684ee3c48b70832d8921bf22abc7ad90