### PR TITLE
Fix dark mode background for modals

### DIFF
--- a/src/components/RecipeDetailModal.jsx
+++ b/src/components/RecipeDetailModal.jsx
@@ -45,7 +45,7 @@ function RecipeDetailModal({ recipe, onClose, userProfile }) {
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         exit={{ opacity: 0 }}
-        className="fixed inset-0 flex items-center justify-center z-[60] p-4 backdrop-blur-sm bg-black/20"
+        className="fixed inset-0 flex items-center justify-center z-[60] p-4 backdrop-blur-sm bg-black/20 dark:bg-black/60"
         onClick={onClose}
       >
         <motion.div
@@ -53,10 +53,10 @@ function RecipeDetailModal({ recipe, onClose, userProfile }) {
           animate={{ y: 0, opacity: 1, scale: 1 }}
           exit={{ y: 50, opacity: 0, scale: 0.9 }}
           transition={{ type: 'spring', stiffness: 300, damping: 30 }}
-          className="rounded-xl shadow-lg w-full max-w-2xl max-h-[90vh] flex flex-col bg-[#fcfbf9] text-pastel-text"
+          className="rounded-xl shadow-lg w-full max-w-2xl max-h-[90vh] flex flex-col bg-white dark:bg-zinc-900 text-pastel-text dark:text-neutral-100"
           onClick={(e) => e.stopPropagation()}
         >
-          <header className="p-6 border-b border-pastel-border flex justify-between items-center sticky top-0 bg-[#fcfbf9] z-10">
+          <header className="p-6 border-b border-pastel-border flex justify-between items-center sticky top-0 bg-white dark:bg-zinc-900 z-10">
             <h2 className="text-2xl sm:text-3xl font-bold text-pastel-primary dark:text-pastel-primary-hover">
               {recipe.name}
             </h2>
@@ -193,7 +193,7 @@ function RecipeDetailModal({ recipe, onClose, userProfile }) {
             )}
           </div>
 
-          <footer className="p-4 border-t border-pastel-border flex justify-end sticky bottom-0 bg-[#fcfbf9] z-10">
+          <footer className="p-4 border-t border-pastel-border flex justify-end sticky bottom-0 bg-white dark:bg-zinc-900 z-10">
             <Button variant="outline" onClick={onClose}>
               Fermer
             </Button>

--- a/src/components/RecipeForm.jsx
+++ b/src/components/RecipeForm.jsx
@@ -557,7 +557,7 @@ function RecipeForm({
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         exit={{ opacity: 0 }}
-        className="fixed inset-0 flex items-center justify-center z-50 p-4 backdrop-blur-sm bg-black/30"
+        className="fixed inset-0 flex items-center justify-center z-50 p-4 backdrop-blur-sm bg-black/30 dark:bg-black/60"
         onClick={onClose}
       >
         <motion.div
@@ -565,7 +565,7 @@ function RecipeForm({
           animate={{ y: 0, opacity: 1, scale: 1 }}
           exit={{ y: 30, opacity: 0, scale: 0.95 }}
           transition={{ type: 'spring', stiffness: 280, damping: 28 }}
-          className="bg-[#fcfbf9] text-pastel-text rounded-xl p-6 sm:p-8 w-full max-w-3xl max-h-[90vh] overflow-y-auto shadow-lg"
+          className="bg-white dark:bg-zinc-900 text-pastel-text dark:text-neutral-100 rounded-xl p-6 sm:p-8 w-full max-w-3xl max-h-[90vh] overflow-y-auto shadow-lg"
           onClick={(e) => e.stopPropagation()}
         >
           <div className="flex justify-between items-center mb-6 pb-4 border-b border-pastel-border/60">

--- a/src/components/menu_planner/MenuPreferencesModal.jsx
+++ b/src/components/menu_planner/MenuPreferencesModal.jsx
@@ -40,7 +40,10 @@ function MenuPreferencesModal({
           Préférences
         </Button>
       </DialogTrigger>
-      <DialogContent overlayClassName="backdrop-blur-sm bg-white/90" className="max-w-3xl bg-white bg-opacity-95 rounded-xl shadow-lg z-50">
+      <DialogContent
+        overlayClassName="backdrop-blur-sm bg-black/30 dark:bg-black/60"
+        className="max-w-3xl bg-white dark:bg-zinc-900 text-black dark:text-neutral-100 rounded-xl shadow-lg z-50"
+      >
         <DialogHeader>
           <DialogTitle>Préférences du Menu</DialogTitle>
           <DialogDescription>


### PR DESCRIPTION
## Summary
- darken MenuPreferencesModal overlay and content
- apply dark backgrounds to RecipeForm modal
- tweak RecipeDetailModal styles for dark mode

## Testing
- `npm run lint` *(fails: react/no-unescaped-entities, no-undef)*
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_68554b4dbab0832d811c97d3c44492a7