### PR TITLE
Implement recipe formatting helper and refactor pages

### DIFF
--- a/src/components/MyPublicProfile.jsx
+++ b/src/components/MyPublicProfile.jsx
@@ -6,6 +6,7 @@ import { UserCircle, Calendar, ShieldCheck } from 'lucide-react';
 import { useToast } from '@/components/ui/use-toast';
 import RecipeDetailModal from '@/components/RecipeDetailModal';
 import { useNavigate, useLocation } from 'react-router-dom';
+import { formatRecipe } from '@/lib/formatRecipe';
 
 export default function MyPublicProfile({
   session,
@@ -53,10 +54,7 @@ export default function MyPublicProfile({
 
       if (recipeError) throw recipeError;
 
-      const formattedRecipes = recipeData.map((r) => ({
-        ...r,
-        user: r.author,
-      }));
+      const formattedRecipes = recipeData.map((r) => formatRecipe(r));
       setRecipes(formattedRecipes || []);
     } catch (error) {
       console.error('Error fetching own profile or recipes:', error);

--- a/src/lib/formatRecipe.js
+++ b/src/lib/formatRecipe.js
@@ -1,0 +1,12 @@
+export function formatRecipe(row) {
+  if (!row || typeof row !== 'object') return row;
+  const user =
+    row.user ||
+    row.author ||
+    row.public_users ||
+    null;
+  const formatted = { ...row, user };
+  delete formatted.author;
+  delete formatted.public_users;
+  return formatted;
+}

--- a/src/pages/UserProfilePage.jsx
+++ b/src/pages/UserProfilePage.jsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/button';
 import { useToast } from '@/components/ui/use-toast';
 import RecipeDetailModal from '@/components/RecipeDetailModal';
 import FriendActionButton from '@/components/FriendActionButton.jsx';
+import { formatRecipe } from '@/lib/formatRecipe';
 
 export default function UserProfilePage({ session, currentUserProfile }) {
   const { userId } = useParams();
@@ -97,10 +98,7 @@ export default function UserProfilePage({ session, currentUserProfile }) {
       );
       if (recipeError) throw recipeError;
 
-      const formattedRecipes = recipeData.map((r) => ({
-        ...r,
-        user: r.author,
-      }));
+      const formattedRecipes = recipeData.map((r) => formatRecipe(r));
       setRecipes(formattedRecipes || []);
     } catch (error) {
       console.error('Error fetching profile or recipes:', error);


### PR DESCRIPTION
## Summary
- add `formatRecipe` utility to normalize recipe rows
- refactor `MyPublicProfile` and `UserProfilePage` to use this helper

## Testing
- `npm run lint` *(fails: 610 errors)*

------
https://chatgpt.com/codex/tasks/task_e_684ee9517510832dada309756a658a02