### PR TITLE
Update cost estimation prompt and price display

### DIFF
--- a/api/estimate-cost.ts
+++ b/api/estimate-cost.ts
@@ -17,8 +17,11 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
     const ingredientsList = Array.isArray(recipe.ingredients)
       ? recipe.ingredients
-          .map((ing) => `${ing.quantity} ${ing.unit || ''} ${ing.name}`.trim())
-          .join(', ')
+          .map(
+            (ing) =>
+              `- ${ing.quantity} ${ing.unit ? ing.unit + ' ' : ''}${ing.name}`.trim()
+          )
+          .join('\n')
       : '';
 
     const response = await openai.chat.completions.create({
@@ -26,7 +29,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       messages: [
         {
           role: 'user',
-          content: `Estime le coût total pour préparer cette recette destinée à ${recipe.servings} personnes. Ingrédients : ${ingredientsList}. Réponds uniquement par le montant arrondi à deux décimales (ex: 4.80) sans unité ni texte.`,
+          content: `Tu es un assistant culinaire. Estime le coût total d'une recette pour les quantités ci-dessous. Donne uniquement le prix en euros, sans explication ni unité. Par exemple : "4.70".\n\nRecette : ${recipe.name}\nNombre de portions : ${recipe.servings}\n\nIngrédients :\n${ingredientsList}`,
         },
       ],
     });

--- a/pages/api/estimate-cost.ts
+++ b/pages/api/estimate-cost.ts
@@ -25,8 +25,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     const ingredientsList = Array.isArray(recipe.ingredients)
       ? recipe.ingredients
-          .map((ing) => `${ing.quantity} ${ing.unit || ''} ${ing.name}`.trim())
-          .join(', ')
+          .map(
+            (ing) =>
+              `- ${ing.quantity} ${ing.unit ? ing.unit + ' ' : ''}${ing.name}`.trim()
+          )
+          .join('\n')
       : '';
 
     const response = await openai.chat.completions.create({
@@ -34,7 +37,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       messages: [
         {
           role: 'user',
-          content: `Estime le coût total pour préparer cette recette destinée à ${recipe.servings} personnes. Ingrédients : ${ingredientsList}. Réponds uniquement par le montant arrondi à deux décimales (ex: 4.80) sans unité ni texte.`,
+          content: `Tu es un assistant culinaire. Estime le coût total d'une recette pour les quantités ci-dessous. Donne uniquement le prix en euros, sans explication ni unité. Par exemple : "4.70".\n\nRecette : ${recipe.name}\nNombre de portions : ${recipe.servings}\n\nIngrédients :\n${ingredientsList}`,
         },
       ],
     });

--- a/src/components/DailyMenu.jsx
+++ b/src/components/DailyMenu.jsx
@@ -145,6 +145,22 @@ const MemoizedDailyMenu = React.memo(function DailyMenu({
                             }
                           />
                         </div>
+                        {typeof recipe.estimated_price === 'number' && (
+                          <p className="text-xs text-pastel-text/70 mt-0.5">
+                            {
+                              (() => {
+                                const base =
+                                  recipe.servings && recipe.servings > 0
+                                    ? recipe.servings
+                                    : 1;
+                                const pricePerPortion =
+                                  recipe.estimated_price / base;
+                                const adjusted = pricePerPortion * plannedServings;
+                                return `💰 Estimé : ${adjusted.toFixed(2)} €`;
+                              })()
+                            }
+                          </p>
+                        )}
                         {recipeIndex < safeMealRecipes.length - 1 && (
                           <hr className="border-pastel-border/10 dark:border-gray-600 my-1.5" />
                         )}

--- a/src/components/RecipeDetailModal.jsx
+++ b/src/components/RecipeDetailModal.jsx
@@ -88,7 +88,15 @@ function RecipeDetailModal({ recipe, onClose, userProfile }) {
                 </p>
                 {typeof recipe.estimated_price === 'number' ? (
                   <p className="text-sm text-gray-500 mt-2">
-                    💰 Estimé : {recipe.estimated_price.toFixed(2)} €
+                    {
+                      (() => {
+                        const base = recipe.servings && recipe.servings > 0 ? recipe.servings : 1;
+                        const planned = recipe.plannedServings || base;
+                        const pricePerPortion = recipe.estimated_price / base;
+                        const adjusted = pricePerPortion * planned;
+                        return `💰 Estimé : ${adjusted.toFixed(2)} €`;
+                      })()
+                    }
                   </p>
                 ) : (
                   <p className="text-sm text-gray-400 mt-2">💰 Estimation indisponible</p>

--- a/src/components/RecipeList.jsx
+++ b/src/components/RecipeList.jsx
@@ -121,7 +121,15 @@ const MemoizedRecipeCard = React.memo(function RecipeCard({
         </div>
         {typeof recipe.estimated_price === 'number' ? (
           <div className="text-xs text-gray-500 mt-1">
-            💰 Estimé : {recipe.estimated_price.toFixed(2)} €
+            {
+              (() => {
+                const base = recipe.servings && recipe.servings > 0 ? recipe.servings : 1;
+                const planned = recipe.plannedServings || base;
+                const pricePerPortion = recipe.estimated_price / base;
+                const adjusted = pricePerPortion * planned;
+                return `💰 Estimé : ${adjusted.toFixed(2)} €`;
+              })()
+            }
           </div>
         ) : (
           <p className="text-xs text-gray-400 mt-1">💰 Estimation indisponible</p>

--- a/src/pages/api/estimate-cost.ts
+++ b/src/pages/api/estimate-cost.ts
@@ -17,8 +17,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     const ingredientsList = Array.isArray(recipe.ingredients)
       ? recipe.ingredients
-          .map((ing) => `${ing.quantity} ${ing.unit || ''} ${ing.name}`.trim())
-          .join(', ')
+          .map(
+            (ing) =>
+              `- ${ing.quantity} ${ing.unit ? ing.unit + ' ' : ''}${ing.name}`.trim()
+          )
+          .join('\n')
       : '';
 
     const response = await openai.chat.completions.create({
@@ -26,7 +29,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       messages: [
         {
           role: 'user',
-          content: `Estime le coût total pour préparer cette recette destinée à ${recipe.servings} personnes. Ingrédients : ${ingredientsList}. Réponds uniquement par le montant arrondi à deux décimales (ex: 4.80) sans unité ni texte.`,
+          content: `Tu es un assistant culinaire. Estime le coût total d'une recette pour les quantités ci-dessous. Donne uniquement le prix en euros, sans explication ni unité. Par exemple : "4.70".\n\nRecette : ${recipe.name}\nNombre de portions : ${recipe.servings}\n\nIngrédients :\n${ingredientsList}`,
         },
       ],
     });


### PR DESCRIPTION
## Summary
- refine API prompt for cost estimation
- adjust price display for recipes and daily menu

## Testing
- `npm test`
- `npm run lint` *(fails: many pre-existing errors)*

------
https://chatgpt.com/codex/tasks/task_e_68553fcdc4a4832d9201e7a00c2e9c3c