### PR TITLE
Add signup SQL function

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ STRIPE_WEBHOOK_SECRET=<your-stripe-webhook-secret>
 
 These values are injected by Vite and used by the app at runtime.
 
+## Database
+
+The `supabase/functions` directory contains SQL scripts used to configure
+the database. In particular, `handle_new_user_signup.sql` defines a function
+that assigns the default `standard` subscription tier to new users.
+
 ## Running tests
 
 Execute the following command to run the Vitest suite:

--- a/supabase/functions/handle_new_user_signup.sql
+++ b/supabase/functions/handle_new_user_signup.sql
@@ -1,0 +1,16 @@
+-- Updates subscription tier metadata for a new user
+create or replace function public.handle_new_user_signup(user_id uuid)
+returns void
+language sql
+security definer
+set search_path = public
+as $$
+  update auth.users
+  set raw_user_meta_data = jsonb_set(
+    coalesce(raw_user_meta_data, '{}'),
+    '{subscription_tier}',
+    '"standard"',
+    true
+  )
+  where id = user_id;
+$$;


### PR DESCRIPTION
## Summary
- add a SQL function `public.handle_new_user_signup`
- document the new `supabase/functions` folder in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68556cd4b4b8832daa0e462f214123d0