### PR TITLE
Fix OpenAI key usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,6 @@ La clé `OPENAI_API_KEY` doit être fournie uniquement aux fonctions côté serv
 
 Cette clé ne doit jamais être exposée au client ; n'utilisez donc pas de préfixe `VITE_`.
 
+# ENV
+OPENAI_API_KEY=sk-...
+

--- a/api/generate-description.ts
+++ b/api/generate-description.ts
@@ -23,12 +23,13 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return res.status(403).json({ error: 'Premium only' });
   }
 
-  if (!process.env.OPENAI_API_KEY) {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
     return res.status(500).json({ error: 'Missing OpenAI API key' });
   }
 
   try {
-    const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+    const openai = new OpenAI({ apiKey });
 
     const response = await openai.chat.completions.create({
       model: 'gpt-3.5-turbo',

--- a/api/generate-image.ts
+++ b/api/generate-image.ts
@@ -17,12 +17,13 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return res.status(400).json({ error: 'Missing recipe' });
   }
 
-  if (!process.env.OPENAI_API_KEY) {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
     return res.status(500).json({ error: 'Missing OpenAI API key' });
   }
 
   try {
-    const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+    const openai = new OpenAI({ apiKey });
     const prompt = `Photographie culinaire professionnelle de ${recipe.name} pr\u00e9par\u00e9 avec ${recipe.ingredients?.map((i:any)=>`${i.quantity||''} ${i.unit||''} ${i.name}`).join(', ')}.`;
     const response = await openai.images.generate({
       model: 'dall-e-3',


### PR DESCRIPTION
## Summary
- handle OpenAI API key via variable in API routes
- document OPENAI_API_KEY env var

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_68559e0b6db4832db0d434bc7ccf5577