### PR TITLE
Use API endpoint for recipe cost

### DIFF
--- a/src/components/RecipeForm.jsx
+++ b/src/components/RecipeForm.jsx
@@ -14,7 +14,7 @@ import RecipeCoreFields from '@/components/form/RecipeCoreFields';
 import RecipeIngredientsManager from '@/components/form/RecipeIngredientsManager';
 import RecipeInstructionsManager from '@/components/form/RecipeInstructionsManager';
 import RecipeMetaFields from '@/components/form/RecipeMetaFields';
-import { estimateRecipePrice, openaiIsAvailable } from '@/lib/openai';
+import { estimateRecipePrice } from '@/lib/openai';
 import {
   Select,
   SelectContent,
@@ -662,11 +662,6 @@ function RecipeForm({
             </div>
           </form>
 
-          {!openaiIsAvailable && (
-            <p className="mt-2 text-red-500">
-              Estimation automatique désactivée (clé manquante).
-            </p>
-          )}
 
           {showTagManager && (
             <TagManager

--- a/src/lib/openai.js
+++ b/src/lib/openai.js
@@ -77,32 +77,20 @@ export const generateRecipeImage = async (recipe) => {
 };
 
 export const estimateRecipePrice = async (recipe) => {
-  if (!openaiIsAvailable) {
-    console.warn('⚠️ Pas de clé OpenAI disponible côté client');
-    return null;
-  }
   try {
-    const ingredientList = recipe.ingredients
-      .map((i) => `${i.quantity} ${i.unit} ${i.name}`)
-      .join(', ');
-    const prompt = `Estime en euros le coût total des ingrédients pour la recette suivante : ${recipe.name}. Ingrédients : ${ingredientList}. Réponds uniquement par un nombre.`;
-
-    const completion = await openai.chat.completions.create({
-      model: 'gpt-3.5-turbo',
-      messages: [
-        {
-          role: 'system',
-          content:
-            "Tu es un assistant qui estime le prix total des ingrédients d'une recette en euros. Répond uniquement par un nombre.",
-        },
-        { role: 'user', content: prompt },
-      ],
-      max_tokens: 10,
+    const response = await fetch('/api/estimate-cost', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        ingredients: recipe.ingredients,
+        servings: recipe.servings,
+      }),
     });
 
-    const raw = completion.choices[0].message.content;
-    const numeric = parseFloat(raw.replace(/[^0-9.,]/g, '').replace(',', '.'));
-    return isNaN(numeric) ? null : numeric;
+    if (!response.ok) throw new Error('Request failed');
+
+    const data = await response.json();
+    return data.estimated_price ?? null;
   } catch (error) {
     console.error("Erreur lors de l'estimation du prix:", error);
     return null;


### PR DESCRIPTION
## Summary
- call `/api/estimate-cost` endpoint from `estimateRecipePrice`
- remove unused OpenAI availability checks

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6853d91e2184832d8e99909bec3a6166