### PR TITLE
Fix recipe validation

### DIFF
--- a/api/generate-description.ts
+++ b/api/generate-description.ts
@@ -22,11 +22,13 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
   let parsed;
   try {
-    parsed = RecipeSchema.parse(req.body);
+    parsed = RecipeSchema.parse(req.body.recipe);
     console.log('Valid payload:', parsed);
   } catch (error) {
-    console.error('Payload error:', error);
-    return res.status(400).json({ error: 'Invalid request payload' });
+    console.error('Invalid recipe payload:', error);
+    const message =
+      error instanceof z.ZodError ? error.errors.map(e => e.message).join(', ') : String(error);
+    return res.status(400).json({ error: 'Invalid recipe payload', details: message });
   }
 
   const user = await getUserFromRequest(req);

--- a/src/components/RecipeForm.jsx
+++ b/src/components/RecipeForm.jsx
@@ -514,9 +514,13 @@ function RecipeForm({
         },
         body: JSON.stringify({
           recipe: {
-            name: formData.name,
-            ingredients: formData.ingredients,
-            instructions: formData.instructions,
+            title: formData.name,
+            ingredients: formData.ingredients
+              .filter((ing) => ing.name)
+              .map((ing) => ing.name),
+            instructions: Array.isArray(formData.instructions)
+              ? formData.instructions.join(' ')
+              : formData.instructions,
           },
         }),
       });


### PR DESCRIPTION
## Summary
- validate `body.recipe` with Zod in the description API
- return validation message on error
- send properly shaped recipe payload from the form

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_68568169292c832d80bfdf78b1033078