### PR TITLE
Improve dark mode styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
                    connect-src 'self' https://*.supabase.co wss://*.supabase.co https://bunolnhegwzhxqxymmet.supabase.co;" />
     <title>Mealmapp - Alpha</title>
   </head>
-  <body class="bg-white text-black dark:bg-gray-900 dark:text-white transition-colors duration-300">
+  <body class="transition-colors duration-300">
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>

--- a/src/components/RecipeList.jsx
+++ b/src/components/RecipeList.jsx
@@ -24,7 +24,7 @@ const MemoizedRecipeCard = React.memo(function RecipeCard({
       animate={{ opacity: 1, y: 0, scale: 1 }}
       exit={{ opacity: 0, y: -20, scale: 0.95 }}
       transition={{ duration: 0.3 }}
-      className={`${color.bg} ${color.text} bg-white dark:bg-gray-700 text-black dark:text-white rounded-xl p-5 shadow-pastel-soft hover:shadow-pastel-medium transition-shadow duration-300 ease-in-out flex flex-col h-full cursor-pointer group`}
+      className={`${color.bg} ${color.text} bg-opacity-80 dark:bg-opacity-80 rounded-xl p-5 shadow-pastel-soft hover:shadow-pastel-medium transition-shadow duration-300 ease-in-out flex flex-col h-full cursor-pointer group`}
       onClick={handleCardClick}
     >
       {recipe.image_url && (

--- a/src/index.css
+++ b/src/index.css
@@ -91,10 +91,10 @@
   }
 
   .dark {
-    --background: 230 10% 18%;
+    --background: 0 0% 7%;
     --foreground: 230 20% 88%;
-    --card: 230 10% 22%;
-    --card-foreground: 230 20% 88%;
+    --card: 0 0% 12%;
+    --card-foreground: 0 0% 88%;
     --popover: 230 10% 22%;
     --popover-foreground: 230 20% 88%;
     --primary: 255 45% 62%;

--- a/src/lib/colors.js
+++ b/src/lib/colors.js
@@ -45,43 +45,43 @@ export const MEAL_BLOCK_OPACITY = {
 
 export const RECIPE_CARD_COLORS_CLASSES = [
   {
-    bg: 'bg-pastel-day-lundi',
+    bg: 'bg-pastel-day-lundi/80',
     text: 'text-pastel-day-text',
     border: 'border-pastel-day-lundi/50',
     hover: 'hover:bg-pastel-day-lundi/90',
   },
   {
-    bg: 'bg-pastel-day-mardi',
+    bg: 'bg-pastel-day-mardi/80',
     text: 'text-pastel-day-text',
     border: 'border-pastel-day-mardi/50',
     hover: 'hover:bg-pastel-day-mardi/90',
   },
   {
-    bg: 'bg-pastel-day-mercredi',
+    bg: 'bg-pastel-day-mercredi/80',
     text: 'text-pastel-day-text',
     border: 'border-pastel-day-mercredi/50',
     hover: 'hover:bg-pastel-day-mercredi/90',
   },
   {
-    bg: 'bg-pastel-day-jeudi',
+    bg: 'bg-pastel-day-jeudi/80',
     text: 'text-pastel-day-text',
     border: 'border-pastel-day-jeudi/50',
     hover: 'hover:bg-pastel-day-jeudi/90',
   },
   {
-    bg: 'bg-pastel-day-vendredi',
+    bg: 'bg-pastel-day-vendredi/80',
     text: 'text-pastel-day-text',
     border: 'border-pastel-day-vendredi/50',
     hover: 'hover:bg-pastel-day-vendredi/90',
   },
   {
-    bg: 'bg-pastel-day-samedi',
+    bg: 'bg-pastel-day-samedi/80',
     text: 'text-pastel-day-text',
     border: 'border-pastel-day-samedi/50',
     hover: 'hover:bg-pastel-day-samedi/90',
   },
   {
-    bg: 'bg-pastel-day-dimanche',
+    bg: 'bg-pastel-day-dimanche/80',
     text: 'text-pastel-day-text',
     border: 'border-pastel-day-dimanche/50',
     hover: 'hover:bg-pastel-day-dimanche/90',


### PR DESCRIPTION
## Summary
- tweak global body class to rely on Tailwind CSS variables
- adjust dark color palette for darker background and cards
- show recipe cards with original pastel colors in both themes

## Testing
- `npm run lint` *(fails: react prop-types and other errors)*
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6852f4966a84832d9a0306212aef6c57