### PR TITLE
Secure Supabase profile & keys

### DIFF
--- a/api/access-key.ts
+++ b/api/access-key.ts
@@ -1,0 +1,54 @@
+import { VercelRequest, VercelResponse } from '@vercel/node';
+import { createClient } from '@supabase/supabase-js';
+import { getUserFromRequest } from '@/utils/auth';
+
+const supabaseAdmin = createClient(
+  process.env.SUPABASE_URL || '',
+  process.env.SUPABASE_SERVICE_ROLE_KEY || ''
+);
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const user = await getUserFromRequest(req);
+  if (!user) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
+  const { key } = req.body || {};
+  if (!key) {
+    return res.status(400).json({ error: 'Key required' });
+  }
+
+  try {
+    const { data, error } = await supabaseAdmin
+      .from('access_keys')
+      .select('id, grants, used_by')
+      .eq('key', key)
+      .maybeSingle();
+
+    if (error || !data) {
+      return res.status(404).json({ error: 'Invalid key' });
+    }
+
+    if (data.used_by) {
+      return res.status(409).json({ error: 'Key already used' });
+    }
+
+    const { error: updateError } = await supabaseAdmin
+      .from('access_keys')
+      .update({ used_by: user.id, used_at: new Date().toISOString() })
+      .eq('id', data.id);
+
+    if (updateError) {
+      console.warn('access_keys update error:', updateError.message);
+    }
+
+    return res.status(200).json({ grants: data.grants });
+  } catch (err) {
+    console.error('access-key error:', err);
+    return res.status(500).json({ error: 'Internal Server Error' });
+  }
+}

--- a/api/update-profile.ts
+++ b/api/update-profile.ts
@@ -1,0 +1,42 @@
+import { VercelRequest, VercelResponse } from '@vercel/node';
+import { createClient } from '@supabase/supabase-js';
+import { getUserFromRequest } from '@/utils/auth';
+
+const supabaseAdmin = createClient(
+  process.env.SUPABASE_URL || '',
+  process.env.SUPABASE_SERVICE_ROLE_KEY || ''
+);
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const user = await getUserFromRequest(req);
+  const body = req.body || {};
+
+  if (!user || user.id !== body.id) {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+
+  const updates: Record<string, any> = {};
+  ['username', 'bio', 'avatar_url', 'user_tag'].forEach((field) => {
+    if (body[field] !== undefined) updates[field] = body[field];
+  });
+
+  try {
+    const { error } = await supabaseAdmin
+      .from('public_users')
+      .update(updates)
+      .eq('id', body.id);
+
+    if (error) {
+      return res.status(500).json({ error: error.message });
+    }
+
+    return res.status(200).json({ success: true });
+  } catch (err) {
+    console.error('update-profile error:', err);
+    return res.status(500).json({ error: 'Internal Server Error' });
+  }
+}

--- a/src/hooks/useUserProfile.js
+++ b/src/hooks/useUserProfile.js
@@ -79,6 +79,10 @@ export function useUserProfile(session) {
           : [],
       };
 
+      if (!finalProfileData.user_tag) {
+        console.warn('user_tag is NULL for user', session.user.id);
+      }
+
       const defaultPreferences = {
         servingsPerMeal: 4,
         maxCalories: 2200,


### PR DESCRIPTION
## Summary
- add secured API routes for updating profile and applying access keys
- refactor profile form to call backend APIs
- warn if a profile has a NULL `user_tag`

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_68559d9fdda4832d866b9bca0bc17ce7