### PR TITLE
Improve tag suggestion style

### DIFF
--- a/src/components/RecipeFormFields.jsx
+++ b/src/components/RecipeFormFields.jsx
@@ -235,14 +235,14 @@ const RecipeFormFields = ({
               <Label className="block text-xs font-medium text-pastel-muted-foreground mb-1">
                 Suggestions
               </Label>
-              <div className="flex flex-wrap gap-1.5">
+              <div className="flex flex-wrap gap-2">
                 {suggestedTags.map((tag) => (
                   <Button
                     key={tag}
                     type="button"
-                    variant="tag"
+                    variant="outline"
                     size="sm"
-                    className="rounded-full px-2 py-0.5 text-xs"
+                    className="h-auto rounded-full px-2 py-1 text-xs font-medium"
                     onClick={() => handleAddTag(tag)}
                   >
                     <Plus className="w-3 h-3 mr-1" />

--- a/src/components/form/RecipeMetaFields.jsx
+++ b/src/components/form/RecipeMetaFields.jsx
@@ -67,7 +67,7 @@ export default function RecipeMetaFields({
           ))}
         </div>
         {suggestedTags.length > 0 && (
-          <div className="flex flex-wrap gap-1.5 pt-2">
+          <div className="flex flex-wrap gap-2 pt-2">
             <span className="text-xs text-pastel-muted-foreground mr-1 self-center">
               Suggestions:
             </span>
@@ -76,9 +76,9 @@ export default function RecipeMetaFields({
                 key={tag}
                 type="button"
                 variant="outline"
-                size="xs"
+                size="sm"
                 onClick={() => handleAddTag(tag)}
-                className="text-xs"
+                className="h-auto rounded-full px-2 py-1 text-xs font-medium"
               >
                 <Tag className="w-3 h-3 mr-1" /> {tag}
               </Button>


### PR DESCRIPTION
## Summary
- tweak tag suggestion buttons to feel like existing tags
- use neutral outline style with more padding

## Testing
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684f117fdac4832db180ad72417524bd