### PR TITLE
Add auth utility and sample protected route

### DIFF
--- a/supabase/functions/protected-route/index.ts
+++ b/supabase/functions/protected-route/index.ts
@@ -1,0 +1,8 @@
+import { serve } from "https://deno.land/std@0.192.0/http/server.ts";
+import { requireAuth } from "../utils/auth.ts";
+
+serve(async (req: Request) => {
+  const user = await requireAuth(req);
+  if (user instanceof Response) return user;
+  return new Response(`Bonjour ${user.email}, accès autorisé`);
+});

--- a/supabase/functions/utils/auth.ts
+++ b/supabase/functions/utils/auth.ts
@@ -1,0 +1,9 @@
+import { getSupabaseUser } from "https://deno.land/x/supabase_auth_helpers/deno/mod.ts";
+
+export async function requireAuth(req: Request) {
+  const { user, error } = await getSupabaseUser(req);
+  if (error || !user) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+  return user;
+}


### PR DESCRIPTION
## Summary
- add Supabase auth helper for Deno functions
- add example protected route using the helper

## Testing
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685580ac5eac832db6f85baf3195b6c8