### PR TITLE
Add Deno generate-description endpoint

### DIFF
--- a/supabase/functions/generate-description/index.ts
+++ b/supabase/functions/generate-description/index.ts
@@ -1,0 +1,30 @@
+import { serve } from "https://deno.land/std@0.192.0/http/server.ts";
+
+serve(async (req: Request) => {
+  try {
+    const body = await req.json();
+    if (!body.prompt) {
+      return new Response("Missing prompt", { status: 400 });
+    }
+
+    const response = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${Deno.env.get("OPENAI_API_KEY")}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "gpt-4",
+        messages: [{ role: "user", content: body.prompt }],
+      }),
+    });
+
+    const result = await response.json();
+    return new Response(JSON.stringify(result.choices[0].message), {
+      status: 200,
+    });
+  } catch (err) {
+    console.error("Erreur IA :", err);
+    return new Response("Erreur interne", { status: 500 });
+  }
+});


### PR DESCRIPTION
## Summary
- add new Supabase function `generate-description` implementing GPT-4 call using fetch

## Testing
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68558adafd5c832dbf9347f017ca5fda