### PR TITLE
Parse OpenAI price response

### DIFF
--- a/api/estimate-cost.ts
+++ b/api/estimate-cost.ts
@@ -25,7 +25,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       ],
     });
 
-    const price = response.choices[0].message.content;
+    const priceText = response.choices[0].message.content;
+    const price = parseFloat(priceText.replace(/[^0-9.]/g, ''));
     return res.status(200).json({ price });
   } catch (err) {
     console.error('Erreur estimation coût :', err);

--- a/pages/api/estimate-cost.ts
+++ b/pages/api/estimate-cost.ts
@@ -33,7 +33,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       ],
     });
 
-    const price = response.choices[0].message.content;
+    const priceText = response.choices[0].message.content;
+    const price = parseFloat(priceText.replace(/[^0-9.]/g, ''));
     return res.status(200).json({ price });
   } catch (err) {
     console.error('Erreur estimation coût :', err);


### PR DESCRIPTION
## Summary
- parse OpenAI response text into a numeric price in both serverless API handlers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68542a265b80832d8753b1f1a1beba18