### PR TITLE
Implement basic shared menu system

### DIFF
--- a/src/components/AppRoutes.jsx
+++ b/src/components/AppRoutes.jsx
@@ -10,6 +10,7 @@ import ShoppingList from '@/components/ShoppingList';
 import AccountPage from '@/components/AccountPage';
 import CommunityPage from '@/pages/CommunityPage';
 import UserProfilePage from '@/pages/UserProfilePage';
+import MenusPage from '@/pages/MenusPage.jsx';
 import LoadingScreen from '@/components/layout/LoadingScreen';
 import { PlusCircle } from 'lucide-react';
 import LoginPage from '@/pages/Login.jsx';
@@ -107,6 +108,10 @@ export default function AppRoutes({
             )}
           </div>
         }
+      />
+      <Route
+        path="/app/menus"
+        element={<MenusPage />}
       />
       <Route
         path="/app/menu"

--- a/src/components/layout/MainAppLayout.jsx
+++ b/src/components/layout/MainAppLayout.jsx
@@ -15,6 +15,7 @@ import {
   Sun,
   Star,
   Utensils,
+  List,
   Users,
 } from 'lucide-react';
 
@@ -100,6 +101,12 @@ export default function MainAppLayout({
                   label: 'Recettes',
                   icon: PlusCircle,
                   path: '/app/recipes',
+                },
+                {
+                  id: 'menus',
+                  label: 'Mes menus',
+                  icon: List,
+                  path: '/app/menus',
                 },
                 {
                   id: 'menu',

--- a/src/hooks/useMenus.js
+++ b/src/hooks/useMenus.js
@@ -1,0 +1,83 @@
+import { useState, useEffect } from 'react';
+import { supabase } from '@/lib/supabase';
+
+export function useMenus(session) {
+  const [menus, setMenus] = useState([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    const loadMenus = async () => {
+      if (!session?.user?.id) {
+        setMenus([]);
+        return;
+      }
+      setLoading(true);
+      try {
+        const { data: ownedMenus, error: ownedError } = await supabase
+          .from('menus')
+          .select('id, name, is_shared, owner_id, created_at')
+          .eq('owner_id', session.user.id);
+        if (ownedError) throw ownedError;
+
+        const { data: links, error: linkError } = await supabase
+          .from('menu_participants')
+          .select('menu_id')
+          .eq('user_id', session.user.id);
+        if (linkError) throw linkError;
+
+        const menuIds = Array.isArray(links) ? links.map((l) => l.menu_id) : [];
+        let participantMenus = [];
+        if (menuIds.length > 0) {
+          const { data: fetched, error: fetchError } = await supabase
+            .from('menus')
+            .select('id, name, is_shared, owner_id, created_at')
+            .in('id', menuIds);
+          if (fetchError) throw fetchError;
+          participantMenus = fetched || [];
+        }
+
+        const uniqueMap = new Map();
+        [...(ownedMenus || []), ...participantMenus].forEach((m) => {
+          if (m && m.id) uniqueMap.set(m.id, m);
+        });
+        setMenus(Array.from(uniqueMap.values()));
+      } catch (err) {
+        console.error('Error fetching menus:', err);
+        setMenus([]);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadMenus();
+  }, [session]);
+
+  const createMenu = async ({ name, isShared, participantIds = [] }) => {
+    if (!session?.user?.id || !name) return null;
+    setLoading(true);
+    try {
+      const { data: created, error } = await supabase
+        .from('menus')
+        .insert({ name, is_shared: !!isShared, owner_id: session.user.id })
+        .select()
+        .single();
+      if (error) throw error;
+
+      const menu = created;
+      const participantRows = [
+        { menu_id: menu.id, user_id: session.user.id },
+        ...participantIds.map((uid) => ({ menu_id: menu.id, user_id: uid })),
+      ];
+      await supabase.from('menu_participants').insert(participantRows);
+      setMenus((prev) => [menu, ...(Array.isArray(prev) ? prev : [])]);
+      return menu;
+    } catch (err) {
+      console.error('Error creating menu:', err);
+      return null;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return { menus, loading, createMenu };
+}

--- a/src/pages/MenusPage.jsx
+++ b/src/pages/MenusPage.jsx
@@ -1,0 +1,47 @@
+import React, { useState } from 'react';
+import { useMenus } from '@/hooks/useMenus.js';
+import { useSession } from '@/hooks/useSession.js';
+import { Button } from '@/components/ui/button.jsx';
+import { Input } from '@/components/ui/input.jsx';
+import { Checkbox } from '@/components/ui/checkbox.jsx';
+
+export default function MenusPage() {
+  const { session } = useSession();
+  const { menus, createMenu } = useMenus(session);
+  const [name, setName] = useState('');
+  const [isShared, setIsShared] = useState(false);
+
+  const handleCreate = async () => {
+    await createMenu({ name, isShared, participantIds: [] });
+    setName('');
+    setIsShared(false);
+  };
+
+  return (
+    <div className="space-y-6 w-full max-w-xl mx-auto">
+      <h2 className="text-2xl font-bold">Mes menus</h2>
+      <div className="flex flex-col gap-3 bg-pastel-card p-4 rounded-lg">
+        <Input
+          placeholder="Nom du menu"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+        <label className="flex items-center space-x-2">
+          <Checkbox checked={isShared} onCheckedChange={setIsShared} />
+          <span>Menu commun</span>
+        </label>
+        <Button onClick={handleCreate} disabled={!name.trim()}>
+          Créer le menu
+        </Button>
+      </div>
+      <div className="space-y-2">
+        {menus.map((m) => (
+          <div key={m.id} className="p-3 rounded border border-pastel-border">
+            <strong>{m.name}</strong>
+            {m.is_shared && <span className="ml-2 text-sm">(partagé)</span>}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/supabase/functions/create_shared_menu_tables.sql
+++ b/supabase/functions/create_shared_menu_tables.sql
@@ -1,0 +1,21 @@
+-- Schema setup for new shared menu system
+
+-- Create menus table
+create table if not exists public.menus (
+  id uuid primary key default uuid_generate_v4(),
+  owner_id uuid references auth.users(id) on delete cascade,
+  name text not null,
+  is_shared boolean default false,
+  created_at timestamp with time zone default now()
+);
+
+-- Junction table linking menus to participants
+create table if not exists public.menu_participants (
+  menu_id uuid references public.menus(id) on delete cascade,
+  user_id uuid references auth.users(id) on delete cascade,
+  primary key (menu_id, user_id)
+);
+
+-- Link weekly menus to a specific menu
+alter table if exists public.weekly_menus
+add column if not exists menu_id uuid references public.menus(id) on delete cascade;


### PR DESCRIPTION
## Summary
- add SQL script to create new tables for shared menus
- provide `useMenus` hook to load and create menus
- add menu list page with simple creation form
- integrate new page in routes and navigation

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6857e989eb74832db96a17c8c1fcee26