### PR TITLE
Improve friend request management

### DIFF
--- a/src/components/FriendActionButton.jsx
+++ b/src/components/FriendActionButton.jsx
@@ -118,12 +118,8 @@ export default function FriendActionButton({
         break;
       case 'pending_them':
         content = (
-          <Button
-            onClick={handleAction}
-            variant="outline"
-            className="mt-4 w-40"
-          >
-            <MessageCircle className="mr-2 h-4 w-4" /> Demande envoyée
+          <Button variant="outline" className="mt-4 w-40" disabled>
+            <MessageCircle className="mr-2 h-4 w-4" /> Demande en attente
           </Button>
         );
         break;


### PR DESCRIPTION
## Summary
- show incoming and outgoing requests inside Friends tab
- disable button after sending a request to avoid duplicates

## Testing
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6852f36308d0832db1198e188d440b93