### PR TITLE
Add friend request acceptance and notification badge

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,8 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { useLocation, useNavigate as useRouterNavigate } from 'react-router-dom';
+import {
+  useLocation,
+  useNavigate as useRouterNavigate,
+} from 'react-router-dom';
 import { Toaster } from '@/components/ui/toaster';
 import Auth from '@/components/Auth';
 import RecipeDetailModal from '@/components/RecipeDetailModal';
@@ -10,13 +13,21 @@ import { useRecipes } from '@/hooks/useRecipes.jsx';
 import { useWeeklyMenu } from '@/hooks/useWeeklyMenu.js';
 import { useSession } from '@/hooks/useSession.js';
 import { useUserProfile } from '@/hooks/useUserProfile.js';
+import { usePendingFriendRequests } from '@/hooks/usePendingFriendRequests.js';
 import AppRoutes from '@/components/AppRoutes.jsx';
 
 function App() {
-  const { session, loading: sessionLoading, refreshSession, handleSignOut } =
-    useSession();
-  const { userProfile, loading: profileLoading, refreshProfile } =
-    useUserProfile(session);
+  const {
+    session,
+    loading: sessionLoading,
+    refreshSession,
+    handleSignOut,
+  } = useSession();
+  const {
+    userProfile,
+    loading: profileLoading,
+    refreshProfile,
+  } = useUserProfile(session);
   const [showAuth, setShowAuth] = useState(false);
   const [activeTab, setActiveTab] = useState('recipes');
   const [showRecipeForm, setShowRecipeForm] = useState(false);
@@ -46,6 +57,9 @@ function App() {
     setWeeklyMenu: saveUserWeeklyMenuHook,
     loading: weeklyMenuLoading,
   } = useWeeklyMenu(session);
+
+  const { pendingCount, refreshPendingFriendRequests } =
+    usePendingFriendRequests(session);
 
   const location = useLocation();
   const routerNavigate = useRouterNavigate();
@@ -110,7 +124,11 @@ function App() {
     await refreshProfile();
   }, [refreshSession, refreshProfile]);
 
