### PR TITLE
Add Vitest tests and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm test

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build --sourcemap false",
     "preview": "vite preview",
     "lint": "eslint . --ext .js,.jsx",
-    "format": "prettier --write \"src/**/*.{js,jsx,json,css}\""
+    "format": "prettier --write \"src/**/*.{js,jsx,json,css}\"",
+    "test": "vitest"
   },
   "dependencies": {
     "@emotion/is-prop-valid": "^1.2.1",
@@ -51,6 +52,9 @@
     "terser": "^5.39.0",
     "vite": "^4.4.5",
     "prettier": "^3.2.5",
-    "eslint-plugin-react": "^7.33.2"
+    "eslint-plugin-react": "^7.33.2",
+    "vitest": "^1.5.0",
+    "jsdom": "^24.0.0",
+    "@testing-library/react": "^14.1.2"
   }
 }

--- a/src/hooks/useRecipes.test.jsx
+++ b/src/hooks/useRecipes.test.jsx
@@ -1,0 +1,49 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { useRecipes } from './useRecipes.jsx';
+
+vi.mock('@/components/ui/use-toast.js', () => ({ useToast: () => ({ toast: vi.fn() }) }));
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('useRecipes', () => {
+  it('adds recipe locally when no session', async () => {
+    const { result } = renderHook(() => useRecipes(null));
+
+    await act(async () => {
+      await result.current.addRecipe({
+        name: 'Test',
+        ingredients: [],
+        instructions: [],
+        meal_types: [],
+        tags: [],
+        servings: 1,
+      });
+    });
+
+    expect(result.current.recipes).toHaveLength(1);
+    expect(result.current.recipes[0].name).toBe('Test');
+    expect(result.current.recipes[0].id).toMatch(/^local_/);
+  });
+
+  it('persists recipes in localStorage', async () => {
+    const { result } = renderHook(() => useRecipes(null));
+
+    await act(async () => {
+      await result.current.addRecipe({
+        name: 'Stored',
+        ingredients: [],
+        instructions: [],
+        meal_types: [],
+        tags: [],
+        servings: 1,
+      });
+    });
+
+    await waitFor(() => {
+      const stored = JSON.parse(localStorage.getItem('localRecipes'));
+      expect(stored[0].name).toBe('Stored');
+    });
+  });
+});

--- a/src/hooks/useWeeklyMenu.test.js
+++ b/src/hooks/useWeeklyMenu.test.js
@@ -1,0 +1,29 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { useWeeklyMenu } from './useWeeklyMenu';
+
+vi.mock('@/components/ui/use-toast', () => ({ useToast: () => ({ toast: vi.fn() }) }));
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('useWeeklyMenu', () => {
+  it('initializes with seven days', () => {
+    const { result } = renderHook(() => useWeeklyMenu(null));
+    expect(result.current.weeklyMenu).toHaveLength(7);
+  });
+
+  it('persists weekly menu locally', async () => {
+    const { result } = renderHook(() => useWeeklyMenu(null));
+    const newMenu = Array(7).fill([]);
+
+    await act(async () => {
+      await result.current.setWeeklyMenu(newMenu);
+    });
+
+    await waitFor(() => {
+      const stored = JSON.parse(localStorage.getItem('localWeeklyMenu'));
+      expect(stored).toEqual(newMenu);
+    });
+  });
+});

--- a/src/lib/ingredientNormalizer.test.js
+++ b/src/lib/ingredientNormalizer.test.js
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeIngredientName,
+  normalizeUnit,
+  canCombineUnits,
+  convertQuantity,
+} from './ingredientNormalizer';
+
+describe('ingredientNormalizer utilities', () => {
+  it('normalizes ingredient names', () => {
+    expect(normalizeIngredientName('Oeufs')).toBe('oeuf');
+    expect(normalizeIngredientName('Tomates')).toBe('tomate');
+  });
+
+  it('normalizes units', () => {
+    expect(normalizeUnit('Gramme')).toBe('g');
+    expect(normalizeUnit('KILO')).toBe('kg');
+  });
+
+  it('checks combinable units', () => {
+    expect(canCombineUnits('g', 'kg')).toBe(true);
+    expect(canCombineUnits('g', 'ml')).toBe(false);
+  });
+
+  it('converts quantities', () => {
+    expect(convertQuantity(1, 'kg', 'g')).toBe(1000);
+    expect(convertQuantity(200, 'g', 'kg')).toBeCloseTo(0.2);
+  });
+});

--- a/src/lib/utils.test.js
+++ b/src/lib/utils.test.js
@@ -1,0 +1,8 @@
+import { describe, it, expect } from 'vitest';
+import { cn } from './utils';
+
+describe('cn utility', () => {
+  it('merges class names', () => {
+    expect(cn('foo', undefined, 'bar')).toBe('foo bar');
+  });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+import path from 'node:path';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+  test: {
+    environment: 'jsdom',
+    globals: true,
+  },
+});


### PR DESCRIPTION
## Summary
- add Vitest configuration and test script
- create tests for hooks and utilities
- run tests in GitHub Actions

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ee9717f18832d8d4caaf0040fd233