### PR TITLE
UI: rework meal preference cards

### DIFF
--- a/src/components/menu_planner/MenuPreferencesPanel.jsx
+++ b/src/components/menu_planner/MenuPreferencesPanel.jsx
@@ -189,13 +189,13 @@ function MenuPreferencesPanel({
           </Button>
         </div>
 
-        <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+        <div className="space-y-4">
           {(preferences.meals || []).map((meal, index) => (
             <motion.div
               key={meal.id || index}
               initial={{ opacity: 0, y: -10 }}
               animate={{ opacity: 1, y: 0 }}
-              className="space-y-3 bg-pastel-card-alt p-4 rounded-lg shadow-pastel-card-item border border-pastel-border"
+              className="space-y-4 bg-pastel-card p-4 rounded-xl shadow-pastel-soft"
             >
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- stack meal preference cards vertically
- use soft pastel card styles for better readability

## Testing
- `npm run lint` *(fails: many unrelated errors)*
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_684f134c5228832db6a755bf8512164a