### PR TITLE
UI polish updates

### DIFF
--- a/src/components/FriendsTab.jsx
+++ b/src/components/FriendsTab.jsx
@@ -168,7 +168,7 @@ export default function FriendsTab({ session, userProfile }) {
             {friendRequests.map((req) => (
               <li
                 key={req.id}
-                className="flex flex-col sm:flex-row items-center justify-between p-3 bg-pastel-card-alt rounded-md shadow-sm gap-3"
+                className="flex items-center justify-between p-3 bg-pastel-card-alt rounded-md shadow-sm gap-3"
               >
                 <Link
                   to={`/app/profile/${req.id}`}
@@ -231,7 +231,7 @@ export default function FriendsTab({ session, userProfile }) {
             {friends.map((friend) => (
               <li
                 key={friend.id}
-                className="flex flex-col sm:flex-row items-center justify-between p-3 bg-pastel-card-alt rounded-md shadow-sm gap-3"
+                className="flex items-center justify-between p-3 bg-pastel-card-alt rounded-md shadow-sm gap-3"
               >
                 <Link
                   to={`/app/profile/${friend.id}`}

--- a/src/components/MyPublicProfile.jsx
+++ b/src/components/MyPublicProfile.jsx
@@ -126,7 +126,7 @@ export default function MyPublicProfile({
     <>
       <div className="space-y-8 mt-6">
         <div className="bg-pastel-card p-6 sm:p-8 rounded-xl shadow-pastel-soft">
-          <div className="flex flex-col sm:flex-row items-center sm:items-start gap-6 mb-8">
+          <div className="flex flex-col sm:flex-row items-center sm:items-center gap-6 mb-8">
             {profileData.avatar_url ? (
               <img
                 src={profileData.avatar_url}
@@ -159,7 +159,7 @@ export default function MyPublicProfile({
                   <Calendar className="w-4 h-4 mr-1.5" /> Membre depuis{' '}
                   {(() => {
                     const d = profileData.created_at ? new Date(profileData.created_at) : null;
-                    return d && !isNaN(d) ? d.toLocaleDateString() : 'Date inconnue';
+                    return d && !isNaN(d.getTime()) ? d.toLocaleDateString() : 'Date inconnue';
                   })()}
                 </span>
               </div>

--- a/src/components/PublicRecipeFeed.jsx
+++ b/src/components/PublicRecipeFeed.jsx
@@ -19,7 +19,7 @@ export default function PublicRecipeFeed({ session, onSelectRecipe }) {
           onSelectRecipe={onSelectRecipe}
         />
       ) : (
-        <div className="text-center py-8">
+        <div className="flex items-center justify-center h-40 text-center">
           <p className="text-lg text-pastel-muted-foreground">
             Aucune recette publique à afficher pour le moment.
           </p>

--- a/src/components/RecipeForm.jsx
+++ b/src/components/RecipeForm.jsx
@@ -521,7 +521,7 @@ function RecipeForm({
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         exit={{ opacity: 0 }}
-        className="fixed inset-0 flex items-center justify-center z-50 p-4 backdrop-blur-sm bg-white/80"
+        className="fixed inset-0 flex items-center justify-center z-50 p-4 backdrop-blur-sm bg-black/30"
         onClick={onClose}
       >
         <motion.div
@@ -529,7 +529,7 @@ function RecipeForm({
           animate={{ y: 0, opacity: 1, scale: 1 }}
           exit={{ y: 30, opacity: 0, scale: 0.95 }}
           transition={{ type: 'spring', stiffness: 280, damping: 28 }}
-          className="bg-white bg-opacity-95 text-pastel-text rounded-xl p-6 sm:p-8 w-full max-w-3xl max-h-[90vh] overflow-y-auto shadow-lg"
+          className="bg-[#fcfbf9] text-pastel-text rounded-xl p-6 sm:p-8 w-full max-w-3xl max-h-[90vh] overflow-y-auto shadow-lg"
           onClick={(e) => e.stopPropagation()}
         >
           <div className="flex justify-between items-center mb-6 pb-4 border-b border-pastel-border/60">

--- a/src/components/UserSearch.jsx
+++ b/src/components/UserSearch.jsx
@@ -56,7 +56,7 @@ export default function UserSearch({ session }) {
         </div>
       )}
       {term && !loading && results.length === 0 && (
-        <div className="text-center py-8 px-6 bg-pastel-card rounded-xl shadow-pastel-soft">
+        <div className="flex items-center justify-center h-40 bg-pastel-card rounded-xl shadow-pastel-soft px-6 text-center">
           <p className="text-lg text-pastel-muted-foreground">Aucun utilisateur trouvé pour "{term}".</p>
         </div>
       )}

--- a/src/components/form/RecipeCoreFields.jsx
+++ b/src/components/form/RecipeCoreFields.jsx
@@ -42,7 +42,7 @@ export default function RecipeCoreFields({
         />
       </div>
 
-      <div className="grid grid-cols-2 gap-4">
+      <div className="space-y-4">
         <div className="space-y-2">
           <Label htmlFor="servings" className="text-pastel-text/90">
             Portions

--- a/src/components/form/RecipeMetaFields.jsx
+++ b/src/components/form/RecipeMetaFields.jsx
@@ -18,20 +18,25 @@ export default function RecipeMetaFields({
       <div className="space-y-3">
         <Label className="text-pastel-text/90">Types de repas</Label>
         <div className="flex flex-wrap gap-2">
-          {MEAL_TYPE_OPTIONS_DATA.map((type) => (
-            <Button
-              key={type.id}
-              type="button"
-              variant={
-                formData.meal_types.includes(type.id) ? 'secondary' : 'outline'
-              }
-              onClick={() => handleMealTypeToggle(type.id)}
-              size="sm"
-              className="transition-all duration-200 ease-in-out"
-            >
-              {type.label}
-            </Button>
-          ))}
+          {MEAL_TYPE_OPTIONS_DATA.map((type) => {
+            const colorMap = {
+              'petit-dejeuner': 'bg-[#d9c2e9]',
+              plat: 'bg-[#e8b0a0]',
+              'encas-sucre': 'bg-[#f0c4cf]',
+            };
+            const active = formData.meal_types.includes(type.id);
+            return (
+              <Button
+                key={type.id}
+                type="button"
+                onClick={() => handleMealTypeToggle(type.id)}
+                size="sm"
+                className={`font-semibold text-pastel-text ${colorMap[type.id] || 'bg-pastel-muted'} ${active ? 'ring-2 ring-pastel-primary' : ''}`}
+              >
+                {type.label}
+              </Button>
+            );
+          })}
         </div>
       </div>
 

--- a/src/components/layout/MainAppLayout.jsx
+++ b/src/components/layout/MainAppLayout.jsx
@@ -45,7 +45,7 @@ export default function MainAppLayout({
 
   return (
     <>
-      <header className="border-b border-pastel-border/60 dark:border-pastel-border/30 shadow-md sticky top-0 z-40 bg-white dark:bg-pastel-card-alt backdrop-blur-md">
+      <header className="border-b border-pastel-border/50 shadow-sm sticky top-0 z-40 bg-white/95 dark:bg-pastel-card-alt/95 backdrop-blur">
         <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-4">
           <div className="flex justify-between items-center">
             <h1 className="text-2xl sm:text-3xl font-bold text-pastel-primary dark:text-pastel-primary-hover flex items-center">

--- a/src/pages/CommunityPage.jsx
+++ b/src/pages/CommunityPage.jsx
@@ -52,7 +52,7 @@ export default function CommunityPage({ session, userProfile }) {
           </div>
         </TabsContent>
 
-        <TabsContent value="friends">
+        <TabsContent value="friends" className="mt-6">
           {session && userProfile ? (
             <FriendsTab session={session} userProfile={userProfile} />
           ) : (
@@ -60,7 +60,7 @@ export default function CommunityPage({ session, userProfile }) {
           )}
         </TabsContent>
 
-        <TabsContent value="my-profile-preview">
+        <TabsContent value="my-profile-preview" className="mt-6">
           {session && userProfile ? (
             <MyPublicProfile session={session} userProfile={userProfile} />
           ) : (


### PR DESCRIPTION
## Summary
- soften main header background
- restyle recipe modal and overlay
- stack serving fields vertically
- colorize meal type buttons
- center empty user search message
- center empty public feed message
- unify community tab margins
- simplify friends cards
- fix profile page layout and date parsing

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f05bd1e88832d933227579cbd41eb