### PR TITLE
Use env variables for Supabase config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 .DS_Store
 plugins/.DS_Store
+.env

--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# Meal Planner
+
+This project uses Supabase as a backend. To run the app locally, create a `.env` file in the project root with the following variables:
+
+```
+VITE_SUPABASE_URL=<your-supabase-url>
+VITE_SUPABASE_ANON_KEY=<your-supabase-anon-key>
+```
+
+These values are injected by Vite and used by the app at runtime.

--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -1,7 +1,6 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = 'https://bunolnhegwzhxqxymmet.supabase.co';
-const supabaseAnonKey =
-  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImJ1bm9sbmhlZ3d6aHhxeHltbWV0Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDYxNzY4MjIsImV4cCI6MjA2MTc1MjgyMn0.f3lUOwuDDIAiZN5p0UwPXmBHjsXCW-ryB6m-G1nof6E';
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey);


### PR DESCRIPTION
## Summary
- remove hardcoded Supabase keys
- load Supabase config from `import.meta.env`
- document required environment variables
- ignore `.env` files in git

## Testing
- `npm run lint` *(fails: many lint errors)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684ee936be34832da56f4769ae32efa5