### PR TITLE
Use pastel color variables

### DIFF
--- a/src/components/Auth.jsx
+++ b/src/components/Auth.jsx
@@ -59,7 +59,7 @@ export default function Auth({ onClose }) {
 
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-      <div className="w-full max-w-md bg-white p-8 rounded-xl shadow-lg relative">
+      <div className="w-full max-w-md bg-pastel-card p-8 rounded-xl shadow-lg relative">
         <Button
           variant="ghost"
           size="icon"
@@ -69,7 +69,7 @@ export default function Auth({ onClose }) {
           <X className="h-4 w-4" />
         </Button>
 
-        <h2 className="text-3xl font-bold text-center text-gray-900 mb-8">
+        <h2 className="text-3xl font-bold text-center text-pastel-text mb-8">
           Connexion
         </h2>
 
@@ -77,7 +77,7 @@ export default function Auth({ onClose }) {
           <div>
             <label
               htmlFor="email-login"
-              className="block text-sm font-medium text-gray-700"
+              className="block text-sm font-medium text-pastel-text"
             >
               Email
             </label>
@@ -86,13 +86,13 @@ export default function Auth({ onClose }) {
               type="email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
-              className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-primary"
+              className="mt-1 block w-full px-3 py-2 border border-pastel-input-border rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-primary bg-pastel-card text-pastel-text"
             />
           </div>
           <div>
             <label
               htmlFor="password-login"
-              className="block text-sm font-medium text-gray-700"
+              className="block text-sm font-medium text-pastel-text"
             >
               Mot de passe
             </label>
@@ -101,7 +101,7 @@ export default function Auth({ onClose }) {
               type="password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
-              className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-primary"
+              className="mt-1 block w-full px-3 py-2 border border-pastel-input-border rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-primary bg-pastel-card text-pastel-text"
             />
           </div>
           <div className="flex flex-col space-y-4">

--- a/src/components/DailyMenu.jsx
+++ b/src/components/DailyMenu.jsx
@@ -55,10 +55,10 @@ const MemoizedDailyMenu = React.memo(function DailyMenu({
                   delay: dayIndex * 0.05 + mealIndex * 0.03,
                   duration: 0.2,
                 }}
-                className={`rounded-lg p-2.5 space-y-1.5 bg-white ${MEAL_BLOCK_OPACITY[mealIndex + 1] || 'bg-opacity-10'} shadow-pastel-card-item`}
+                className={`rounded-lg p-2.5 space-y-1.5 bg-pastel-card ${MEAL_BLOCK_OPACITY[mealIndex + 1] || 'bg-opacity-10'} shadow-pastel-card-item`}
               >
                 <div className="flex justify-between items-center mb-1">
-                  <h4 className="text-xs font-semibold uppercase tracking-wider text-white/90">
+                  <h4 className="text-xs font-semibold uppercase tracking-wider text-pastel-text/90">
                     {mealTitle}
                   </h4>
                   <div className="flex items-center">
@@ -73,7 +73,7 @@ const MemoizedDailyMenu = React.memo(function DailyMenu({
                         <Button
                           variant="ghost"
                           size="icon"
-                          className="h-6 w-6 text-white/70 hover:text-white hover:bg-white/20"
+                          className="h-6 w-6 text-pastel-text/70 hover:text-pastel-text hover:bg-pastel-highlight/20"
                           onClick={() =>
                             onReplaceRecipe(mealIndex, recipeIndex)
                           }
@@ -83,7 +83,7 @@ const MemoizedDailyMenu = React.memo(function DailyMenu({
                         <Button
                           variant="ghost"
                           size="icon"
-                          className="h-6 w-6 text-red-400/70 hover:text-red-400 hover:bg-red-500/20"
+                          className="h-6 w-6 text-destructive/70 hover:text-destructive hover:bg-destructive/20"
                           onClick={() => onDeleteRecipe(mealIndex, recipeIndex)}
                         >
                           <Trash2 className="w-3.5 h-3.5" />
@@ -122,11 +122,11 @@ const MemoizedDailyMenu = React.memo(function DailyMenu({
                         <p className="text-sm font-semibold leading-tight">
                           {recipe?.name || 'Recette inconnue'}
                         </p>
-                        <div className="text-xs text-white/80">
+                        <div className="text-xs text-pastel-text/80">
                           <p>{mealTypeDisplay}</p>
                         </div>
                         <div className="flex items-center gap-1 mt-1">
-                          <Users className="w-3.5 h-3.5 text-white/70 opacity-80" />
+                          <Users className="w-3.5 h-3.5 text-pastel-text/70 opacity-80" />
                           <ServingsAdjuster
                             servings={plannedServings}
                             onDecrease={() =>
@@ -146,7 +146,7 @@ const MemoizedDailyMenu = React.memo(function DailyMenu({
                           />
                         </div>
                         {recipeIndex < safeMealRecipes.length - 1 && (
-                          <hr className="border-white/10 my-1.5" />
+                          <hr className="border-pastel-border/10 my-1.5" />
                         )}
                       </div>
                     );
@@ -161,7 +161,7 @@ const MemoizedDailyMenu = React.memo(function DailyMenu({
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           transition={{ delay: dayIndex * 0.05 + 0.1, duration: 0.2 }}
-          className="rounded-lg p-3 text-center bg-white bg-opacity-10 flex-grow flex items-center justify-center min-h-[50px]"
+          className="rounded-lg p-3 text-center bg-pastel-card bg-opacity-10 flex-grow flex items-center justify-center min-h-[50px]"
         >
           <p className="text-xs opacity-70">Aucun repas prévu</p>
         </motion.div>

--- a/src/components/RecipeList.jsx
+++ b/src/components/RecipeList.jsx
@@ -37,7 +37,7 @@ const MemoizedRecipeCard = React.memo(function RecipeCard({
         </div>
       )}
       <div className="flex justify-between items-start mb-1.5">
-        <h3 className="text-xl font-bold group-hover:text-white/90 transition-colors">
+        <h3 className="text-xl font-bold group-hover:text-pastel-text/90 transition-colors">
           {recipe.name}
         </h3>
         <div className="flex gap-1 shrink-0">
@@ -49,7 +49,7 @@ const MemoizedRecipeCard = React.memo(function RecipeCard({
               onSelectRecipe(recipe);
             }}
             title="Voir le détail"
-            className={`h-8 w-8 hover:bg-white/20 ${color.text} hover:${color.text}`}
+            className={`h-8 w-8 hover:bg-pastel-highlight/20 ${color.text} hover:${color.text}`}
           >
             <Eye className="h-4 w-4" />
           </Button>
@@ -61,7 +61,7 @@ const MemoizedRecipeCard = React.memo(function RecipeCard({
               onEdit(recipe);
             }}
             title="Modifier"
-            className={`h-8 w-8 hover:bg-white/20 ${color.text} hover:${color.text}`}
+            className={`h-8 w-8 hover:bg-pastel-highlight/20 ${color.text} hover:${color.text}`}
           >
             <Edit2 className="h-4 w-4" />
           </Button>
@@ -73,7 +73,7 @@ const MemoizedRecipeCard = React.memo(function RecipeCard({
               onDelete(recipe.id);
             }}
             title="Supprimer"
-            className={`h-8 w-8 text-red-300 hover:bg-red-400/30 hover:text-red-200`}
+            className={`h-8 w-8 text-destructive/70 hover:bg-destructive/30 hover:text-destructive-foreground`}
           >
             <Trash2 className="h-4 w-4" />
           </Button>
@@ -93,7 +93,7 @@ const MemoizedRecipeCard = React.memo(function RecipeCard({
           recipe.tags.slice(0, 3).map((tag) => (
             <span
               key={tag}
-              className={`text-[10px] ${color.text} bg-white/20 px-2.5 py-1 rounded-full font-medium`}
+              className={`text-[10px] ${color.text} bg-pastel-highlight/20 px-2.5 py-1 rounded-full font-medium`}
             >
               {tag}
             </span>
@@ -102,7 +102,7 @@ const MemoizedRecipeCard = React.memo(function RecipeCard({
           Array.isArray(recipe.tags) &&
           recipe.tags.length > 3 && (
             <span
-              className={`text-[10px] ${color.text} bg-white/20 px-2.5 py-1 rounded-full font-medium`}
+              className={`text-[10px] ${color.text} bg-pastel-highlight/20 px-2.5 py-1 rounded-full font-medium`}
             >
               +{recipe.tags.length - 3}
             </span>

--- a/src/components/SignUpForm.jsx
+++ b/src/components/SignUpForm.jsx
@@ -144,7 +144,7 @@ export default function SignUpForm({ onClose, onBackToLogin }) {
 
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-      <div className="w-full max-w-md bg-white p-8 rounded-xl shadow-lg relative">
+      <div className="w-full max-w-md bg-pastel-card p-8 rounded-xl shadow-lg relative">
         <Button
           variant="ghost"
           size="icon"
@@ -162,7 +162,7 @@ export default function SignUpForm({ onClose, onBackToLogin }) {
           <ArrowLeft className="h-4 w-4" />
         </Button>
 
-        <h2 className="text-3xl font-bold text-center text-gray-900 mb-8">
+        <h2 className="text-3xl font-bold text-center text-pastel-text mb-8">
           Inscription
         </h2>
 
@@ -170,7 +170,7 @@ export default function SignUpForm({ onClose, onBackToLogin }) {
           <div>
             <label
               htmlFor="user-tag-signup"
-              className="block text-sm font-medium text-gray-700"
+              className="block text-sm font-medium text-pastel-text"
             >
               Identifiant Unique (non modifiable)
             </label>
@@ -179,17 +179,17 @@ export default function SignUpForm({ onClose, onBackToLogin }) {
               type="text"
               value={userTag}
               onChange={(e) => setUserTag(e.target.value)}
-              className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-primary"
+              className="mt-1 block w-full px-3 py-2 border border-pastel-input-border rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-primary bg-pastel-card text-pastel-text"
               placeholder="Ex: mon_id_123"
             />
-            <p className="text-xs text-gray-500 mt-1">
+            <p className="text-xs text-pastel-muted-foreground mt-1">
               3-15 caractères, alphanumériques et '_'.
             </p>
           </div>
           <div>
             <label
               htmlFor="username-signup"
-              className="block text-sm font-medium text-gray-700"
+              className="block text-sm font-medium text-pastel-text"
             >
               Pseudo (modifiable)
             </label>
@@ -198,13 +198,13 @@ export default function SignUpForm({ onClose, onBackToLogin }) {
               type="text"
               value={username}
               onChange={(e) => setUsername(e.target.value)}
-              className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-primary"
+              className="mt-1 block w-full px-3 py-2 border border-pastel-input-border rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-primary bg-pastel-card text-pastel-text"
             />
           </div>
           <div>
             <label
               htmlFor="email-signup"
-              className="block text-sm font-medium text-gray-700"
+              className="block text-sm font-medium text-pastel-text"
             >
               Email
             </label>
@@ -213,13 +213,13 @@ export default function SignUpForm({ onClose, onBackToLogin }) {
               type="email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
-              className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-primary"
+              className="mt-1 block w-full px-3 py-2 border border-pastel-input-border rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-primary bg-pastel-card text-pastel-text"
             />
           </div>
           <div>
             <label
               htmlFor="dob-signup"
-              className="block text-sm font-medium text-gray-700"
+              className="block text-sm font-medium text-pastel-text"
             >
               Date de naissance
             </label>
@@ -228,13 +228,13 @@ export default function SignUpForm({ onClose, onBackToLogin }) {
               type="date"
               value={dateOfBirth}
               onChange={(e) => setDateOfBirth(e.target.value)}
-              className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-primary"
+              className="mt-1 block w-full px-3 py-2 border border-pastel-input-border rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-primary bg-pastel-card text-pastel-text"
             />
           </div>
           <div>
             <label
               htmlFor="password-signup"
-              className="block text-sm font-medium text-gray-700"
+              className="block text-sm font-medium text-pastel-text"
             >
               Mot de passe
             </label>
@@ -243,13 +243,13 @@ export default function SignUpForm({ onClose, onBackToLogin }) {
               type="password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
-              className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-primary"
+              className="mt-1 block w-full px-3 py-2 border border-pastel-input-border rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-primary bg-pastel-card text-pastel-text"
             />
           </div>
           <div>
             <label
               htmlFor="confirm-password-signup"
-              className="block text-sm font-medium text-gray-700"
+              className="block text-sm font-medium text-pastel-text"
             >
               Confirmation du mot de passe
             </label>
@@ -258,7 +258,7 @@ export default function SignUpForm({ onClose, onBackToLogin }) {
               type="password"
               value={confirmPassword}
               onChange={(e) => setConfirmPassword(e.target.value)}
-              className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-primary"
+              className="mt-1 block w-full px-3 py-2 border border-pastel-input-border rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-primary bg-pastel-card text-pastel-text"
             />
           </div>
           <div className="flex flex-col space-y-4 pt-2">

--- a/src/components/account/ProfileInformationForm.jsx
+++ b/src/components/account/ProfileInformationForm.jsx
@@ -231,7 +231,7 @@ export default function ProfileInformationForm({
           onChange={(e) => setBio(e.target.value)}
           rows="3"
           placeholder="Une courte description de vous..."
-          className="flex w-full rounded-md border-2 border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 placeholder-gray-400 ring-offset-pastel-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pastel-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 transition-shadow duration-150 shadow-pastel-input hover:border-pastel-muted-foreground/30 focus-visible:shadow-pastel-input-focus dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:placeholder-gray-500"
+          className="flex w-full rounded-md border-2 border-pastel-input-border bg-pastel-card px-3 py-2 text-sm text-pastel-text placeholder-pastel-muted-foreground ring-offset-pastel-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pastel-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 transition-shadow duration-150 shadow-pastel-input hover:border-pastel-muted-foreground/30 focus-visible:shadow-pastel-input-focus dark:border-pastel-input-border dark:bg-pastel-card-alt dark:text-pastel-text dark:placeholder-pastel-muted-foreground"
         />
       </div>
       <Button

--- a/src/components/layout/MainAppLayout.jsx
+++ b/src/components/layout/MainAppLayout.jsx
@@ -45,7 +45,7 @@ export default function MainAppLayout({
 
   return (
     <>
-      <header className="border-b border-pastel-border/60 dark:border-pastel-border/30 shadow-pastel-soft sticky top-0 z-40 bg-white dark:bg-slate-800 bg-opacity-90 dark:bg-opacity-80 backdrop-blur-md">
+      <header className="border-b border-pastel-border/60 dark:border-pastel-border/30 shadow-pastel-soft sticky top-0 z-40 bg-pastel-card dark:bg-pastel-card-alt bg-opacity-90 dark:bg-opacity-80 backdrop-blur-md">
         <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-4">
           <div className="flex justify-between items-center">
             <h1 className="text-2xl sm:text-3xl font-bold text-pastel-primary dark:text-pastel-primary-hover flex items-center">
@@ -57,8 +57,8 @@ export default function MainAppLayout({
             </h1>
             <div className="flex items-center gap-2 sm:gap-3">
               {userProfile?.subscription_tier === 'premium' && (
-                <span className="flex items-center text-sm font-medium text-yellow-500 bg-yellow-500/10 px-2.5 py-1 rounded-full">
-                  <Star className="h-4 w-4 mr-1.5 text-yellow-400" /> Premium
+                <span className="flex items-center text-sm font-medium text-pastel-accent bg-pastel-accent/10 px-2.5 py-1 rounded-full">
+                  <Star className="h-4 w-4 mr-1.5 text-pastel-accent" /> Premium
                 </span>
               )}
               <Button

--- a/src/components/ui/button.jsx
+++ b/src/components/ui/button.jsx
@@ -11,7 +11,7 @@ const buttonVariants = cva(
         default:
           'bg-pastel-primary text-pastel-primary-text shadow-pastel-button border border-transparent hover:bg-pastel-primary-hover hover:shadow-pastel-button-hover hover:border-pastel-primary-hover active:bg-pastel-primary-hover/90 active:shadow-pastel-button-inset active:border-pastel-primary transform active:scale-[0.97]',
         destructive:
-          'bg-red-500 text-white shadow-pastel-button border border-transparent hover:bg-red-600 hover:shadow-pastel-button-hover hover:border-red-600 active:bg-red-700/90 active:shadow-pastel-button-inset active:border-red-700 transform active:scale-[0.97]',
+          'bg-destructive text-destructive-foreground shadow-pastel-button border border-transparent hover:bg-destructive/90 hover:shadow-pastel-button-hover hover:border-destructive active:bg-destructive/80 active:shadow-pastel-button-inset active:border-destructive transform active:scale-[0.97]',
         outline:
           'border border-pastel-input-border bg-pastel-card text-pastel-text hover:bg-pastel-highlight hover:border-pastel-active-border hover:shadow-pastel-button active:bg-pastel-highlight/80 active:border-pastel-active-border/70 active:shadow-pastel-button-inset transform active:scale-[0.98]',
         secondary:
@@ -23,9 +23,9 @@ const buttonVariants = cva(
           'bg-pastel-tertiary text-pastel-tertiary-text shadow-pastel-button border border-transparent hover:bg-pastel-tertiary-hover hover:shadow-pastel-button-hover hover:border-pastel-tertiary-hover active:bg-pastel-tertiary-hover/90 active:shadow-pastel-button-inset active:border-pastel-tertiary transform active:scale-[0.97]',
         accent:
           'bg-pastel-accent text-pastel-accent-text shadow-pastel-button border border-transparent hover:bg-pastel-accent-hover hover:shadow-pastel-button-hover hover:border-pastel-accent-hover active:bg-pastel-accent-hover/90 active:shadow-pastel-button-inset active:border-pastel-accent transform active:scale-[0.97]',
-        tag: 'border data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:border-transparent bg-white text-gray-700 border-gray-300 dark:bg-gray-800 dark:text-gray-300 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-700 transform active:scale-[0.97]',
+        tag: 'border data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:border-transparent bg-pastel-card text-pastel-text border-pastel-border dark:bg-pastel-card-alt dark:text-pastel-text dark:border-pastel-border hover:bg-pastel-highlight dark:hover:bg-pastel-highlight transform active:scale-[0.97]',
         premium:
-          'bg-yellow-400 text-black border-yellow-600 rounded-md px-4 py-2 hover:bg-yellow-500 active:bg-yellow-600 transform active:scale-[0.97] border',
+          'bg-pastel-accent text-pastel-accent-text border-pastel-accent rounded-md px-4 py-2 hover:bg-pastel-accent-hover active:bg-pastel-accent-hover/90 transform active:scale-[0.97] border',
       },
       size: {
         default: 'h-10 px-4 py-2',

--- a/src/components/ui/input.jsx
+++ b/src/components/ui/input.jsx
@@ -7,7 +7,7 @@ const Input = React.forwardRef(({ className, type, ...props }, ref) => {
       type={type}
       className={cn(
         'flex h-10 w-full rounded-md px-3 py-2 text-sm ring-offset-pastel-background file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pastel-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 transition-shadow duration-150 shadow-pastel-input hover:border-pastel-muted-foreground/30 focus-visible:shadow-pastel-input-focus',
-        'border-2 border-gray-300 bg-white text-gray-900 placeholder-gray-400 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:placeholder-gray-500',
+        'border-2 border-pastel-input-border bg-pastel-card text-pastel-text placeholder-pastel-muted-foreground dark:border-pastel-input-border dark:bg-pastel-card-alt dark:text-pastel-text dark:placeholder-pastel-muted-foreground',
         className
       )}
       ref={ref}

--- a/src/components/ui/textarea.jsx
+++ b/src/components/ui/textarea.jsx
@@ -7,7 +7,7 @@ const Textarea = React.forwardRef(({ className, ...props }, ref) => {
     <textarea
       className={cn(
         'flex min-h-[80px] w-full rounded-md px-3 py-2 text-sm ring-offset-pastel-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pastel-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 transition-shadow duration-150 shadow-pastel-input hover:border-pastel-muted-foreground/30 focus-visible:shadow-pastel-input-focus',
-        'border-2 border-gray-300 bg-white text-gray-900 placeholder-gray-400 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:placeholder-gray-500',
+        'border-2 border-pastel-input-border bg-pastel-card text-pastel-text placeholder-pastel-muted-foreground dark:border-pastel-input-border dark:bg-pastel-card-alt dark:text-pastel-text dark:placeholder-pastel-muted-foreground',
         className
       )}
       ref={ref}


### PR DESCRIPTION
## Summary
- switch button variant colors to pastel tokens
- refactor form inputs to use pastel styles
- replace hardcoded colors in layout and menus
- update recipe and authentication components to use CSS variables

## Testing
- `npm run lint` *(fails: 610 errors)*

------
https://chatgpt.com/codex/tasks/task_e_684ee98542c4832da06604fdc95dc300