### PR TITLE
Update recipe price estimation logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,9 @@ Execute the following command to run the Vitest suite:
 ```bash
 npm run test
 ```
+
+## Price estimation
+
+Recipe prices are estimated with OpenAI only when required. A new estimate is
+requested when a recipe is created or when its ingredients or base servings
+change during editing. Existing estimates are reused otherwise.


### PR DESCRIPTION
## Summary
- compute price estimates only when creating recipes or when ingredients/servings change
- document selective price estimation behavior in README

## Testing
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6855461d334c832db14973fc1f659188