### PR TITLE
Fix dark nav color

### DIFF
--- a/src/components/layout/MainAppLayout.jsx
+++ b/src/components/layout/MainAppLayout.jsx
@@ -93,7 +93,7 @@ export default function MainAppLayout({
             </div>
           </div>
           {showMainNavigation && (
-            <nav className="flex space-x-1 sm:space-x-2 mt-5 overflow-x-auto pb-1 -mb-px transition-colors duration-300 bg-white text-black dark:bg-[#121212] dark:text-white">
+            <nav className="flex space-x-1 sm:space-x-2 mt-5 overflow-x-auto pb-1 -mb-px transition-colors duration-300 bg-white text-black dark:bg-[#1e1e1e] dark:text-white">
               {[
                 {
                   id: 'recipes',


### PR DESCRIPTION
## Summary
- make navigation bar share the same dark background as the header

## Testing
- `npm test`
- `npm run lint` *(fails: many prop-type errors)*

------
https://chatgpt.com/codex/tasks/task_e_685302a08f74832dbbd1222c65d27cd1