### PR TITLE
Afficher quotas IA pour VIP

### DIFF
--- a/src/components/RecipeFormAIFeatures.jsx
+++ b/src/components/RecipeFormAIFeatures.jsx
@@ -12,6 +12,7 @@ const RecipeFormAIFeatures = ({
   formData,
   handleDescriptionChange,
   descriptionRef,
+  iaUsage,
 }) => {
   console.log('RecipeFormAIFeatures subscription tier:', subscription_tier);
   return (
@@ -28,7 +29,11 @@ const RecipeFormAIFeatures = ({
           variant={subscription_tier === 'premium' ? 'premium' : 'tertiary'}
           size="sm"
           onClick={() => generateWithAI('description')}
-          disabled={isGeneratingDescription || !session}
+          disabled={
+            isGeneratingDescription ||
+            !session ||
+            (subscription_tier === 'vip' && (iaUsage?.text_requests ?? 0) >= 20)
+          }
           className="w-full sm:w-auto"
         >
           {isGeneratingDescription ? (
@@ -45,6 +50,11 @@ const RecipeFormAIFeatures = ({
               : 'Premium Description'}
         </Button>
       </div>
+      {subscription_tier === 'vip' && (
+        <p className="text-xs text-pastel-muted-foreground text-right">
+          Descriptions IA : {iaUsage?.text_requests ?? 0} / 20
+        </p>
+      )}
       <Textarea
         id="description-ai-features"
         ref={descriptionRef}

--- a/src/components/RecipeFormImageHandler.jsx
+++ b/src/components/RecipeFormImageHandler.jsx
@@ -20,6 +20,7 @@ const RecipeFormImageHandler = ({
   subscription_tier,
   generateWithAI,
   isGeneratingImage,
+  iaUsage,
 }) => {
   console.log('RecipeFormImageHandler subscription tier:', subscription_tier);
   return (
@@ -58,7 +59,11 @@ const RecipeFormImageHandler = ({
           type="button"
           variant={subscription_tier === 'premium' ? 'premium' : 'accent'}
           onClick={() => generateWithAI('image')}
-          disabled={isGeneratingImage || !session}
+          disabled={
+            isGeneratingImage ||
+            !session ||
+            (subscription_tier === 'vip' && (iaUsage?.image_requests ?? 0) >= 5)
+          }
           className="h-auto py-3"
         >
           {isGeneratingImage ? (
@@ -75,6 +80,11 @@ const RecipeFormImageHandler = ({
               : 'Premium Image'}
         </Button>
       </div>
+      {subscription_tier === 'vip' && (
+        <p className="text-xs text-pastel-muted-foreground text-right">
+          Images IA : {iaUsage?.image_requests ?? 0} / 5
+        </p>
+      )}
       {previewImage && (
         <div className="mt-3 aspect-video rounded-lg overflow-hidden border border-pastel-border bg-pastel-card-alt shadow-pastel-card-item">
           <img


### PR DESCRIPTION
## Summary
- add VIP IA usage fetching in `RecipeForm`
- disable generation buttons when VIP quota exceeded
- show description/image quota in `RecipeFormAIFeatures` and `RecipeFormImageHandler`

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6856ecd5d0e0832d8f03134758c98d21