### PR TITLE
Add path alias for src

### DIFF
--- a/src/pages/api/generate-estimate.ts
+++ b/src/pages/api/generate-estimate.ts
@@ -1,5 +1,5 @@
 import { NextApiRequest, NextApiResponse } from 'next';
-import { generateRecipeEstimate } from '../../api/generateEstimate';
+import { generateRecipeEstimate } from '@/api/generateEstimate';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,11 @@
     "esModuleInterop": true,
     "strict": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
   },
   "include": ["api/**/*", "pages/**/*", "src/**/*"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## Summary
- configure tsconfig with `baseUrl` and an alias for `@` pointing to `src`
- refactor TypeScript API route to use the alias

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856a28977b8832da7f23b76a7f22429