### PR TITLE
Remove user_tag from user queries

### DIFF
--- a/src/components/MyPublicProfile.jsx
+++ b/src/components/MyPublicProfile.jsx
@@ -30,7 +30,7 @@ export default function MyPublicProfile({
     try {
       const { data: user, error: userError } = await supabase
         .from('public_users')
-        .select('id, username, avatar_url, bio, user_tag, subscription_tier')
+        .select('id, username, avatar_url, bio, subscription_tier')
         .eq('id', session.user.id)
         .single();
 
@@ -54,7 +54,7 @@ export default function MyPublicProfile({
       const userIds = [...new Set(recipeData.map((r) => r.user_id))];
       const { data: users } = await supabase
         .from('public_users')
-        .select('id, username, avatar_url, bio, user_tag, subscription_tier')
+        .select('id, username, avatar_url, bio, subscription_tier')
         .in('id', userIds);
       const usersMap = Object.fromEntries((users || []).map((u) => [u.id, u]));
 

--- a/src/hooks/useLinkedUsers.js
+++ b/src/hooks/useLinkedUsers.js
@@ -22,7 +22,7 @@ export function useLinkedUsers(userProfile, preferences, setPreferences) {
         const userIds = [...new Set(recipes.map((r) => r.user_id))];
         const { data: users } = await supabase
           .from('public_users')
-          .select('id, username, avatar_url, bio, user_tag')
+          .select('id, username, avatar_url, bio, subscription_tier')
           .in('id', userIds);
         const usersMap = Object.fromEntries(
           (users || []).map((u) => [u.id, u])
@@ -124,7 +124,7 @@ export function useLinkedUsers(userProfile, preferences, setPreferences) {
     try {
       const { data: usersData, error: usersError } = await supabase
         .from('public_users')
-        .select('id, username, avatar_url, bio, user_tag')
+        .select('id, username, avatar_url, bio, subscription_tier')
         .ilike('username', newLinkedUserTag.trim())
         .single();
 
@@ -243,7 +243,7 @@ export function useLinkedUsers(userProfile, preferences, setPreferences) {
         ];
         const { data: users } = await supabase
           .from('public_users')
-          .select('id, username, avatar_url, bio, user_tag')
+          .select('id, username, avatar_url, bio, subscription_tier')
           .in('id', userIds);
         const usersMap = Object.fromEntries(
           (users || []).map((u) => [u.id, u])

--- a/src/hooks/usePublicRecipes.js
+++ b/src/hooks/usePublicRecipes.js
@@ -25,7 +25,7 @@ export function usePublicRecipes(session) {
       const userIds = [...new Set(recipes.map((r) => r.user_id))];
       const { data: users } = await supabase
         .from('public_users')
-        .select('id, username, avatar_url, bio, user_tag, subscription_tier')
+        .select('id, username, avatar_url, bio, subscription_tier')
         .in('id', userIds);
       const usersMap = Object.fromEntries((users || []).map((u) => [u.id, u]));
 

--- a/src/hooks/useRecipes.jsx
+++ b/src/hooks/useRecipes.jsx
@@ -52,7 +52,7 @@ export function useRecipes(session, subscriptionTier) {
         const userIds = [...new Set(data.map((r) => r.user_id))];
         const { data: users } = await supabase
           .from('public_users')
-          .select('id, username, avatar_url, bio, user_tag, subscription_tier')
+          .select('id, username, avatar_url, bio, subscription_tier')
           .in('id', userIds);
 
         const usersMap = Object.fromEntries(
@@ -189,7 +189,7 @@ export function useRecipes(session, subscriptionTier) {
 
         const { data: user } = await supabase
           .from('public_users')
-          .select('id, username, avatar_url, bio, user_tag, subscription_tier')
+          .select('id, username, avatar_url, bio, subscription_tier')
           .eq('id', newRecipeResult.user_id)
           .single();
 
@@ -285,7 +285,7 @@ export function useRecipes(session, subscriptionTier) {
 
         const { data: user } = await supabase
           .from('public_users')
-          .select('id, username, avatar_url, bio, user_tag, subscription_tier')
+          .select('id, username, avatar_url, bio, subscription_tier')
           .eq('id', updatedRecipeResult.user_id)
           .single();
 

--- a/src/hooks/useUserProfile.js
+++ b/src/hooks/useUserProfile.js
@@ -40,7 +40,7 @@ export function useUserProfile(session) {
     try {
       const { data: profile, error: profileError } = await supabase
         .from('public_users')
-        .select('id, username, avatar_url, bio, user_tag, subscription_tier')
+        .select('id, username, avatar_url, bio, subscription_tier')
         .eq('id', session.user.id)
         .single();
 

--- a/src/hooks/useUserSearch.js
+++ b/src/hooks/useUserSearch.js
@@ -17,7 +17,7 @@ export function useUserSearch(session) {
       try {
         let query = supabase
           .from('public_users')
-          .select('id, username, avatar_url, bio, user_tag, subscription_tier')
+          .select('id, username, avatar_url, bio, subscription_tier')
           .or(`username.ilike.*${sanitized}*,bio.ilike.*${sanitized}*`)
           .limit(10);
         if (session?.user?.id) {

--- a/src/pages/UserProfilePage.jsx
+++ b/src/pages/UserProfilePage.jsx
@@ -32,7 +32,7 @@ export default function UserProfilePage({
     try {
       const { data: user, error: userError } = await supabase
         .from('public_users')
-        .select('id, username, avatar_url, bio, user_tag, subscription_tier')
+        .select('id, username, avatar_url, bio, subscription_tier')
         .eq('id', userId)
         .single();
 
@@ -114,7 +114,7 @@ export default function UserProfilePage({
       const userIds = [...new Set(recipeData.map((r) => r.user_id))];
       const { data: users } = await supabase
         .from('public_users')
-        .select('id, username, avatar_url, bio, user_tag, subscription_tier')
+        .select('id, username, avatar_url, bio, subscription_tier')
         .in('id', userIds);
       const usersMap = Object.fromEntries((users || []).map((u) => [u.id, u]));
 


### PR DESCRIPTION
## Summary
- stop selecting `user_tag` when fetching public user info

## Testing
- `npm test`
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68567b8d25c0832d8c8ab57c969d316b