### PR TITLE
Add recipe validation with Zod

### DIFF
--- a/api/generate-description.ts
+++ b/api/generate-description.ts
@@ -22,13 +22,11 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
   let parsed;
   try {
-    parsed = RecipeSchema.parse(req.body.recipe);
-    console.log('Valid payload:', parsed);
-  } catch (error) {
-    console.error('Invalid recipe payload:', error);
-    const message =
-      error instanceof z.ZodError ? error.errors.map(e => e.message).join(', ') : String(error);
-    return res.status(400).json({ error: 'Invalid recipe payload', details: message });
+    const { recipe } = req.body;
+    parsed = RecipeSchema.parse(recipe);
+  } catch (err) {
+    console.error('Payload invalid:', err);
+    return res.status(400).json({ error: 'Invalid recipe payload', details: err });
   }
 
   const user = await getUserFromRequest(req);


### PR DESCRIPTION
## Summary
- validate the `recipe` payload in `generate-description` using Zod

## Testing
- `npm test`
- `npm run lint` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6856873e8d7c832db76503d7c12be530