### PR TITLE
Fix AI image display via CSP

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,7 +5,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' https://js.stripe.com; frame-src https://js.stripe.com; style-src 'self' 'unsafe-inline'; connect-src *; img-src 'self' blob: data: https://*.supabase.co"
+          "value": "default-src 'self'; script-src 'self' https://js.stripe.com; frame-src https://js.stripe.com; style-src 'self' 'unsafe-inline'; connect-src *; img-src 'self' blob: data: https://*.supabase.co https://*.blob.core.windows.net"
         }
       ]
     }


### PR DESCRIPTION
## Summary
- allow OpenAI hosted images to load by adding blob.core.windows.net to CSP

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856aa9ed400832d8f8d9e466227f200