### PR TITLE
Improve budget handling in menu planner

### DIFF
--- a/src/components/RecipeList.jsx
+++ b/src/components/RecipeList.jsx
@@ -119,21 +119,6 @@ const MemoizedRecipeCard = React.memo(function RecipeCard({
             {recipe.calories || 'N/A'} calories
           </span>
         </div>
-        {typeof recipe.estimated_price === 'number' ? (
-          <div className="text-xs text-gray-500 mt-1">
-            {
-              (() => {
-                const base = recipe.servings && recipe.servings > 0 ? recipe.servings : 1;
-                const planned = recipe.plannedServings || base;
-                const pricePerPortion = recipe.estimated_price / base;
-                const adjusted = pricePerPortion * planned;
-                return `💰 Estimé : ${adjusted.toFixed(2)} €`;
-              })()
-            }
-          </div>
-        ) : (
-          <p className="text-xs text-gray-400 mt-1">💰 Estimation indisponible</p>
-        )}
       </div>
     </motion.div>
   );

--- a/src/components/menu_planner/WeeklyMenuView.jsx
+++ b/src/components/menu_planner/WeeklyMenuView.jsx
@@ -137,7 +137,9 @@ function WeeklyMenuView({
   );
 
   const weeklyBudget =
-    userProfile?.preferences?.weeklyBudget ?? preferences.weeklyBudget ?? 0;
+    preferences.weeklyBudget !== undefined
+      ? preferences.weeklyBudget
+      : userProfile?.preferences?.weeklyBudget ?? 0;
   const tolerance =
     userProfile?.preferences?.tolerance ?? preferences.tolerance ?? 0;
   const maxBudget = weeklyBudget * (1 + tolerance);


### PR DESCRIPTION
## Summary
- remove estimated price from recipe cards
- reactively show updated budget in weekly menu
- use weekly budget to influence menu generation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855487d69fc832d925436684a5feea5