### PR TITLE
Fix ESLint issues in account components

### DIFF
--- a/src/components/account/EmailForm.jsx
+++ b/src/components/account/EmailForm.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
 import { supabase } from '@/lib/supabase';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -90,3 +91,13 @@ export default function EmailForm({ session, onProfileUpdate }) {
     </form>
   );
 }
+
+EmailForm.propTypes = {
+  session: PropTypes.shape({
+    user: PropTypes.shape({
+      id: PropTypes.string,
+      email: PropTypes.string,
+    }),
+  }),
+  onProfileUpdate: PropTypes.func,
+};

--- a/src/components/account/ProfileInformationForm.jsx
+++ b/src/components/account/ProfileInformationForm.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
+import PropTypes from 'prop-types';
 import { supabase } from '@/lib/supabase';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -25,7 +26,6 @@ export default function ProfileInformationForm({
 
   const [initialUsername, setInitialUsername] = useState('');
   const [initialBio, setInitialBio] = useState('');
-  const [initialAvatarUrl, setInitialAvatarUrl] = useState(null);
 
   useEffect(() => {
     if (userProfile) {
@@ -35,7 +35,6 @@ export default function ProfileInformationForm({
       setBio(userProfile.bio || '');
       setInitialBio(userProfile.bio || '');
       setAvatarPreview(userProfile.avatar_url || DEFAULT_AVATAR_URL);
-      setInitialAvatarUrl(userProfile.avatar_url || DEFAULT_AVATAR_URL);
     }
   }, [userProfile]);
 
@@ -65,7 +64,6 @@ export default function ProfileInformationForm({
     setLoading(true);
 
     let profileUpdated = false;
-    let avatarUploaded = false;
 
     try {
       const userUpdates = {};
@@ -93,7 +91,6 @@ export default function ProfileInformationForm({
         } = supabase.storage.from('avatars').getPublicUrl(uploadData.path);
         userUpdates.avatar_url = publicUrl;
         publicUserUpdates.avatar_url = publicUrl;
-        avatarUploaded = true;
       }
 
       // Update auth.users.user_metadata first
@@ -125,8 +122,6 @@ export default function ProfileInformationForm({
         setInitialBio(
           userUpdates.bio !== undefined ? userUpdates.bio : initialBio
         );
-        if (avatarUploaded && userUpdates.avatar_url)
-          setInitialAvatarUrl(userUpdates.avatar_url);
         toast({
           title: 'Profil mis à jour',
           description: 'Vos informations de profil ont été sauvegardées.',
@@ -248,3 +243,18 @@ export default function ProfileInformationForm({
     </form>
   );
 }
+
+ProfileInformationForm.propTypes = {
+  session: PropTypes.shape({
+    user: PropTypes.shape({
+      id: PropTypes.string,
+    }),
+  }),
+  userProfile: PropTypes.shape({
+    username: PropTypes.string,
+    user_tag: PropTypes.string,
+    bio: PropTypes.string,
+    avatar_url: PropTypes.string,
+  }),
+  onProfileUpdate: PropTypes.func,
+};

--- a/src/components/account/SubscriptionManagement.jsx
+++ b/src/components/account/SubscriptionManagement.jsx
@@ -2,7 +2,8 @@ import React, { useState, useEffect } from 'react';
 import { supabase } from '@/lib/supabase';
 import { Button } from '@/components/ui/button';
 import { useToast } from '@/components/ui/use-toast';
-import { Loader2, Star, CheckCircle, CreditCard, Users } from 'lucide-react';
+import { Loader2, Star, CheckCircle, CreditCard } from 'lucide-react';
+import PropTypes from 'prop-types';
 import { loadStripe } from '@stripe/stripe-js';
 
 const STRIPE_PUBLISHABLE_KEY =
@@ -148,7 +149,7 @@ export default function SubscriptionManagement({
   return (
     <div className="bg-pastel-card p-6 sm:p-8 rounded-xl shadow-pastel-soft space-y-6">
       <h3 className="text-xl sm:text-2xl font-semibold text-pastel-text/90 border-b border-pastel-border pb-3 mb-5">
-        Gestion de l'Abonnement
+        Gestion de l&apos;Abonnement
       </h3>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
@@ -217,7 +218,7 @@ export default function SubscriptionManagement({
               Génération IA de descriptions
             </li>
             <li className="font-medium text-pastel-accent/90">
-              Génération IA d'images
+              Génération IA d&apos;images
             </li>
             <li>Support prioritaire (à venir)</li>
           </ul>
@@ -249,3 +250,16 @@ export default function SubscriptionManagement({
     </div>
   );
 }
+
+SubscriptionManagement.propTypes = {
+  session: PropTypes.shape({
+    user: PropTypes.shape({
+      id: PropTypes.string,
+      email: PropTypes.string,
+    }),
+  }),
+  userProfile: PropTypes.shape({
+    subscription_tier: PropTypes.string,
+  }),
+  onProfileUpdate: PropTypes.func,
+};


### PR DESCRIPTION
## Summary
- add prop type validation to account forms
- remove unused variables and fix imports
- escape apostrophes in SubscriptionManagement

## Testing
- `npm run lint` *(fails: existing issues outside scope)*
- `npx eslint "src/components/account/**/*.{js,jsx}"`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684efdee1500832d889e48403a1eaf96