### PR TITLE
Parse price number

### DIFF
--- a/api/estimate-cost.ts
+++ b/api/estimate-cost.ts
@@ -25,7 +25,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       ],
     });
 
-    const price = response.choices[0].message.content;
+    const priceText = response.choices[0].message.content;
+    const price = parseFloat(priceText.replace(/[^0-9.]/g, ''));
     return res.status(200).json({ price });
   } catch (err) {
     console.error('Erreur estimation coût :', err);

--- a/pages/api/estimate-cost.ts
+++ b/pages/api/estimate-cost.ts
@@ -33,7 +33,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       ],
     });
 
-    const price = response.choices[0].message.content;
+    const priceText = response.choices[0].message.content;
+    const price = parseFloat(priceText.replace(/[^0-9.]/g, ''));
     return res.status(200).json({ price });
   } catch (err) {
     console.error('Erreur estimation coût :', err);

--- a/src/lib/openai.js
+++ b/src/lib/openai.js
@@ -87,7 +87,7 @@ export const estimateRecipePrice = async (recipe) => {
     if (!response.ok) throw new Error('Request failed');
 
     const data = await response.json();
-    return data.estimated_price ?? null;
+    return typeof data.price === 'number' ? data.price : null;
   } catch (error) {
     console.error("Erreur lors de l'estimation du prix:", error);
     return null;


### PR DESCRIPTION
## Summary
- return price from both api endpoints as numbers
- adjust OpenAI helper to use the numeric price

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685424448700832d893e71c902c31566