### PR TITLE
Add recipe formatting helper

### DIFF
--- a/src/components/MyPublicProfile.jsx
+++ b/src/components/MyPublicProfile.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { supabase } from '@/lib/supabase';
+import { formatRecipes } from '@/lib/formatRecipe.js';
 import RecipeList from '@/components/RecipeList';
 import LoadingScreen from '@/components/layout/LoadingScreen';
 import { UserCircle, Calendar, ShieldCheck } from 'lucide-react';
@@ -53,10 +54,7 @@ export default function MyPublicProfile({
 
       if (recipeError) throw recipeError;
 
-      const formattedRecipes = recipeData.map((r) => ({
-        ...r,
-        user: r.author,
-      }));
+      const formattedRecipes = formatRecipes(recipeData);
       setRecipes(formattedRecipes || []);
     } catch (error) {
       console.error('Error fetching own profile or recipes:', error);

--- a/src/lib/formatRecipe.js
+++ b/src/lib/formatRecipe.js
@@ -1,0 +1,20 @@
+export function formatRecipe(recipe) {
+  if (!recipe || typeof recipe !== 'object') {
+    return recipe;
+  }
+
+  const { author, public_users, user, ...rest } = recipe;
+  let formattedUser = user;
+
+  if (author) {
+    formattedUser = author;
+  } else if (public_users) {
+    formattedUser = public_users;
+  }
+
+  return { ...rest, user: formattedUser };
+}
+
+export function formatRecipes(rows) {
+  return Array.isArray(rows) ? rows.map(formatRecipe) : [];
+}

--- a/src/pages/CommunityPage.jsx
+++ b/src/pages/CommunityPage.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { supabase } from '@/lib/supabase';
+import { formatRecipes } from '@/lib/formatRecipe.js';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Link, useNavigate } from 'react-router-dom';
@@ -100,10 +101,7 @@ export default function CommunityPage({ session, userProfile }) {
         );
       }
 
-      const formattedRecipes = data.map((recipe) => ({
-        ...recipe,
-        user: recipe.author,
-      }));
+      const formattedRecipes = formatRecipes(data);
       setPublicRecipes(formattedRecipes);
     } catch (error) {
       console.error('Error fetching public recipes (processed):', error);

--- a/src/pages/UserProfilePage.jsx
+++ b/src/pages/UserProfilePage.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { useParams, Link, useLocation, useNavigate } from 'react-router-dom';
 import { supabase } from '@/lib/supabase';
+import { formatRecipes } from '@/lib/formatRecipe.js';
 import RecipeList from '@/components/RecipeList';
 import LoadingScreen from '@/components/layout/LoadingScreen';
 import {
@@ -106,10 +107,7 @@ export default function UserProfilePage({ session, currentUserProfile }) {
       );
       if (recipeError) throw recipeError;
 
-      const formattedRecipes = recipeData.map((r) => ({
-        ...r,
-        user: r.author,
-      }));
+      const formattedRecipes = formatRecipes(recipeData);
       setRecipes(formattedRecipes || []);
     } catch (error) {
       console.error('Error fetching profile or recipes:', error);


### PR DESCRIPTION
## Summary
- add `formatRecipe` utility
- use `formatRecipes` helper in `CommunityPage`, `UserProfilePage`, and `MyPublicProfile`

## Testing
- `npm run lint` *(fails: 533 errors)*

------
https://chatgpt.com/codex/tasks/task_e_684ee3f6b970832db1c6ebea01df6635