### PR TITLE
Remove email fallback from user profile

### DIFF
--- a/src/hooks/useUserProfile.js
+++ b/src/hooks/useUserProfile.js
@@ -59,7 +59,6 @@ export function useUserProfile(session) {
         username:
           profile?.username ||
           userMetadata.username ||
-          session.user.email?.split('@')[0] ||
           'Utilisateur',
         user_tag:
           profile?.user_tag ||
@@ -110,7 +109,7 @@ export function useUserProfile(session) {
         id: session.user.id,
         ...defaultProfileBase,
         subscription_tier: 'standard',
-        username: session.user.email?.split('@')[0] || 'Utilisateur',
+        username: 'Utilisateur',
         user_tag: 'user_' + session.user.id.substring(0, 8),
         avatar_url: DEFAULT_AVATAR_URL,
       };


### PR DESCRIPTION
## Summary
- avoid using the email address to build usernames

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6852bb640ad0832d85bf5e07113f34df