### PR TITLE
Update price estimate prompt

### DIFF
--- a/api/estimate-cost.ts
+++ b/api/estimate-cost.ts
@@ -15,18 +15,25 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
     const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
+    const ingredientsList = Array.isArray(recipe.ingredients)
+      ? recipe.ingredients
+          .map((ing) => `${ing.quantity} ${ing.unit || ''} ${ing.name}`.trim())
+          .join(', ')
+      : '';
+
     const response = await openai.chat.completions.create({
       model: 'gpt-3.5-turbo',
       messages: [
         {
           role: 'user',
-          content: `Estime le prix de cette recette pour ${recipe.servings} personnes : ${JSON.stringify(recipe.ingredients)}. Donne uniquement le prix en euros.`,
+          content: `Estime le coût total pour préparer cette recette destinée à ${recipe.servings} personnes. Ingrédients : ${ingredientsList}. Réponds uniquement par le montant arrondi à deux décimales (ex: 4.80) sans unité ni texte.`,
         },
       ],
     });
 
-    const priceText = response.choices[0].message.content;
-    const price = parseFloat(priceText.replace(/[^0-9.]/g, ''));
+    const priceText = response.choices[0].message.content || '';
+    const normalized = priceText.replace(',', '.').replace(/[^0-9.]/g, '');
+    const price = parseFloat(normalized);
     return res.status(200).json({ price });
   } catch (err) {
     console.error('Erreur estimation coût :', err);

--- a/src/lib/openai.js
+++ b/src/lib/openai.js
@@ -87,7 +87,8 @@ export const estimateRecipePrice = async (recipe) => {
     if (!response.ok) throw new Error('Request failed');
 
     const { price } = await response.json();
-    const value = parseFloat(price);
+    const normalized = String(price).replace(',', '.');
+    const value = parseFloat(normalized);
     console.log('Price estimate:', value);
     return isNaN(value) ? null : value;
   } catch (error) {

--- a/src/pages/api/estimate-cost.ts
+++ b/src/pages/api/estimate-cost.ts
@@ -15,17 +15,25 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
+    const ingredientsList = Array.isArray(recipe.ingredients)
+      ? recipe.ingredients
+          .map((ing) => `${ing.quantity} ${ing.unit || ''} ${ing.name}`.trim())
+          .join(', ')
+      : '';
+
     const response = await openai.chat.completions.create({
       model: 'gpt-3.5-turbo',
       messages: [
         {
           role: 'user',
-          content: `Estime le prix de cette recette pour ${recipe.servings} personnes : ${JSON.stringify(recipe.ingredients)}. Donne uniquement le prix en euros.`,
+          content: `Estime le coût total pour préparer cette recette destinée à ${recipe.servings} personnes. Ingrédients : ${ingredientsList}. Réponds uniquement par le montant arrondi à deux décimales (ex: 4.80) sans unité ni texte.`,
         },
       ],
     });
 
-    const price = response.choices[0].message.content;
+    const priceText = response.choices[0].message.content || '';
+    const normalized = priceText.replace(',', '.').replace(/[^0-9.]/g, '');
+    const price = parseFloat(normalized);
     return res.status(200).json({ price });
   } catch (err) {
     console.error('Erreur estimation coût :', err);


### PR DESCRIPTION
## Summary
- generate ingredient list in plain text for API calls
- revise prompt to estimate total cost of base servings only
- normalize decimal parsing in estimate response

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68553d3c7b90832db90b6d68b94b451a