### PR TITLE
Fix generate description route validation

### DIFF
--- a/api/generate-description.ts
+++ b/api/generate-description.ts
@@ -7,15 +7,20 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return res.status(405).json({ error: 'Method not allowed' });
   }
 
+  if (!req.headers['content-type']?.includes('application/json')) {
+    return res
+      .status(400)
+      .json({ error: 'Content-Type must be application/json' });
+  }
+
+  const { prompt } = req.body || {};
+  if (!prompt || typeof prompt !== 'string') {
+    return res.status(400).json({ error: 'Invalid or missing prompt' });
+  }
+
   const user = await getUserFromRequest(req);
   if (!user || user.raw_user_meta_data?.subscription_tier !== 'premium') {
     return res.status(403).json({ error: 'Premium only' });
-  }
-
-  console.log('Request body:', req.body);
-  const { recipe } = req.body;
-  if (!recipe) {
-    return res.status(400).json({ error: 'Missing recipe' });
   }
 
   if (!process.env.OPENAI_API_KEY) {
@@ -24,11 +29,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
   try {
     const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
-    const prompt = `G\u00e9n\u00e8re une description courte (environ 150 caract\u00e8res), engageante et app\u00e9tissante pour ${recipe.name}. Ingr\u00e9dients: ${recipe.ingredients?.map((i:any)=>`${i.quantity||''} ${i.unit||''} ${i.name}`).join(', ')}. Instructions: ${Array.isArray(recipe.instructions)?recipe.instructions.join(' '):''}.`;
 
-    if (!prompt || typeof prompt !== 'string' || prompt.trim() === '') {
-      return res.status(400).json({ error: 'Invalid prompt' });
-    }
     const response = await openai.chat.completions.create({
       model: 'gpt-3.5-turbo',
       messages: [{ role: 'user', content: prompt }],
@@ -37,6 +38,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return res.status(200).json({ description });
   } catch (err) {
     console.error('OpenAI error:', err);
-    return res.status(500).json({ error: 'Internal Server Error', details: String(err) });
+    return res
+      .status(500)
+      .json({ error: 'Internal Server Error', details: String(err) });
   }
 }


### PR DESCRIPTION
## Summary
- require POST `/api/generate-description` to include a non-empty `prompt`
- validate that requests use `application/json`

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6855934e3c30832d92b316cbad93ce48