### PR TITLE
Refactor menu settings

### DIFF
--- a/src/components/MealTypeSelector.jsx
+++ b/src/components/MealTypeSelector.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Button } from '@/components/ui/button';
+import { MEAL_TYPE_OPTIONS_MAP } from '@/lib/mealTypes';
+
+function MealTypeSelector({ selectedTypes = [], onToggle }) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      {Object.entries(MEAL_TYPE_OPTIONS_MAP).map(([typeKey, label]) => {
+        const isActive = selectedTypes.includes(typeKey);
+        return (
+          <Button
+            key={typeKey}
+            type="button"
+            size="sm"
+            variant={isActive ? 'default' : 'outline'}
+            onClick={() => onToggle(typeKey)}
+            className="rounded-full px-3 py-1 text-xs"
+          >
+            {label}
+          </Button>
+        );
+      })}
+    </div>
+  );
+}
+
+export default MealTypeSelector;

--- a/src/components/MenuPreferences.jsx
+++ b/src/components/MenuPreferences.jsx
@@ -4,15 +4,8 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Plus, ChevronDown, ChevronUp, Trash2, Users } from 'lucide-react';
 import { motion } from 'framer-motion';
-
-const MEAL_TYPE_OPTIONS_DATA = {
-  'petit-dejeuner': 'Petit déjeuner',
-  entree: 'Entrée',
-  plat: 'Plat principal',
-  dessert: 'Dessert',
-  'encas-sucre': 'Encas sucré',
-  'encas-sale': 'Encas salé',
-};
+import MealTypeSelector from '@/components/MealTypeSelector';
+import TagPreferencesForm from '@/components/menu_planner/TagPreferencesForm.jsx';
 
 function MenuPreferences({ preferences, setPreferences, availableTags }) {
   const addMeal = () => {
@@ -76,29 +69,6 @@ function MenuPreferences({ preferences, setPreferences, availableTags }) {
     setPreferences({ ...preferences, meals: renumberedMeals });
   };
 
-  const addTagPreference = () => {
-    if (availableTags?.length > 0) {
-      setPreferences({
-        ...preferences,
-        tagPreferences: [
-          ...(preferences.tagPreferences || []),
-          { tag: availableTags[0], percentage: 50 },
-        ],
-      });
-    }
-  };
-
-  const removeTagPreference = (index) => {
-    const newPreferences = [...(preferences.tagPreferences || [])];
-    newPreferences.splice(index, 1);
-    setPreferences({ ...preferences, tagPreferences: newPreferences });
-  };
-
-  const updateTagPreference = (index, field, value) => {
-    const newPreferences = [...(preferences.tagPreferences || [])];
-    newPreferences[index] = { ...newPreferences[index], [field]: value };
-    setPreferences({ ...preferences, tagPreferences: newPreferences });
-  };
 
   const handleServingsPerMealChange = (e) => {
     const value = parseInt(e.target.value, 10);
@@ -237,96 +207,22 @@ function MenuPreferences({ preferences, setPreferences, availableTags }) {
               </div>
             </div>
 
-            <div className="flex flex-wrap gap-2 pt-2 border-t border-pastel-border/70">
-              {Object.entries(MEAL_TYPE_OPTIONS_DATA).map(
-                ([typeKey, label]) => {
-                  const isActive = (meal.types || []).includes(typeKey);
-                  return (
-                    <Button
-                      key={typeKey}
-                      type="button"
-                      size="sm"
-                      variant={isActive ? 'default' : 'outline'}
-                      onClick={() => toggleMealType(index, typeKey)}
-                      className="rounded-full px-3 py-1 text-xs"
-                    >
-                      {label}
-                    </Button>
-                  );
-                }
-              )}
+            <div className="pt-2 border-t border-pastel-border/70">
+              <MealTypeSelector
+                selectedTypes={meal.types || []}
+                onToggle={(type) => toggleMealType(index, type)}
+              />
             </div>
           </motion.div>
         ))}
       </div>
 
       <div className="space-y-4 pt-4 border-t border-pastel-border/70">
-        <div className="flex justify-between items-center">
-          <Label className="text-base font-medium">
-            Préférences de tags hebdomadaires
-          </Label>
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            onClick={addTagPreference}
-            disabled={!availableTags?.length}
-            className="shadow-pastel-button hover:shadow-pastel-button-hover"
-          >
-            <Plus className="w-4 h-4 mr-1.5" /> Ajouter un tag
-          </Button>
-        </div>
-
-        {(preferences.tagPreferences || []).map((pref, index) => (
-          <motion.div
-            key={index}
-            initial={{ opacity: 0, y: -10 }}
-            animate={{ opacity: 1, y: 0 }}
-            className="flex flex-col sm:flex-row gap-3 items-center bg-pastel-card-alt p-3 rounded-lg shadow-pastel-card-item"
-          >
-            <select
-              className="flex-grow h-10 rounded-md bg-pastel-input px-3 text-sm text-pastel-text ring-offset-pastel-background placeholder:text-pastel-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pastel-ring focus-visible:border-pastel-input-focus-border shadow-pastel-input hover:border-pastel-muted-foreground/30 focus-visible:shadow-pastel-input-focus w-full sm:w-auto"
-              value={pref.tag}
-              onChange={(e) =>
-                updateTagPreference(index, 'tag', e.target.value)
-              }
-            >
-              {(availableTags || []).map((tag) => (
-                <option key={tag} value={tag}>
-                  {' '}
-                  {tag}{' '}
-                </option>
-              ))}
-            </select>
-            <div className="flex items-center gap-2 w-full sm:w-auto">
-              <Input
-                type="number"
-                className="w-24"
-                value={pref.percentage}
-                onChange={(e) =>
-                  updateTagPreference(
-                    index,
-                    'percentage',
-                    Math.min(100, Math.max(0, parseInt(e.target.value) || 0))
-                  )
-                }
-                min="0"
-                max="100"
-              />
-              <span className="text-sm text-pastel-text/80">%</span>
-            </div>
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              onClick={() => removeTagPreference(index)}
-              className="text-red-500 hover:bg-red-500/10 hover:text-red-600 h-8 w-8"
-            >
-              {' '}
-              <Trash2 className="w-4 h-4" />{' '}
-            </Button>
-          </motion.div>
-        ))}
+        <TagPreferencesForm
+          preferences={preferences}
+          setPreferences={setPreferences}
+          availableTags={availableTags}
+        />
       </div>
     </div>
   );

