### PR TITLE
Fix estimate-cost module type

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["api/**/*", "pages/**/*", "src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- ensure TypeScript API routes compile as ES modules by adding `tsconfig.json`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854049d099c832da79dfb193101daf8