### PR TITLE
Check OpenAI key before usage

### DIFF
--- a/src/components/RecipeForm.jsx
+++ b/src/components/RecipeForm.jsx
@@ -14,7 +14,7 @@ import RecipeCoreFields from '@/components/form/RecipeCoreFields';
 import RecipeIngredientsManager from '@/components/form/RecipeIngredientsManager';
 import RecipeInstructionsManager from '@/components/form/RecipeInstructionsManager';
 import RecipeMetaFields from '@/components/form/RecipeMetaFields';
-import { estimateRecipePrice } from '@/lib/openai';
+import { estimateRecipePrice, openaiIsAvailable } from '@/lib/openai';
 import {
   Select,
   SelectContent,
@@ -661,6 +661,12 @@ function RecipeForm({
               </Button>
             </div>
           </form>
+
+          {!openaiIsAvailable && (
+            <p className="mt-2 text-red-500">
+              Estimation automatique désactivée (clé manquante).
+            </p>
+          )}
 
           {showTagManager && (
             <TagManager

--- a/src/lib/openai.js
+++ b/src/lib/openai.js
@@ -1,11 +1,26 @@
 import OpenAI from 'openai';
 
-const openai = new OpenAI({
-  apiKey: process.env.VITE_OPENAI_API_KEY,
-  dangerouslyAllowBrowser: true,
-});
+const apiKey =
+  (typeof import.meta !== 'undefined' && import.meta.env?.VITE_OPENAI_API_KEY) ||
+  process.env.VITE_OPENAI_API_KEY;
+
+export const openaiIsAvailable = !!apiKey;
+
+let openai = null;
+if (openaiIsAvailable) {
+  openai = new OpenAI({
+    apiKey,
+    dangerouslyAllowBrowser: true,
+  });
+} else {
+  console.warn('⚠️ Pas de clé OpenAI disponible côté client');
+}
 
 export const generateRecipeDescription = async (recipe) => {
+  if (!openaiIsAvailable) {
+    console.warn('⚠️ Pas de clé OpenAI disponible côté client');
+    return null;
+  }
   try {
     const prompt = `Génère une description détaillée et attrayante pour la recette suivante:
     Nom: ${recipe.name}
@@ -38,6 +53,10 @@ export const generateRecipeDescription = async (recipe) => {
 };
 
 export const generateRecipeImage = async (recipe) => {
+  if (!openaiIsAvailable) {
+    console.warn('⚠️ Pas de clé OpenAI disponible côté client');
+    return null;
+  }
   try {
     const prompt = `Une photo appétissante de ${recipe.name}, style photographie culinaire professionnelle`;
 
@@ -58,6 +77,10 @@ export const generateRecipeImage = async (recipe) => {
 };
 
 export const estimateRecipePrice = async (recipe) => {
+  if (!openaiIsAvailable) {
+    console.warn('⚠️ Pas de clé OpenAI disponible côté client');
+    return null;
+  }
   try {
     const ingredientList = recipe.ingredients
       .map((i) => `${i.quantity} ${i.unit} ${i.name}`)


### PR DESCRIPTION
## Summary
- guard client initialization with a key check
- export `openaiIsAvailable` flag
- skip calls and show a warning when no key is provided
- display a notice in `RecipeForm` when automatic estimation is disabled

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853d39d3be0832db2d5503ac8d9bced