--- a/src/components/menu_planner/CommonMenuSettings.jsx
+++ b/src/components/menu_planner/CommonMenuSettings.jsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogTrigger } from '@/components/ui/dialog';
+import { Info, Link, Unlink } from 'lucide-react';
+
+function CommonMenuSettings({
+  preferences,
+  newLinkedUserEmail,
+  setNewLinkedUserEmail,
+  isLinkingUser,
+  handleAddLinkedUser,
+  handleToggleCommonMenu,
+  handleLinkedUserRatioChange,
+  handleRemoveLinkedUser,
+}) {
+  return (
+    <div className="space-y-4 pt-4 border-t border-pastel-border/70">
+      <div className="flex items-center space-x-2">
+        <Switch
+          id="common-menu-toggle"
+          checked={preferences.commonMenuSettings?.enabled || false}
+          onCheckedChange={handleToggleCommonMenu}
+        />
+        <Label htmlFor="common-menu-toggle" className="text-base font-medium">
+          Activer le menu commun
+        </Label>
+        <Dialog>
+          <DialogTrigger asChild>
+            <Button variant="ghost" size="icon" className="h-6 w-6 text-pastel-muted-foreground">
+              <Info className="h-4 w-4" />
+            </Button>
+          </DialogTrigger>
+          <DialogContent className="bg-pastel-card border border-pastel-border rounded-lg dark:bg-pastel-card dark:border-pastel-border">
+            <DialogHeader>
+              <DialogTitle>Menu Commun</DialogTitle>
+              <DialogDescription>
+                Le menu commun vous permet de planifier des repas en utilisant les recettes d'autres utilisateurs que vous avez liés. Activez cette option pour lier des utilisateurs et ajuster les ratios de contribution pour la génération de menu.
+              </DialogDescription>
+            </DialogHeader>
+          </DialogContent>
+        </Dialog>
+      </div>
+
+      {preferences.commonMenuSettings?.enabled && (
+        <motion.div
+          initial={{ opacity: 0, y: -10 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="space-y-3 bg-pastel-card-alt p-4 rounded-lg shadow-pastel-card-item mt-3"
+        >
+          <Label className="text-sm font-medium text-pastel-text/90">Utilisateurs liés :</Label>
+          {(preferences.commonMenuSettings?.linkedUsers || []).map((user, index) => (
+            <div key={user.id} className="flex items-center justify-between gap-2 text-sm">
+              <span className="truncate flex-1">
+                {user.name} {user.isOwner && '(Vous)'}
+              </span>
+              <div className="flex items-center gap-2">
+                <Input
+                  type="number"
+                  value={user.ratio || 0}
+                  onChange={(e) => handleLinkedUserRatioChange(index, e.target.value)}
+                  className="w-16 h-8 text-xs px-1.5 py-1"
+                  min="0"
+                  max="100"
+                  disabled={
+                    user.isOwner &&
+                    (preferences.commonMenuSettings?.linkedUsers || []).length === 1
+                  }
+                />
+                <span className="text-xs">%</span>
+                {!user.isOwner && (
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7 text-red-500 hover:bg-red-500/10"
+                    onClick={() => handleRemoveLinkedUser(user.id)}
+                  >
+                    <Unlink className="h-3.5 w-3.5" />
+                  </Button>
+                )}
+              </div>
+            </div>
+          ))}
+          <div className="flex gap-2 pt-2 border-t border-pastel-border/50">
+            <Input
+              type="email"
+              placeholder="Email de l'utilisateur à lier"
+              value={newLinkedUserEmail}
+              onChange={(e) => setNewLinkedUserEmail(e.target.value)}
+              className="flex-grow h-9 text-sm"
+            />
+            <Button
+              onClick={handleAddLinkedUser}
+              disabled={isLinkingUser || !newLinkedUserEmail.trim()}
+              size="sm"
+              className="h-9"
+            >
+              <Link className="w-3.5 h-3.5 mr-1.5" /> {isLinkingUser ? 'Liaison...' : 'Lier'}
+            </Button>
+          </div>
+        </motion.div>
+      )}
+    </div>
+  );
+}
+
+export default CommonMenuSettings;

--- a/src/components/menu_planner/MenuPreferencesPanel.jsx
+++ b/src/components/menu_planner/MenuPreferencesPanel.jsx
@@ -24,15 +24,9 @@ import {
   DialogFooter,
   DialogTrigger,
 } from '@/components/ui/dialog.jsx';
-
-const MEAL_TYPE_OPTIONS_DATA = {
-  'petit-dejeuner': 'Petit déjeuner',
-  entree: 'Entrée',
-  plat: 'Plat principal',
-  dessert: 'Dessert',
-  'encas-sucre': 'Encas sucré',
-  'encas-sale': 'Encas salé',
-};
+import MealTypeSelector from '@/components/MealTypeSelector';
+import TagPreferencesForm from '@/components/menu_planner/TagPreferencesForm.jsx';
+import CommonMenuSettings from '@/components/menu_planner/CommonMenuSettings.jsx';
 
 function MenuPreferencesPanel({
   preferences,
@@ -107,29 +101,6 @@ function MenuPreferencesPanel({
     setPreferences({ ...preferences, meals: renumberedMeals });
   };
 
-  const addTagPreference = () => {
-    if (availableTags?.length > 0) {
-      setPreferences({
-        ...preferences,
-        tagPreferences: [
-          ...(preferences.tagPreferences || []),
-          { tag: availableTags[0], percentage: 50 },
-        ],
-      });
-    }
-  };
-
-  const removeTagPreference = (index) => {
-    const newPreferences = [...(preferences.tagPreferences || [])];
-    newPreferences.splice(index, 1);
-    setPreferences({ ...preferences, tagPreferences: newPreferences });
-  };
-
-  const updateTagPreference = (index, field, value) => {
-    const newPreferences = [...(preferences.tagPreferences || [])];
-    newPreferences[index] = { ...newPreferences[index], [field]: value };
-    setPreferences({ ...preferences, tagPreferences: newPreferences });
-  };
 
   const handleServingsPerMealChange = (e) => {
     const value = parseInt(e.target.value, 10);
@@ -191,110 +162,16 @@ function MenuPreferencesPanel({
         </div>
       </div>
 
-      <div className="space-y-4 pt-4 border-t border-pastel-border/70">
-        <div className="flex items-center space-x-2">
-          <Switch
-            id="common-menu-toggle"
-            checked={preferences.commonMenuSettings?.enabled || false}
-            onCheckedChange={handleToggleCommonMenu}
-          />
-          <Label htmlFor="common-menu-toggle" className="text-base font-medium">
-            Activer le menu commun
-          </Label>
-          <Dialog>
-            <DialogTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-6 w-6 text-pastel-muted-foreground"
-              >
-                <Info className="h-4 w-4" />
-              </Button>
-            </DialogTrigger>
-            <DialogContent className="bg-pastel-card border border-pastel-border rounded-lg dark:bg-pastel-card dark:border-pastel-border">
-              <DialogHeader>
-                <DialogTitle>Menu Commun</DialogTitle>
-                <DialogDescription>
-                  Le menu commun vous permet de planifier des repas en utilisant
-                  les recettes d'autres utilisateurs que vous avez liés. Activez
-                  cette option pour lier des utilisateurs et ajuster les ratios
-                  de contribution pour la génération de menu.
-                </DialogDescription>
-              </DialogHeader>
-            </DialogContent>
-          </Dialog>
-        </div>
-
-        {preferences.commonMenuSettings?.enabled && (
-          <motion.div
-            initial={{ opacity: 0, y: -10 }}
-            animate={{ opacity: 1, y: 0 }}
-            className="space-y-3 bg-pastel-card-alt p-4 rounded-lg shadow-pastel-card-item mt-3"
-          >
-            <Label className="text-sm font-medium text-pastel-text/90">
-              Utilisateurs liés :
-            </Label>
-            {(preferences.commonMenuSettings?.linkedUsers || []).map(
-              (user, index) => (
-                <div
-                  key={user.id}
-                  className="flex items-center justify-between gap-2 text-sm"
-                >
-                  <span className="truncate flex-1">
-                    {user.name} {user.isOwner && '(Vous)'}
-                  </span>
-                  <div className="flex items-center gap-2">
-                    <Input
-                      type="number"
-                      value={user.ratio || 0}
-                      onChange={(e) =>
-                        handleLinkedUserRatioChange(index, e.target.value)
-                      }
-                      className="w-16 h-8 text-xs px-1.5 py-1"
-                      min="0"
-                      max="100"
-                      disabled={
-                        user.isOwner &&
-                        (preferences.commonMenuSettings?.linkedUsers || [])
-                          .length === 1
-                      }
-                    />
-                    <span className="text-xs">%</span>
-                    {!user.isOwner && (
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        className="h-7 w-7 text-red-500 hover:bg-red-500/10"
-                        onClick={() => handleRemoveLinkedUser(user.id)}
-                      >
-                        <Unlink className="h-3.5 w-3.5" />
-                      </Button>
-                    )}
-                  </div>
-                </div>
-              )
-            )}
-            <div className="flex gap-2 pt-2 border-t border-pastel-border/50">
-              <Input
-                type="email"
-                placeholder="Email de l'utilisateur à lier"
-                value={newLinkedUserEmail}
-                onChange={(e) => setNewLinkedUserEmail(e.target.value)}
-                className="flex-grow h-9 text-sm"
-              />
-              <Button
-                onClick={handleAddLinkedUser}
-                disabled={isLinkingUser || !newLinkedUserEmail.trim()}
-                size="sm"
-                className="h-9"
-              >
-                <Link className="w-3.5 h-3.5 mr-1.5" />{' '}
-                {isLinkingUser ? 'Liaison...' : 'Lier'}
-              </Button>
-            </div>
-          </motion.div>
-        )}
-      </div>
+        <CommonMenuSettings
+          preferences={preferences}
+          newLinkedUserEmail={newLinkedUserEmail}
+          setNewLinkedUserEmail={setNewLinkedUserEmail}
+          isLinkingUser={isLinkingUser}
+          handleAddLinkedUser={handleAddLinkedUser}
+          handleToggleCommonMenu={handleToggleCommonMenu}
+          handleLinkedUserRatioChange={handleLinkedUserRatioChange}
+          handleRemoveLinkedUser={handleRemoveLinkedUser}
+        />
 
       <div className="space-y-4 pt-4 border-t border-pastel-border/70">
         <div className="flex justify-between items-center">
@@ -379,97 +256,21 @@ function MenuPreferencesPanel({
               </div>
             </div>
 
-            <div className="flex flex-wrap gap-2 pt-2 border-t border-pastel-border/70">
-              {Object.entries(MEAL_TYPE_OPTIONS_DATA).map(
-                ([typeKey, label]) => {
-                  const isActive = (meal.types || []).includes(typeKey);
-                  return (
-                    <Button
-                      key={typeKey}
-                      type="button"
-                      size="sm"
-                      variant={isActive ? 'default' : 'outline'}
-                      onClick={() => toggleMealType(index, typeKey)}
-                      className="rounded-full px-3 py-1 text-xs"
-                    >
-                      {label}
-                    </Button>
-                  );
-                }
-              )}
-            </div>
+              <div className="pt-2 border-t border-pastel-border/70">
+                <MealTypeSelector
+                  selectedTypes={meal.types || []}
+                  onToggle={(type) => toggleMealType(index, type)}
+                />
+              </div>
           </motion.div>
         ))}
       </div>
 
-      <div className="space-y-4 pt-4 border-t border-pastel-border/70">
-        <div className="flex justify-between items-center">
-          <Label className="text-base font-medium">
-            Préférences de tags hebdomadaires
-          </Label>
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            onClick={addTagPreference}
-            disabled={!availableTags?.length}
-            className="shadow-pastel-button hover:shadow-pastel-button-hover"
-          >
-            <Plus className="w-4 h-4 mr-1.5" /> Ajouter un tag
-          </Button>
-        </div>
-
-        {(preferences.tagPreferences || []).map((pref, index) => (
-          <motion.div
-            key={index}
-            initial={{ opacity: 0, y: -10 }}
-            animate={{ opacity: 1, y: 0 }}
-            className="flex flex-col sm:flex-row gap-3 items-center bg-pastel-card-alt p-3 rounded-lg shadow-pastel-card-item"
-          >
-            <select
-              className="flex-grow h-10 rounded-md bg-pastel-input px-3 text-sm text-pastel-text ring-offset-pastel-background placeholder:text-pastel-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pastel-ring focus-visible:border-pastel-input-focus-border shadow-pastel-input hover:border-pastel-muted-foreground/30 focus-visible:shadow-pastel-input-focus w-full sm:w-auto"
-              value={pref.tag}
-              onChange={(e) =>
-                updateTagPreference(index, 'tag', e.target.value)
-              }
-            >
-              {(availableTags || []).map((tag) => (
-                <option key={tag} value={tag}>
-                  {' '}
-                  {tag}{' '}
-                </option>
-              ))}
-            </select>
-            <div className="flex items-center gap-2 w-full sm:w-auto">
-              <Input
-                type="number"
-                className="w-24"
-                value={pref.percentage}
-                onChange={(e) =>
-                  updateTagPreference(
-                    index,
-                    'percentage',
-                    Math.min(100, Math.max(0, parseInt(e.target.value) || 0))
-                  )
-                }
-                min="0"
-                max="100"
-              />
-              <span className="text-sm text-pastel-text/80">%</span>
-            </div>
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              onClick={() => removeTagPreference(index)}
-              className="text-red-500 hover:bg-red-500/10 hover:text-red-600 h-8 w-8"
-            >
-              {' '}
-              <Trash2 className="w-4 h-4" />{' '}
-            </Button>
-          </motion.div>
-        ))}
-      </div>
+        <TagPreferencesForm
+          preferences={preferences}
+          setPreferences={setPreferences}
+          availableTags={availableTags}
+        />
     </motion.div>
   );
 }

--- a/src/components/menu_planner/TagPreferencesForm.jsx
+++ b/src/components/menu_planner/TagPreferencesForm.jsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Plus, Trash2 } from 'lucide-react';
+
+function TagPreferencesForm({ preferences, setPreferences, availableTags }) {
+  const addTagPreference = () => {
+    if (availableTags?.length > 0) {
+      setPreferences({
+        ...preferences,
+        tagPreferences: [
+          ...(preferences.tagPreferences || []),
+          { tag: availableTags[0], percentage: 50 },
+        ],
+      });
+    }
+  };
+
+  const removeTagPreference = (index) => {
+    const newPreferences = [...(preferences.tagPreferences || [])];
+    newPreferences.splice(index, 1);
+    setPreferences({ ...preferences, tagPreferences: newPreferences });
+  };
+
+  const updateTagPreference = (index, field, value) => {
+    const newPreferences = [...(preferences.tagPreferences || [])];
+    newPreferences[index] = { ...newPreferences[index], [field]: value };
+    setPreferences({ ...preferences, tagPreferences: newPreferences });
+  };
+
+  return (
+    <div className="space-y-4 pt-4 border-t border-pastel-border/70">
+      <div className="flex justify-between items-center">
+        <Label className="text-base font-medium">Préférences de tags hebdomadaires</Label>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={addTagPreference}
+          disabled={!availableTags?.length}
+          className="shadow-pastel-button hover:shadow-pastel-button-hover"
+        >
+          <Plus className="w-4 h-4 mr-1.5" /> Ajouter un tag
+        </Button>
+      </div>
+
+      {(preferences.tagPreferences || []).map((pref, index) => (
+        <motion.div
+          key={index}
+          initial={{ opacity: 0, y: -10 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="flex flex-col sm:flex-row gap-3 items-center bg-pastel-card-alt p-3 rounded-lg shadow-pastel-card-item"
+        >
+          <select
+            className="flex-grow h-10 rounded-md bg-pastel-input px-3 text-sm text-pastel-text ring-offset-pastel-background placeholder:text-pastel-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pastel-ring focus-visible:border-pastel-input-focus-border shadow-pastel-input hover:border-pastel-muted-foreground/30 focus-visible:shadow-pastel-input-focus w-full sm:w-auto"
+            value={pref.tag}
+            onChange={(e) => updateTagPreference(index, 'tag', e.target.value)}
+          >
+            {(availableTags || []).map((tag) => (
+              <option key={tag} value={tag}>
+                {tag}
+              </option>
+            ))}
+          </select>
+          <div className="flex items-center gap-2 w-full sm:w-auto">
+            <Input
+              type="number"
+              className="w-24"
+              value={pref.percentage}
+              onChange={(e) =>
+                updateTagPreference(
+                  index,
+                  'percentage',
+                  Math.min(100, Math.max(0, parseInt(e.target.value) || 0))
+                )
+              }
+              min="0"
+              max="100"
+            />
+            <span className="text-sm text-pastel-text/80">%</span>
+          </div>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            onClick={() => removeTagPreference(index)}
+            className="text-red-500 hover:bg-red-500/10 hover:text-red-600 h-8 w-8"
+          >
+            <Trash2 className="w-4 h-4" />
+          </Button>
+        </motion.div>
+      ))}
+    </div>
+  );
+}
+
+export default TagPreferencesForm;


### PR DESCRIPTION
## Summary
- break out reusable MealTypeSelector
- add CommonMenuSettings and TagPreferencesForm components
- use new components in menu preferences forms

## Testing
- `npm run lint` *(fails: many prop-types warnings)*

------
https://chatgpt.com/codex/tasks/task_e_684ee3cf91dc832da138b8b112abe524