### PR TITLE
Fix price display when recipe has no cost

### DIFF
--- a/src/components/RecipeDetailModal.jsx
+++ b/src/components/RecipeDetailModal.jsx
@@ -86,10 +86,12 @@ function RecipeDetailModal({ recipe, onClose, userProfile }) {
                 <p className="text-pastel-text leading-relaxed">
                   {recipe.description}
                 </p>
-                {recipe.estimated_price !== undefined && (
+                {typeof recipe.estimated_price === 'number' ? (
                   <p className="text-sm text-gray-500 mt-2">
                     💰 Estimé : {recipe.estimated_price.toFixed(2)} €
                   </p>
+                ) : (
+                  <p className="text-sm text-gray-400 mt-2">💰 Estimation indisponible</p>
                 )}
               </div>
             )}

--- a/src/components/RecipeList.jsx
+++ b/src/components/RecipeList.jsx
@@ -119,10 +119,12 @@ const MemoizedRecipeCard = React.memo(function RecipeCard({
             {recipe.calories || 'N/A'} calories
           </span>
         </div>
-        {recipe.estimated_price !== undefined && (
+        {typeof recipe.estimated_price === 'number' ? (
           <div className="text-xs text-gray-500 mt-1">
             💰 Estimé : {recipe.estimated_price.toFixed(2)} €
           </div>
+        ) : (
+          <p className="text-xs text-gray-400 mt-1">💰 Estimation indisponible</p>
         )}
       </div>
     </motion.div>


### PR DESCRIPTION
## Summary
- handle missing `estimated_price` in `RecipeList` and `RecipeDetailModal`

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6853dcf86e64832d8c6a9f4fb9cff17e