### PR TITLE
Add env checks for Supabase clients

### DIFF
--- a/api/access-key.ts
+++ b/api/access-key.ts
@@ -2,10 +2,13 @@ import { VercelRequest, VercelResponse } from '@vercel/node';
 import { createClient } from '@supabase/supabase-js';
 import { getUserFromRequest } from '../src/utils/auth.js';
 
-const supabaseAdmin = createClient(
-  process.env.SUPABASE_URL || '',
-  process.env.SUPABASE_SERVICE_ROLE_KEY || ''
-);
+const supabaseUrl = process.env.SUPABASE_URL;
+if (!supabaseUrl) throw new Error('SUPABASE_URL is not defined');
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!serviceRoleKey)
+  throw new Error('SUPABASE_SERVICE_ROLE_KEY is not defined');
+
+const supabaseAdmin = createClient(supabaseUrl, serviceRoleKey);
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method !== 'POST') {

--- a/api/stripe/webhook.ts
+++ b/api/stripe/webhook.ts
@@ -4,8 +4,11 @@ import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 
 const stripeSecret = Deno.env.get("STRIPE_SECRET_KEY") ?? "";
 const webhookSecret = Deno.env.get("STRIPE_WEBHOOK_SECRET") ?? "";
-const supabaseUrl = Deno.env.get("SUPABASE_URL") ?? "";
-const supabaseServiceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "";
+const supabaseUrl = Deno.env.get("SUPABASE_URL") ?? undefined;
+if (!supabaseUrl) throw new Error("SUPABASE_URL is not defined");
+const supabaseServiceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? undefined;
+if (!supabaseServiceKey)
+  throw new Error("SUPABASE_SERVICE_ROLE_KEY is not defined");
 
 const stripe = new Stripe(stripeSecret, { apiVersion: "2024-04-10" });
 

--- a/api/update-profile.ts
+++ b/api/update-profile.ts
@@ -2,10 +2,13 @@ import { VercelRequest, VercelResponse } from '@vercel/node';
 import { createClient } from '@supabase/supabase-js';
 import { getUserFromRequest } from '../src/utils/auth.js';
 
-const supabaseAdmin = createClient(
-  process.env.SUPABASE_URL || '',
-  process.env.SUPABASE_SERVICE_ROLE_KEY || ''
-);
+const supabaseUrl = process.env.SUPABASE_URL;
+if (!supabaseUrl) throw new Error('SUPABASE_URL is not defined');
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!serviceRoleKey)
+  throw new Error('SUPABASE_SERVICE_ROLE_KEY is not defined');
+
+const supabaseAdmin = createClient(supabaseUrl, serviceRoleKey);
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method !== 'POST') {

--- a/pages/api/stripe/webhook.ts
+++ b/pages/api/stripe/webhook.ts
@@ -6,10 +6,13 @@ import { Readable } from 'stream';
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || '', {
   apiVersion: '2024-04-10',
 });
-const supabase = createClient(
-  process.env.SUPABASE_URL || '',
-  process.env.SUPABASE_SERVICE_ROLE_KEY || ''
-);
+const supabaseUrl = process.env.SUPABASE_URL;
+if (!supabaseUrl) throw new Error('SUPABASE_URL is not defined');
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!serviceRoleKey)
+  throw new Error('SUPABASE_SERVICE_ROLE_KEY is not defined');
+
+const supabase = createClient(supabaseUrl, serviceRoleKey);
 
 export const config = {
   api: {

--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -1,6 +1,8 @@
 import { createClient } from '@supabase/supabase-js';
 
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+if (!supabaseUrl) throw new Error('VITE_SUPABASE_URL is not defined');
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+if (!supabaseAnonKey) throw new Error('VITE_SUPABASE_ANON_KEY is not defined');
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey);

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -1,9 +1,12 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabase = createClient(
-  process.env.SUPABASE_URL || '',
-  process.env.SUPABASE_SERVICE_ROLE_KEY || ''
-);
+const supabaseUrl = process.env.SUPABASE_URL;
+if (!supabaseUrl) throw new Error('SUPABASE_URL is not defined');
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!serviceRoleKey)
+  throw new Error('SUPABASE_SERVICE_ROLE_KEY is not defined');
+
+const supabase = createClient(supabaseUrl, serviceRoleKey);
 
 export async function getUserFromRequest(req) {
   const authHeader = req.headers['authorization'] || '';

--- a/stripe/webhook.ts
+++ b/stripe/webhook.ts
@@ -6,11 +6,13 @@ import { Readable } from 'stream';
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || '', {
   apiVersion: '2024-04-10',
 });
+const supabaseUrl = process.env.SUPABASE_URL;
+if (!supabaseUrl) throw new Error('SUPABASE_URL is not defined');
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!serviceRoleKey)
+  throw new Error('SUPABASE_SERVICE_ROLE_KEY is not defined');
 
-const supabase = createClient(
-  process.env.SUPABASE_URL || '',
-  process.env.SUPABASE_SERVICE_ROLE_KEY || ''
-);
+const supabase = createClient(supabaseUrl, serviceRoleKey);
 
 export const config = {
   api: {

--- a/supabase/functions/generate-recipe/index.ts
+++ b/supabase/functions/generate-recipe/index.ts
@@ -16,9 +16,14 @@ serve(async (req) => {
     );
   }
 
+  const supabaseUrl = Deno.env.get("SUPABASE_URL") ?? undefined;
+  if (!supabaseUrl) throw new Error("SUPABASE_URL is not defined");
+  const anonKey = Deno.env.get("SUPABASE_ANON_KEY") ?? undefined;
+  if (!anonKey) throw new Error("SUPABASE_ANON_KEY is not defined");
+
   const supabase = createClient(
-    Deno.env.get("SUPABASE_URL") ?? "",
-    Deno.env.get("SUPABASE_ANON_KEY") ?? "",
+    supabaseUrl,
+    anonKey,
     {
       global: { headers: { Authorization: req.headers.get("Authorization")! } },
     }


### PR DESCRIPTION
## Summary
- validate Supabase environment variables before calling `createClient`
- apply checks across API handlers, utilities and edge functions

## Testing
- `npm run lint` *(fails: 'process' is not defined)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856a28cc55c832db177c0db402a7c6c