### PR TITLE
Fix cost estimation API call

### DIFF
--- a/src/api/estimate-cost.ts
+++ b/src/api/estimate-cost.ts
@@ -1,0 +1,35 @@
+import OpenAI from 'openai';
+
+const openai = new OpenAI({
+  apiKey: process.env.OPENAI_API_KEY,
+});
+
+export async function generateRecipeCostEstimation(recipe: { ingredients: any[]; servings?: number }) {
+  const { ingredients, servings = 4 } = recipe || {};
+
+  if (!Array.isArray(ingredients)) {
+    throw new Error('Ingrédients manquants ou invalides');
+  }
+
+  const formattedIngredients = ingredients
+    .map((ing: any) => `- ${ing.quantity} ${ing.unit} ${ing.name}`)
+    .join('\n');
+
+  const prompt = `
+Estime le coût total approximatif de cette recette pour ${servings} personnes :
+${formattedIngredients}
+Donne seulement le prix estimé, en euros, arrondi à 0,10€. Sans texte autour.
+`;
+
+  const completion = await openai.chat.completions.create({
+    model: 'gpt-4',
+    messages: [{ role: 'user', content: prompt }],
+    temperature: 0.2,
+  });
+
+  const response = completion.choices[0].message.content;
+  const parsed = parseFloat(response?.replace(/[^\d.,]/g, '').replace(',', '.'));
+  const estimatedPrice = isNaN(parsed) ? null : Number(parsed.toFixed(2));
+
+  return estimatedPrice;
+}

--- a/src/lib/openai.js
+++ b/src/lib/openai.js
@@ -81,10 +81,7 @@ export const estimateRecipePrice = async (recipe) => {
     const response = await fetch('/api/estimate-cost', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        ingredients: recipe.ingredients,
-        servings: recipe.servings,
-      }),
+      body: JSON.stringify({ recipe }),
     });
 
     if (!response.ok) throw new Error('Request failed');

--- a/src/pages/api/estimate-cost.ts
+++ b/src/pages/api/estimate-cost.ts
@@ -1,46 +1,25 @@
-import { NextApiRequest, NextApiResponse } from "next";
-import OpenAI from "openai";
+import { NextApiRequest, NextApiResponse } from 'next';
+import { generateRecipeCostEstimation } from '@/api/estimate-cost';
 
-const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY, // 👈 sécurisée (non exposée au client)
-});
-
-export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  if (req.method !== "POST") {
-    return res.status(405).json({ error: "Méthode non autorisée" });
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Méthode non autorisée' });
   }
 
-  const { ingredients, servings } = req.body;
+  const { recipe } = req.body;
 
-  if (!ingredients || !Array.isArray(ingredients)) {
-    return res.status(400).json({ error: "Ingrédients manquants ou invalides" });
+  if (!recipe || !Array.isArray(recipe.ingredients)) {
+    return res.status(400).json({ error: 'Recette invalide' });
   }
-
-  const formattedIngredients = ingredients
-    .map((ing: any) => `- ${ing.quantity} ${ing.unit} ${ing.name}`)
-    .join("\n");
-
-  const prompt = `
-Estime le coût total approximatif de cette recette pour ${servings || 4} personnes :
-${formattedIngredients}
-Donne seulement le prix estimé, en euros, arrondi à 0,10€. Sans texte autour.
-`;
 
   try {
-    const completion = await openai.chat.completions.create({
-      model: "gpt-4",
-      messages: [{ role: "user", content: prompt }],
-      temperature: 0.2,
-    });
-
-    const response = completion.choices[0].message.content;
-    const parsed = parseFloat(response?.replace(/[^\d.,]/g, "").replace(",", "."));
-
-    const estimatedPrice = isNaN(parsed) ? null : Number(parsed.toFixed(2));
-
+    const estimatedPrice = await generateRecipeCostEstimation(recipe);
     res.status(200).json({ estimated_price: estimatedPrice });
   } catch (error) {
-    console.error("Erreur OpenAI", error);
+    console.error('Erreur OpenAI', error);
     res.status(500).json({ error: "Erreur lors de l'estimation" });
   }
 }


### PR DESCRIPTION
## Summary
- centralize recipe cost estimation logic in `src/api/estimate-cost.ts`
- refactor API route to use the new helper and expect a `recipe` object
- adjust client-side `estimateRecipePrice` fetch body

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853e34cd44c832da4596410c2dfb528