### PR TITLE
Fix editing mode in RecipeForm

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -97,8 +97,7 @@ function App() {
     return success;
   };
 
-  const openRecipeFormForAdd = () => {
-    setEditingRecipe(null);
+  const openRecipeForm = () => {
     setShowRecipeForm(true);
   };
   const closeRecipeForm = () => {
@@ -139,7 +138,7 @@ function App() {
           weeklyMenuLoading={weeklyMenuLoading}
           showRecipeForm={showRecipeForm}
           editingRecipe={editingRecipe}
-          openRecipeFormForAdd={openRecipeFormForAdd}
+          openRecipeFormForAdd={openRecipeForm}
           closeRecipeForm={closeRecipeForm}
           handleAddRecipeSubmit={handleAddRecipeSubmit}
           handleEditRecipeSubmit={handleEditRecipeSubmit}

--- a/src/components/AppRoutes.jsx
+++ b/src/components/AppRoutes.jsx
@@ -64,7 +64,10 @@ export default function AppRoutes({
                 {recipePageTitle}
               </h2>
               <button
-                onClick={openRecipeFormForAdd}
+                onClick={() => {
+                  setEditingRecipe(null);
+                  openRecipeFormForAdd();
+                }}
                 className="bg-pastel-secondary text-pastel-secondary-text hover:bg-pastel-secondary-hover px-4 py-2 rounded-md shadow-pastel-button hover:shadow-pastel-button-hover flex items-center"
               >
                 <PlusCircle className="w-5 h-5 mr-2" />


### PR DESCRIPTION
## Summary
- keep editingRecipe state when opening form to edit a recipe
- reset editingRecipe only when creating a new recipe

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f08da1bc8832d834f89462b13e6b7