### PR TITLE
Update vercel CSP headers

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,7 +5,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' https://cdn.jsdelivr.net; connect-src *; img-src 'self' data: https://bunolnhegwzhxqxymmet.supabase.co;"
+          "value": "default-src 'self'; script-src 'self' https://js.stripe.com; style-src 'self' 'unsafe-inline'; connect-src *; img-src 'self' blob: data: https://*.supabase.co"
         }
       ]
     }


### PR DESCRIPTION
## Summary
- update CSP header in `vercel.json` to allow Stripe scripts and Supabase assets

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856880a7360832dad91ab52cff616b1