### PR TITLE
Add logging and input validation for description generation

### DIFF
--- a/api/generate-description.ts
+++ b/api/generate-description.ts
@@ -12,6 +12,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return res.status(403).json({ error: 'Premium only' });
   }
 
+  console.log('Request body:', req.body);
   const { recipe } = req.body;
   if (!recipe) {
     return res.status(400).json({ error: 'Missing recipe' });
@@ -24,6 +25,10 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   try {
     const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
     const prompt = `G\u00e9n\u00e8re une description courte (environ 150 caract\u00e8res), engageante et app\u00e9tissante pour ${recipe.name}. Ingr\u00e9dients: ${recipe.ingredients?.map((i:any)=>`${i.quantity||''} ${i.unit||''} ${i.name}`).join(', ')}. Instructions: ${Array.isArray(recipe.instructions)?recipe.instructions.join(' '):''}.`;
+
+    if (!prompt || typeof prompt !== 'string' || prompt.trim() === '') {
+      return res.status(400).json({ error: 'Invalid prompt' });
+    }
     const response = await openai.chat.completions.create({
       model: 'gpt-3.5-turbo',
       messages: [{ role: 'user', content: prompt }],


### PR DESCRIPTION
## Summary
- log incoming JSON in `/api/generate-description`
- validate prompt before calling OpenAI

## Testing
- `npm test`
- `npm run lint` *(fails: 515 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68558961e508832d96f6e93a07c46822