### PR TITLE
Fix Vitest config and add basic tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,11 @@ VITE_SUPABASE_ANON_KEY=<your-supabase-anon-key>
 ```
 
 These values are injected by Vite and used by the app at runtime.
+
+## Running tests
+
+Execute the following command to run the Vitest suite:
+
+```bash
+npm run test
+```

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
   "build": "vite build",
   "preview": "vite preview",
-  "test": "vitest",
+  "test": "vitest run",
     "lint": "eslint . --ext .js,.jsx",
     "format": "prettier --write \"src/**/*.{js,jsx,json,css}\""
   },

--- a/src/__tests__/basic.spec.js
+++ b/src/__tests__/basic.spec.js
@@ -1,0 +1,7 @@
+import { describe, it, expect } from 'vitest';
+
+describe('Spec test', () => {
+  it('addition works', () => {
+    expect(1 + 1).toBe(2);
+  });
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -198,7 +198,7 @@ export default defineConfig({
 		addTransformIndexHtml
 	],
 	test: {
-  include: ['src/**/*.test.{js,jsx}', 'src/**/*.spec.{js,jsx}'],
+  include: ['src/__tests__/**/*.{test,spec}.{js,jsx}'],
   globals: true,
   environment: 'jsdom',
   },


### PR DESCRIPTION
## Summary
- adjust vitest include pattern for `src/__tests__`
- run vitest in non-watch mode
- add `.spec.js` example
- document how to run the tests

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_684ef7745ac0832d8f66805d664af87f