### PR TITLE
Fix price estimate parsing

### DIFF
--- a/src/lib/openai.js
+++ b/src/lib/openai.js
@@ -86,8 +86,10 @@ export const estimateRecipePrice = async (recipe) => {
 
     if (!response.ok) throw new Error('Request failed');
 
-    const data = await response.json();
-    return data.estimated_price ?? null;
+    const { price } = await response.json();
+    const value = parseFloat(price);
+    console.log('Price estimate:', value);
+    return isNaN(value) ? null : value;
   } catch (error) {
     console.error("Erreur lors de l'estimation du prix:", error);
     return null;


### PR DESCRIPTION
## Summary
- parse the price returned from `/api/estimate-cost`
- log and return the parsed float

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854243b0bbc832d971519cb26fec961