### PR TITLE
Fix Supabase env variables in API routes

### DIFF
--- a/api/access-key.ts
+++ b/api/access-key.ts
@@ -2,8 +2,8 @@ import { VercelRequest, VercelResponse } from '@vercel/node';
 import { createClient } from '@supabase/supabase-js';
 import { getUserFromRequest } from '../src/utils/auth.js';
 
-const supabaseUrl = process.env.SUPABASE_URL;
-if (!supabaseUrl) throw new Error('SUPABASE_URL is not defined');
+const supabaseUrl = process.env.VITE_SUPABASE_URL;
+if (!supabaseUrl) throw new Error('VITE_SUPABASE_URL is not defined');
 const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 if (!serviceRoleKey)
   throw new Error('SUPABASE_SERVICE_ROLE_KEY is not defined');

--- a/api/update-profile.ts
+++ b/api/update-profile.ts
@@ -2,8 +2,8 @@ import { VercelRequest, VercelResponse } from '@vercel/node';
 import { createClient } from '@supabase/supabase-js';
 import { getUserFromRequest } from '../src/utils/auth.js';
 
-const supabaseUrl = process.env.SUPABASE_URL;
-if (!supabaseUrl) throw new Error('SUPABASE_URL is not defined');
+const supabaseUrl = process.env.VITE_SUPABASE_URL;
+if (!supabaseUrl) throw new Error('VITE_SUPABASE_URL is not defined');
 const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 if (!serviceRoleKey)
   throw new Error('SUPABASE_SERVICE_ROLE_KEY is not defined');

--- a/pages/api/stripe/webhook.ts
+++ b/pages/api/stripe/webhook.ts
@@ -6,8 +6,8 @@ import { Readable } from 'stream';
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || '', {
   apiVersion: '2024-04-10',
 });
-const supabaseUrl = process.env.SUPABASE_URL;
-if (!supabaseUrl) throw new Error('SUPABASE_URL is not defined');
+const supabaseUrl = process.env.VITE_SUPABASE_URL;
+if (!supabaseUrl) throw new Error('VITE_SUPABASE_URL is not defined');
 const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 if (!serviceRoleKey)
   throw new Error('SUPABASE_SERVICE_ROLE_KEY is not defined');

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -1,7 +1,7 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = process.env.SUPABASE_URL;
-if (!supabaseUrl) throw new Error('SUPABASE_URL is not defined');
+const supabaseUrl = process.env.VITE_SUPABASE_URL;
+if (!supabaseUrl) throw new Error('VITE_SUPABASE_URL is not defined');
 const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 if (!serviceRoleKey)
   throw new Error('SUPABASE_SERVICE_ROLE_KEY is not defined');

--- a/stripe/webhook.ts
+++ b/stripe/webhook.ts
@@ -6,8 +6,8 @@ import { Readable } from 'stream';
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || '', {
   apiVersion: '2024-04-10',
 });
-const supabaseUrl = process.env.SUPABASE_URL;
-if (!supabaseUrl) throw new Error('SUPABASE_URL is not defined');
+const supabaseUrl = process.env.VITE_SUPABASE_URL;
+if (!supabaseUrl) throw new Error('VITE_SUPABASE_URL is not defined');
 const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 if (!serviceRoleKey)
   throw new Error('SUPABASE_SERVICE_ROLE_KEY is not defined');


### PR DESCRIPTION
## Summary
- use `VITE_SUPABASE_URL` in API routes and auth helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856a570b9b8832db9d1381773c2e533