### PR TITLE
Fix generate description imports

### DIFF
--- a/api/generate-description.ts
+++ b/api/generate-description.ts
@@ -1,7 +1,7 @@
 import { VercelRequest, VercelResponse } from '@vercel/node';
 import OpenAI from 'openai';
 import { z } from 'zod';
-import { getUserFromRequest } from '@/utils/auth';
+import { getUserFromRequest } from '../src/utils/auth';
 
 const RecipeSchema = z.object({
   title: z.string().optional(),

--- a/pages/api/generate-description.ts
+++ b/pages/api/generate-description.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import OpenAI from 'openai';
 import { z } from 'zod';
-import { getUserFromRequest } from '@/utils/auth';
+import { getUserFromRequest } from '../../src/utils/auth';
 
 const RecipeSchema = z.object({
   title: z.string().optional(),


### PR DESCRIPTION
## Summary
- resolve runtime error in generate-description serverless function by switching to relative imports

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68569473f7dc832dabd279f6493a4823