-  if (loadingInitialState || session === undefined || userProfile === undefined) {
+  if (
+    loadingInitialState ||
+    session === undefined ||
+    userProfile === undefined
+  ) {
     return <LoadingScreen />;
   }
 
@@ -128,6 +146,7 @@ function App() {
         setShowAuth={setShowAuth}
         toggleDarkMode={toggleDarkMode}
         darkMode={darkMode}
+        pendingRequestCount={pendingCount}
       >
         <AppRoutes
           session={session}
@@ -147,6 +166,7 @@ function App() {
           setEditingRecipe={setEditingRecipe}
           setSelectedRecipeForDetail={setSelectedRecipeForDetail}
           handleProfileUpdated={handleProfileUpdated}
+          refreshPendingFriendRequests={refreshPendingFriendRequests}
         />
       </MainAppLayout>
 

--- a/src/components/AppRoutes.jsx
+++ b/src/components/AppRoutes.jsx
@@ -32,9 +32,14 @@ export default function AppRoutes({
   setEditingRecipe,
   setSelectedRecipeForDetail,
   handleProfileUpdated,
+  refreshPendingFriendRequests,
 }) {
   const recipePageTitle = useMemo(() => {
-    if (userProfile && userProfile.username && userProfile.username !== 'Visiteur') {
+    if (
+      userProfile &&
+      userProfile.username &&
+      userProfile.username !== 'Visiteur'
+    ) {
       return `Recettes de ${userProfile.username}`;
     }
     return 'Mes Recettes';
@@ -45,7 +50,9 @@ export default function AppRoutes({
     return !menu.some(
       (dayMeals) =>
         Array.isArray(dayMeals) &&
-        dayMeals.some((mealRecipes) => Array.isArray(mealRecipes) && mealRecipes.length > 0)
+        dayMeals.some(
+          (mealRecipes) => Array.isArray(mealRecipes) && mealRecipes.length > 0
+        )
     );
   };
 
@@ -90,7 +97,9 @@ export default function AppRoutes({
             {showRecipeForm && (
               <RecipeForm
                 recipe={editingRecipe}
-                onSubmit={editingRecipe ? handleEditRecipeSubmit : handleAddRecipeSubmit}
+                onSubmit={
+                  editingRecipe ? handleEditRecipeSubmit : handleAddRecipeSubmit
+                }
                 onClose={closeRecipeForm}
                 session={session}
                 userProfile={userProfile}
@@ -125,7 +134,11 @@ export default function AppRoutes({
           isMenuDataEmpty(weeklyMenu) ? (
             <LoadingScreen message="Chargement de la liste de courses..." />
           ) : (
-            <ShoppingList weeklyMenu={weeklyMenu} recipes={recipes} userProfile={userProfile} />
+            <ShoppingList
+              weeklyMenu={weeklyMenu}
+              recipes={recipes}
+              userProfile={userProfile}
+            />
           )
         }
       />
@@ -133,7 +146,11 @@ export default function AppRoutes({
         path="/app/community"
         element={
           session ? (
-            <CommunityPage session={session} userProfile={userProfile} />
+            <CommunityPage
+              session={session}
+              userProfile={userProfile}
+              onRequestsChange={refreshPendingFriendRequests}
+            />
           ) : (
             <Navigate to="/app/recipes" replace />
           )
@@ -141,7 +158,13 @@ export default function AppRoutes({
       />
       <Route
         path="/app/profile/:userId"
-        element={<UserProfilePage session={session} currentUserProfile={userProfile} />}
+        element={
+          <UserProfilePage
+            session={session}
+            currentUserProfile={userProfile}
+            onRequestsChange={refreshPendingFriendRequests}
+          />
+        }
       />
       <Route
         path="/app/account"

--- a/src/components/FriendActionButton.jsx
+++ b/src/components/FriendActionButton.jsx
@@ -2,10 +2,24 @@ import React, { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { useToast } from '@/components/ui/use-toast';
 import { supabase } from '@/lib/supabase';
-import { Loader2, UserPlus, UserX, UserCheck, MessageCircle } from 'lucide-react';
+import { acceptFriendRequest } from '@/lib/friends';
+import {
+  Loader2,
+  UserPlus,
+  UserX,
+  UserCheck,
+  MessageCircle,
+} from 'lucide-react';
 import useSessionRequired from '@/hooks/useSessionRequired';
 
-export default function FriendActionButton({ session, profileUserId, initialStatus, relationshipId: initialRelId, onStatusChange }) {
+export default function FriendActionButton({
+  session,
+  profileUserId,
+  initialStatus,
+  relationshipId: initialRelId,
+  onStatusChange,
+  onRequestHandled,
+}) {
   const [status, setStatus] = useState(initialStatus);
   const [relId, setRelId] = useState(initialRelId);
   const [loading, setLoading] = useState(false);
@@ -19,7 +33,9 @@ export default function FriendActionButton({ session, profileUserId, initialStat
 
   React.useEffect(() => {
     const fetchSession = async () => {
-      const { data: { session: fresh } } = await supabase.auth.getSession();
+      const {
+        data: { session: fresh },
+      } = await supabase.auth.getSession();
       setCurrentSession(fresh);
     };
     fetchSession();
@@ -38,29 +54,41 @@ export default function FriendActionButton({ session, profileUserId, initialStat
       if (status === 'not_friends') {
         const { data, error } = await supabase
           .from('user_relationships')
-          .insert({ requester_id: currentSession.user.id, addressee_id: profileUserId, status: 'pending' })
+          .insert({
+            requester_id: currentSession.user.id,
+            addressee_id: profileUserId,
+            status: 'pending',
+          })
           .select()
           .single();
         if (error) throw error;
         updateState('pending_them', data.id);
         toast({ title: 'Demande envoyée' });
+        onRequestHandled && onRequestHandled();
       } else if (status === 'pending_me') {
-        const { error } = await supabase
-          .from('user_relationships')
-          .update({ status: 'accepted', updated_at: new Date().toISOString() })
-          .eq('id', relId);
-        if (error) throw error;
+        await acceptFriendRequest(relId, currentSession.user.id);
         updateState('friends', relId);
         toast({ title: 'Demande acceptée' });
+        onRequestHandled && onRequestHandled();
       } else if (status === 'pending_them' || status === 'friends') {
-        const { error } = await supabase.from('user_relationships').delete().eq('id', relId);
+        const { error } = await supabase
+          .from('user_relationships')
+          .delete()
+          .eq('id', relId);
         if (error) throw error;
         updateState('not_friends', null);
-        toast({ title: status === 'friends' ? 'Ami supprimé' : 'Demande annulée' });
+        toast({
+          title: status === 'friends' ? 'Ami supprimé' : 'Demande annulée',
+        });
+        onRequestHandled && onRequestHandled();
       }
     } catch (err) {
       console.error('Friend action error:', err);
-      toast({ title: 'Erreur', description: err.message, variant: 'destructive' });
+      toast({
+        title: 'Erreur',
+        description: err.message,
+        variant: 'destructive',
+      });
     } finally {
       setLoading(false);
     }
@@ -79,28 +107,44 @@ export default function FriendActionButton({ session, profileUserId, initialStat
     switch (status) {
       case 'friends':
         content = (
-          <Button onClick={handleAction} variant="secondary" className="mt-4 w-40">
+          <Button
+            onClick={handleAction}
+            variant="secondary"
+            className="mt-4 w-40"
+          >
             <UserX className="mr-2 h-4 w-4" /> Retirer l&apos;ami
           </Button>
         );
         break;
       case 'pending_them':
         content = (
-          <Button onClick={handleAction} variant="outline" className="mt-4 w-40">
+          <Button
+            onClick={handleAction}
+            variant="outline"
+            className="mt-4 w-40"
+          >
             <MessageCircle className="mr-2 h-4 w-4" /> Demande envoyée
           </Button>
         );
         break;
       case 'pending_me':
         content = (
-          <Button onClick={handleAction} variant="default" className="mt-4 w-40">
+          <Button
+            onClick={handleAction}
+            variant="default"
+            className="mt-4 w-40"
+          >
             <UserCheck className="mr-2 h-4 w-4" /> Accepter la demande
           </Button>
         );
         break;
       default:
         content = (
-          <Button onClick={handleAction} variant="default" className="mt-4 w-40">
+          <Button
+            onClick={handleAction}
+            variant="default"
+            className="mt-4 w-40"
+          >
             <UserPlus className="mr-2 h-4 w-4" /> Ajouter en ami
           </Button>
         );

--- a/src/components/FriendsTab.jsx
+++ b/src/components/FriendsTab.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { supabase } from '@/lib/supabase';
+import { acceptFriendRequest } from '@/lib/friends';
 import { Button } from '@/components/ui/button';
 import { useToast } from '@/components/ui/use-toast';
 import {
@@ -23,7 +24,7 @@ import {
   DialogClose,
 } from '@/components/ui/dialog.jsx';
 
-export default function FriendsTab({ session, userProfile }) {
+export default function FriendsTab({ session, userProfile, onRequestsChange }) {
   const { toast } = useToast();
   const [friendRequests, setFriendRequests] = useState([]);
   const [friends, setFriends] = useState([]);
@@ -95,12 +96,7 @@ export default function FriendsTab({ session, userProfile }) {
     setActionLoading(true);
     try {
       if (action === 'accept') {
-        const { error } = await supabase
-          .from('user_relationships')
-          .update({ status: 'accepted', updated_at: new Date().toISOString() })
-          .eq('id', relationshipId)
-          .eq('addressee_id', session.user.id);
-        if (error) throw error;
+        await acceptFriendRequest(relationshipId, session.user.id);
         toast({
           title: 'Demande acceptée',
           description: 'Vous êtes maintenant amis !',
@@ -115,6 +111,7 @@ export default function FriendsTab({ session, userProfile }) {
         toast({ title: 'Demande refusée' });
       }
       fetchFriendsAndRequests();
+      onRequestsChange && onRequestsChange();
     } catch (error) {
       toast({
         title: 'Erreur',
@@ -137,6 +134,7 @@ export default function FriendsTab({ session, userProfile }) {
       if (error) throw error;
       toast({ title: 'Ami supprimé' });
       fetchFriendsAndRequests();
+      onRequestsChange && onRequestsChange();
     } catch (error) {
       toast({
         title: 'Erreur',

--- a/src/components/layout/MainAppLayout.jsx
+++ b/src/components/layout/MainAppLayout.jsx
@@ -33,6 +33,7 @@ export default function MainAppLayout({
   setShowAuth,
   toggleDarkMode,
   darkMode,
+  pendingRequestCount = 0,
 }) {
   const location = useLocation();
   const showMainNavigation = !isLegalPage(location.pathname);
@@ -143,7 +144,13 @@ export default function MainAppLayout({
                         : 'text-pastel-text/60 dark:text-pastel-text/70 hover:bg-pastel-muted/70 dark:hover:bg-pastel-muted/30 hover:text-pastel-text dark:hover:text-pastel-text/90 border-b-2 border-transparent'
                     }`}
                 >
-                  <tab.icon className="w-3.5 h-3.5 mr-1.5 hidden sm:inline-block" />
+                  <span className="relative mr-1.5 hidden sm:inline-block">
+                    <tab.icon className="w-3.5 h-3.5" />
+                    {pendingRequestCount > 0 &&
+                      ['community', 'account'].includes(tab.id) && (
+                        <span className="absolute -top-1 -right-1 block w-2 h-2 bg-red-500 rounded-full" />
+                      )}
+                  </span>
                   {tab.label}
                 </Button>
               ))}

--- a/src/hooks/usePendingFriendRequests.js
+++ b/src/hooks/usePendingFriendRequests.js
@@ -1,0 +1,35 @@
+import { useState, useEffect, useCallback } from 'react';
+import { supabase } from '@/lib/supabase';
+
+export function usePendingFriendRequests(session) {
+  const [pendingCount, setPendingCount] = useState(0);
+  const [loading, setLoading] = useState(false);
+
+  const fetchPending = useCallback(async () => {
+    if (!session?.user?.id) {
+      setPendingCount(0);
+      return;
+    }
+    setLoading(true);
+    try {
+      const { count, error } = await supabase
+        .from('user_relationships')
+        .select('id', { count: 'exact', head: true })
+        .eq('addressee_id', session.user.id)
+        .eq('status', 'pending');
+      if (error) throw error;
+      setPendingCount(count || 0);
+    } catch (err) {
+      console.error('Error fetching pending friend requests:', err);
+      setPendingCount(0);
+    } finally {
+      setLoading(false);
+    }
+  }, [session]);
+
+  useEffect(() => {
+    fetchPending();
+  }, [fetchPending]);
+
+  return { pendingCount, refreshPendingFriendRequests: fetchPending, loading };
+}

--- a/src/lib/friends.js
+++ b/src/lib/friends.js
@@ -1,0 +1,12 @@
+import { supabase } from './supabase';
+
+export async function acceptFriendRequest(relationshipId, userId) {
+  const { error } = await supabase
+    .from('user_relationships')
+    .update({ status: 'accepted', updated_at: new Date().toISOString() })
+    .eq('id', relationshipId)
+    .eq('addressee_id', userId)
+    .eq('status', 'pending');
+  if (error) throw error;
+  return true;
+}

--- a/src/pages/CommunityPage.jsx
+++ b/src/pages/CommunityPage.jsx
@@ -13,7 +13,11 @@ import MyPublicProfile from '@/components/MyPublicProfile.jsx';
 import PublicRecipeFeed from '@/components/PublicRecipeFeed.jsx';
 import UserSearch from '@/components/UserSearch.jsx';
 
-export default function CommunityPage({ session, userProfile }) {
+export default function CommunityPage({
+  session,
+  userProfile,
+  onRequestsChange,
+}) {
   const [activeSubTab, setActiveSubTab] = useState('discover');
   const navigate = useNavigate();
 
@@ -27,7 +31,11 @@ export default function CommunityPage({ session, userProfile }) {
 
   return (
     <div className="space-y-8">
-      <Tabs value={activeSubTab} onValueChange={setActiveSubTab} className="w-full">
+      <Tabs
+        value={activeSubTab}
+        onValueChange={setActiveSubTab}
+        className="w-full"
+      >
         <TabsList className="grid w-full grid-cols-3 max-w-lg mx-auto">
           <TabsTrigger value="discover" className="flex items-center gap-2">
             <Compass className="w-4 h-4" /> Découvrir
@@ -35,7 +43,10 @@ export default function CommunityPage({ session, userProfile }) {
           <TabsTrigger value="friends" className="flex items-center gap-2">
             <Users className="w-4 h-4" /> Amis
           </TabsTrigger>
-          <TabsTrigger value="my-profile-preview" className="flex items-center gap-2">
+          <TabsTrigger
+            value="my-profile-preview"
+            className="flex items-center gap-2"
+          >
             <Eye className="w-4 h-4" /> Mon Profil Public
           </TabsTrigger>
         </TabsList>
@@ -47,14 +58,21 @@ export default function CommunityPage({ session, userProfile }) {
               <h2 className="text-xl sm:text-2xl font-bold text-pastel-secondary mb-6 text-center">
                 Dernières Recettes Publiques
               </h2>
-              <PublicRecipeFeed session={session} onSelectRecipe={handleSelectRecipe} />
+              <PublicRecipeFeed
+                session={session}
+                onSelectRecipe={handleSelectRecipe}
+              />
             </div>
           </div>
         </TabsContent>
 
         <TabsContent value="friends" className="mt-6">
           {session && userProfile ? (
-            <FriendsTab session={session} userProfile={userProfile} />
+            <FriendsTab
+              session={session}
+              userProfile={userProfile}
+              onRequestsChange={onRequestsChange}
+            />
           ) : (
             <LoadingScreen message="Chargement des informations utilisateur..." />
           )}

--- a/src/pages/UserProfilePage.jsx
+++ b/src/pages/UserProfilePage.jsx
@@ -10,7 +10,11 @@ import RecipeDetailModal from '@/components/RecipeDetailModal';
 import FriendActionButton from '@/components/FriendActionButton.jsx';
 import { formatRecipe } from '@/lib/formatRecipe';
 
-export default function UserProfilePage({ session, currentUserProfile }) {
+export default function UserProfilePage({
+  session,
+  currentUserProfile,
+  onRequestsChange,
+}) {
   const { userId } = useParams();
   const [profileData, setProfileData] = useState(null);
   const [recipes, setRecipes] = useState([]);
@@ -100,9 +104,7 @@ export default function UserProfilePage({ session, currentUserProfile }) {
         .from('public_users')
         .select('id, username, avatar_url, bio')
         .in('id', userIds);
-      const usersMap = Object.fromEntries(
-        (users || []).map((u) => [u.id, u])
-      );
+      const usersMap = Object.fromEntries((users || []).map((u) => [u.id, u]));
 
       const formattedRecipes = recipeData.map((r) =>
         formatRecipe({ ...r, user: usersMap[r.user_id] ?? null })
@@ -139,7 +141,6 @@ export default function UserProfilePage({ session, currentUserProfile }) {
     }
   }, [location.search, recipes, location.pathname, navigate]);
 
-
   if (loading) {
     return <LoadingScreen message="Chargement du profil..." />;
   }
@@ -164,7 +165,6 @@ export default function UserProfilePage({ session, currentUserProfile }) {
   }
 
   const isOwnProfile = session?.user?.id === userId;
-
 
   return (
     <>
@@ -198,6 +198,7 @@ export default function UserProfilePage({ session, currentUserProfile }) {
                     setRelationshipStatus(s);
                     setRelationshipId(id);
                   }}
+                  onRequestHandled={onRequestsChange}
                 />
               )}
             </div>


### PR DESCRIPTION
## Summary
- add `acceptFriendRequest` helper
- track pending friend requests with new hook
- update `FriendActionButton` to use helper and callback
- update `FriendsTab` to notify parent when requests change
- show pending requests badge in navigation
- use hook in `App` and propagate callbacks

## Testing
- `npm run lint` *(fails: many prop-type errors)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852edff066c832d9e87bce4f060dde4