### PR TITLE
Fix supabase public_users references

### DIFF
--- a/src/components/account/ProfileInformationForm.jsx
+++ b/src/components/account/ProfileInformationForm.jsx
@@ -90,8 +90,8 @@ export default function ProfileInformationForm({
       }
 
       if (Object.keys(publicUserUpdates).length > 0) {
-        const { error: updateError } = await supabase
-          .from('public.public_users')
+          const { error: updateError } = await supabase
+            .from('public_users')
           .update(publicUserUpdates)
           .eq('id', session.user.id);
         if (updateError) throw updateError;

--- a/src/hooks/useLinkedUsers.js
+++ b/src/hooks/useLinkedUsers.js
@@ -123,7 +123,7 @@ export function useLinkedUsers(userProfile, preferences, setPreferences) {
     setIsLinkingUser(true);
     try {
       const { data: usersData, error: usersError } = await supabase
-        .from('public.public_users')
+        .from('public_users')
         .select('id, username, avatar_url, bio')
         .ilike('username', newLinkedUserTag.trim())
         .single();

--- a/src/hooks/useUserProfile.js
+++ b/src/hooks/useUserProfile.js
@@ -37,7 +37,7 @@ export function useUserProfile(session) {
     setLoading(true);
     try {
       const { data: profile, error: profileError } = await supabase
-        .from('public.public_users')
+        .from('public_users')
         .select('id, username, avatar_url, bio')
         .eq('id', session.user.id)
         .single();

--- a/src/hooks/useUserSearch.js
+++ b/src/hooks/useUserSearch.js
@@ -15,7 +15,7 @@ export function useUserSearch(session) {
     setLoading(true);
     try {
       let query = supabase
-        .from('public.public_users')
+        .from('public_users')
         .select('id, username, avatar_url, bio')
         .or(`username.ilike.*${sanitized}*,bio.ilike.*${sanitized}*`)
         .limit(10);


### PR DESCRIPTION
## Summary
- correct references to `public_users` table in supabase queries

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6852d95ddbb4832dbce0e2cc9dc70acb