### PR TITLE
Add OPENAI_API_KEY checks in Deno functions

### DIFF
--- a/api/stripe/webhook.ts
+++ b/api/stripe/webhook.ts
@@ -13,6 +13,12 @@ console.log("Stripe webhook handler initialized");
 
 serve(async (req) => {
   console.log("Webhook request received");
+
+  const key = Deno.env.get("OPENAI_API_KEY");
+  if (!key) {
+    return new Response("Missing OpenAI API key", { status: 500 });
+  }
+
   const signature = req.headers.get("stripe-signature") ?? "";
 
   let event: Stripe.Event;

--- a/supabase/functions/generate-recipe/index.ts
+++ b/supabase/functions/generate-recipe/index.ts
@@ -37,7 +37,15 @@ serve(async (req) => {
 
   const { prompt } = await req.json();
 
-  const openai = new OpenAI({ apiKey: Deno.env.get("OPENAI_API_KEY") });
+  const key = Deno.env.get("OPENAI_API_KEY");
+  if (!key) {
+    return new Response(
+      JSON.stringify({ error: "Missing OpenAI API key" }),
+      { status: 500, headers: corsHeaders },
+    );
+  }
+
+  const openai = new OpenAI({ apiKey: key });
 
   const result = await openai.chat.completions.create({
     model: "gpt-3.5-turbo",


### PR DESCRIPTION
## Summary
- check `OPENAI_API_KEY` before creating OpenAI client in `generate-recipe` function
- verify that `OPENAI_API_KEY` exists in the Stripe webhook

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68558ffdd138832d9c5310f43855f39f