### PR TITLE
Add headers for AI endpoints

### DIFF
--- a/src/components/RecipeForm.jsx
+++ b/src/components/RecipeForm.jsx
@@ -506,8 +506,19 @@ function RecipeForm({
 
       const response = await fetch(endpoint, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${session.access_token}` },
-        body: JSON.stringify({ recipe: { name: formData.name, ingredients: formData.ingredients, instructions: formData.instructions } }),
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${session.access_token}`,
+          apikey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+          'x-subscription-tier': subscriptionTier,
+        },
+        body: JSON.stringify({
+          recipe: {
+            name: formData.name,
+            ingredients: formData.ingredients,
+            instructions: formData.instructions,
+          },
+        }),
       });
 
       if (!response.ok) {

--- a/src/lib/openai.js
+++ b/src/lib/openai.js
@@ -77,6 +77,27 @@ export const generateRecipeImage = async (recipe) => {
   }
 };
 
+export const generateRecipe = async (prompt, subscriptionTier = 'standard') => {
+  try {
+    const response = await fetch('/api/generate-recipe', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        apikey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+        'x-subscription-tier': subscriptionTier,
+      },
+      body: JSON.stringify({ prompt }),
+    });
+
+    if (!response.ok) throw new Error('Request failed');
+
+    return await response.json();
+  } catch (error) {
+    console.error('Erreur lors de la génération de la recette:', error);
+    return null;
+  }
+};
+
 export const estimateRecipePrice = async (
   recipe,
   subscriptionTier = 'standard'


### PR DESCRIPTION
## Summary
- include subscription tier and anon key when generating images
- add helper to request recipe generation with required headers

## Testing
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68557ff94648832d8931c97e79c591ac