### PR TITLE
Remove tolerance setting

### DIFF
--- a/src/components/MenuPlanner.jsx
+++ b/src/components/MenuPlanner.jsx
@@ -67,7 +67,6 @@ function MenuPlanner({
       ],
       maxCalories: 2200,
       weeklyBudget: 35,
-      tolerance: 0.1,
       tagPreferences: [],
       servingsPerMeal: 4,
       commonMenuSettings: {
@@ -78,6 +77,9 @@ function MenuPlanner({
     };
 
     let initialPrefs = saved ? JSON.parse(saved) : defaultPreferences;
+    if (initialPrefs.tolerance !== undefined) {
+      delete initialPrefs.tolerance;
+    }
     if (userProfile?.preferences) {
       initialPrefs = {
         ...initialPrefs,
@@ -93,8 +95,6 @@ function MenuPlanner({
           userProfile.preferences.weeklyBudget ||
           initialPrefs.weeklyBudget ||
           35,
-        tolerance:
-          userProfile.preferences.tolerance || initialPrefs.tolerance || 0.1,
         meals: userProfile.preferences.meals?.length
           ? userProfile.preferences.meals
           : initialPrefs.meals,
@@ -109,6 +109,9 @@ function MenuPlanner({
           linkedUserRecipes: [],
         },
       };
+      if (initialPrefs.tolerance !== undefined) {
+        delete initialPrefs.tolerance;
+      }
     }
     return initialPrefs;
   });

--- a/src/components/menu_planner/MenuPreferencesPanel.jsx
+++ b/src/components/menu_planner/MenuPreferencesPanel.jsx
@@ -181,29 +181,6 @@ function MenuPreferencesPanel({
             className="max-w-xs"
           />
         </div>
-        <div className="space-y-2">
-          <Label
-            htmlFor="tolerance"
-            className="block text-base font-medium mb-1.5"
-          >
-            Tolérance dépassement (%)
-          </Label>
-          <Input
-            id="tolerance"
-            type="number"
-            value={Math.round((preferences.tolerance || 0) * 100)}
-            onChange={(e) =>
-              setPreferences({
-                ...preferences,
-                tolerance: Math.max(0, parseFloat(e.target.value) || 0) / 100,
-              })
-            }
-            min="0"
-            max="100"
-            step="1"
-            className="max-w-xs"
-          />
-        </div>
       </div>
 
       <CommonMenuSettings

--- a/src/components/menu_planner/WeeklyMenuView.jsx
+++ b/src/components/menu_planner/WeeklyMenuView.jsx
@@ -140,9 +140,8 @@ function WeeklyMenuView({
     preferences.weeklyBudget !== undefined
       ? preferences.weeklyBudget
       : userProfile?.preferences?.weeklyBudget ?? 0;
-  const tolerance =
-    userProfile?.preferences?.tolerance ?? preferences.tolerance ?? 0;
-  const maxBudget = weeklyBudget * (1 + tolerance);
+  const TOLERANCE = 0.1;
+  const maxBudget = weeklyBudget * (1 + TOLERANCE);
   const overBudget = totalMenuCost > maxBudget && weeklyBudget > 0;
 
   return (

--- a/src/hooks/useUserProfile.js
+++ b/src/hooks/useUserProfile.js
@@ -19,7 +19,6 @@ export function useUserProfile(session) {
         servingsPerMeal: 4,
         maxCalories: 2200,
         weeklyBudget: 35,
-        tolerance: 0.1,
         meals: [],
         tagPreferences: [],
         commonMenuSettings: { enabled: false, linkedUsers: [] },
@@ -76,7 +75,6 @@ export function useUserProfile(session) {
         servingsPerMeal: 4,
         maxCalories: 2200,
         weeklyBudget: 35,
-        tolerance: 0.1,
         meals: [],
         tagPreferences: [],
         commonMenuSettings: { enabled: false, linkedUsers: [] },
@@ -85,6 +83,7 @@ export function useUserProfile(session) {
         ...defaultPreferences,
         ...(userMetadata.preferences || {}),
       };
+      delete finalProfileData.preferences.tolerance;
       finalProfileData.preferences.commonMenuSettings = {
         ...defaultPreferences.commonMenuSettings,
         ...(userMetadata.preferences?.commonMenuSettings || {}),


### PR DESCRIPTION
## Summary
- drop tolerance preference field from user profile defaults
- remove tolerance input from menu preferences UI
- stop loading/storing tolerance from menu preferences
- apply static 10% tolerance for weekly budget overages

## Testing
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68554b9c1504832d8d6c75926da4b641