### PR TITLE
Add log when calling recipe estimation API

### DIFF
--- a/src/pages/api/estimate-cost.ts
+++ b/src/pages/api/estimate-cost.ts
@@ -4,6 +4,7 @@ import OpenAI from 'openai';
 const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  console.log("[API] Estimation OpenAI déclenchée");
   if (req.method !== 'POST') return res.status(405).end();
 
   const recipe = req.body.recipe;


### PR DESCRIPTION
## Summary
- log OpenAI estimation trigger in `estimate-cost.ts`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6853e7ac1bf4832d8e332af94815e2d3