### PR TITLE
Fix CORS preflight handling

### DIFF
--- a/pages/api/estimate-cost.ts
+++ b/pages/api/estimate-cost.ts
@@ -2,6 +2,14 @@ import { NextApiRequest, NextApiResponse } from 'next';
 import OpenAI from 'openai';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+
+  if (req.method === 'OPTIONS') {
+    return res.status(200).end();
+  }
+
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' });
   }


### PR DESCRIPTION
## Summary
- add `Access-Control-Allow-*` headers
- handle OPTIONS requests for `/api/estimate-cost`

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_68541ff1d1c4832d9f0853e86a42130d