### PR TITLE
Lire subscription tier depuis metadata

### DIFF
--- a/api/estimate-cost.ts
+++ b/api/estimate-cost.ts
@@ -8,7 +8,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   }
 
   const user = await getUserFromRequest(req);
-  if (!user || user.user_metadata?.subscription_tier !== 'premium') {
+  if (!user || user.raw_user_meta_data?.subscription_tier !== 'premium') {
     return res.status(403).json({ error: 'Premium only' });
   }
 

--- a/api/generate-description.ts
+++ b/api/generate-description.ts
@@ -1,0 +1,37 @@
+import { VercelRequest, VercelResponse } from '@vercel/node';
+import OpenAI from 'openai';
+import { getUserFromRequest } from '@/utils/auth';
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const user = await getUserFromRequest(req);
+  if (!user || user.raw_user_meta_data?.subscription_tier !== 'premium') {
+    return res.status(403).json({ error: 'Premium only' });
+  }
+
+  const { recipe } = req.body;
+  if (!recipe) {
+    return res.status(400).json({ error: 'Missing recipe' });
+  }
+
+  if (!process.env.OPENAI_API_KEY) {
+    return res.status(500).json({ error: 'Missing OpenAI API key' });
+  }
+
+  try {
+    const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+    const prompt = `G\u00e9n\u00e8re une description courte (environ 150 caract\u00e8res), engageante et app\u00e9tissante pour ${recipe.name}. Ingr\u00e9dients: ${recipe.ingredients?.map((i:any)=>`${i.quantity||''} ${i.unit||''} ${i.name}`).join(', ')}. Instructions: ${Array.isArray(recipe.instructions)?recipe.instructions.join(' '):''}.`;
+    const response = await openai.chat.completions.create({
+      model: 'gpt-3.5-turbo',
+      messages: [{ role: 'user', content: prompt }],
+    });
+    const description = response.choices[0].message.content || '';
+    return res.status(200).json({ description });
+  } catch (err) {
+    console.error('OpenAI error:', err);
+    return res.status(500).json({ error: 'Internal Server Error', details: String(err) });
+  }
+}

--- a/api/generate-image.ts
+++ b/api/generate-image.ts
@@ -1,0 +1,40 @@
+import { VercelRequest, VercelResponse } from '@vercel/node';
+import OpenAI from 'openai';
+import { getUserFromRequest } from '@/utils/auth';
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const user = await getUserFromRequest(req);
+  if (!user || user.raw_user_meta_data?.subscription_tier !== 'premium') {
+    return res.status(403).json({ error: 'Premium only' });
+  }
+
+  const { recipe } = req.body;
+  if (!recipe) {
+    return res.status(400).json({ error: 'Missing recipe' });
+  }
+
+  if (!process.env.OPENAI_API_KEY) {
+    return res.status(500).json({ error: 'Missing OpenAI API key' });
+  }
+
+  try {
+    const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+    const prompt = `Photographie culinaire professionnelle de ${recipe.name} pr\u00e9par\u00e9 avec ${recipe.ingredients?.map((i:any)=>`${i.quantity||''} ${i.unit||''} ${i.name}`).join(', ')}.`;
+    const response = await openai.images.generate({
+      model: 'dall-e-3',
+      prompt,
+      n: 1,
+      size: '1024x1024',
+      quality: 'standard',
+      response_format: 'url',
+    });
+    return res.status(200).json({ url: response.data[0].url });
+  } catch (err) {
+    console.error('OpenAI error:', err);
+    return res.status(500).json({ error: 'Internal Server Error', details: String(err) });
+  }
+}

--- a/src/components/account/SubscriptionManagement.jsx
+++ b/src/components/account/SubscriptionManagement.jsx
@@ -152,6 +152,9 @@ export default function SubscriptionManagement({
       <h3 className="text-xl sm:text-2xl font-semibold text-pastel-text/90 border-b border-pastel-border pb-3 mb-5">
         Gestion de l&apos;Abonnement
       </h3>
+      <p className="text-sm text-pastel-muted-foreground">
+        Statut actuel : {currentSubscriptionTier === 'premium' ? 'Premium' : 'Standard'}
+      </p>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         <div

--- a/src/hooks/useUserProfile.js
+++ b/src/hooks/useUserProfile.js
@@ -56,7 +56,8 @@ export function useUserProfile(session) {
       }
 
       const appMetadata = session.user.app_metadata || {};
-      const userMetadata = session.user.user_metadata || {};
+      const userMetadata =
+        session.user.raw_user_meta_data || session.user.user_metadata || {};
 
       let finalProfileData = {
         id: session.user.id,

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -14,5 +14,9 @@ export async function getUserFromRequest(req) {
     console.warn('Error fetching user from token:', error.message);
     return null;
   }
-  return data.user || null;
+  const user = data.user || null;
+  if (user && !user.raw_user_meta_data && user.user_metadata) {
+    user.raw_user_meta_data = user.user_metadata;
+  }
+  return user;
 }


### PR DESCRIPTION
## Summary
- enrich auth util to expose `raw_user_meta_data`
- gate estimate-cost on `raw_user_meta_data.subscription_tier`
- implement `generate-description` and `generate-image` endpoints
- display subscription status in the account page
- call new AI endpoints from the recipe form
- read `raw_user_meta_data` in user profile hook
- remove obsolete `isPremiumUser` variable

## Testing
- `npx --no-install vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68557331f6a0832d963f23a5c043d1e1