### PR TITLE
Update CSP policy

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,7 +5,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' https://js.stripe.com 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://api.openai.com https://js.stripe.com https://bunolhgehzwxhzqymmet.supabase.co https://mealmapp.vercel.app; frame-src https://js.stripe.com; object-src 'none'; base-uri 'self';"
+          "value": "default-src 'self'; script-src 'self' https://js.stripe.com 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://api.openai.com https://js.stripe.com https://bunolhgehzwxhzqymmet.supabase.co https://*.supabase.co https://mealmapp.vercel.app; frame-src https://js.stripe.com; object-src 'none'; base-uri 'self';"
         }
       ]
     }


### PR DESCRIPTION
## Summary
- update the Content-Security-Policy header in `vercel.json` to allow calls to OpenAI, Stripe, and Supabase

## Testing
- `npm test`
- `npm run lint` *(fails: many errors)*
- `vercel --prod` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685590c50ac0832d9f1d742be0e0452d