### PR TITLE
Add estimated price estimation and display

### DIFF
--- a/src/components/RecipeDetailModal.jsx
+++ b/src/components/RecipeDetailModal.jsx
@@ -86,6 +86,11 @@ function RecipeDetailModal({ recipe, onClose, userProfile }) {
                 <p className="text-pastel-text leading-relaxed">
                   {recipe.description}
                 </p>
+                {recipe.estimated_price !== undefined && (
+                  <p className="text-sm text-gray-500 mt-2">
+                    💰 Estimé : {recipe.estimated_price.toFixed(2)} €
+                  </p>
+                )}
               </div>
             )}
 

--- a/src/components/RecipeForm.jsx
+++ b/src/components/RecipeForm.jsx
@@ -372,6 +372,11 @@ function RecipeForm({
       return;
     }
 
+    const estimated = await estimateRecipePrice({
+      ingredients: formData.ingredients.filter((ing) => ing.name.trim() !== ''),
+      servings: parseInt(formData.servings, 10) || 1,
+    });
+
     let finalImageUrl = formData.image_url;
     if (selectedFile) {
       const uploadedUrl = await uploadImage();
@@ -399,14 +404,8 @@ function RecipeForm({
         ? formData.instructions.filter((line) => line.trim() !== '')
         : [],
       visibility: formData.visibility,
+      estimated_price: estimated !== null ? estimated : undefined,
     };
-
-    if (!recipeDataToSubmit.estimated_price) {
-      const estimated = await estimateRecipePrice(recipeDataToSubmit);
-      if (estimated !== null) {
-        recipeDataToSubmit.estimated_price = estimated;
-      }
-    }
 
     const success = await onSubmit(recipeDataToSubmit);
     if (success) {

--- a/src/components/RecipeList.jsx
+++ b/src/components/RecipeList.jsx
@@ -119,6 +119,11 @@ const MemoizedRecipeCard = React.memo(function RecipeCard({
             {recipe.calories || 'N/A'} calories
           </span>
         </div>
+        {recipe.estimated_price !== undefined && (
+          <div className="text-xs text-gray-500 mt-1">
+            💰 Estimé : {recipe.estimated_price.toFixed(2)} €
+          </div>
+        )}
       </div>
     </motion.div>
   );


### PR DESCRIPTION
## Summary
- estimate recipe price during form submission and include in payload
- show estimated price in recipe detail modal
- show estimated price on recipe cards

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853db4c79cc832db2e9ec18e3388b92