### PR TITLE
Add basic shared menu system

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -70,7 +70,7 @@ function App() {
 
   useEffect(() => {
     const currentPathTab = location.pathname.split('/app/')[1]?.split('/')[0];
-    const validTabs = ['recipes', 'menu', 'shopping', 'community', 'account'];
+    const validTabs = ['recipes', 'menus', 'menu', 'shopping', 'community', 'account'];
     if (validTabs.includes(currentPathTab)) {
       if (activeTab !== currentPathTab) {
         setActiveTab(currentPathTab);

--- a/src/components/AppRoutes.jsx
+++ b/src/components/AppRoutes.jsx
@@ -6,6 +6,7 @@ import ContactPage from '@/pages/legal/ContactPage';
 import RecipeForm from '@/components/RecipeForm';
 import RecipeList from '@/components/RecipeList';
 import MenuPlanner from '@/components/MenuPlanner';
+import MenusPage from '@/pages/MenusPage.jsx';
 import ShoppingList from '@/components/ShoppingList';
 import AccountPage from '@/components/AccountPage';
 import CommunityPage from '@/pages/CommunityPage';
@@ -107,6 +108,10 @@ export default function AppRoutes({
             )}
           </div>
         }
+      />
+      <Route
+        path="/app/menus"
+        element={<MenusPage session={session} />}
       />
       <Route
         path="/app/menu"

--- a/src/components/MenuPlanner.jsx
+++ b/src/components/MenuPlanner.jsx
@@ -4,7 +4,6 @@ import { RotateCw } from 'lucide-react';
 import MenuPreferencesModal from '@/components/menu_planner/MenuPreferencesModal.jsx';
 import WeeklyMenuView from '@/components/menu_planner/WeeklyMenuView.jsx';
 import { useMenuGeneration } from '@/hooks/useMenuGeneration.js';
-import { useLinkedUsers } from '@/hooks/useLinkedUsers.js';
 import { initialWeeklyMenuState } from '@/lib/menu';
 import {
   Dialog,
@@ -69,11 +68,6 @@ function MenuPlanner({
       weeklyBudget: 35,
       tagPreferences: [],
       servingsPerMeal: 4,
-      commonMenuSettings: {
-        enabled: false,
-        linkedUsers: [],
-        linkedUserRecipes: [],
-      },
     };
 
     const profilePrefs = userProfile?.preferences || {};
@@ -89,10 +83,6 @@ function MenuPlanner({
         initialPrefs = {
           ...initialPrefs,
           ...savedPrefs,
-          commonMenuSettings: {
-            ...initialPrefs.commonMenuSettings,
-            ...(savedPrefs.commonMenuSettings || {}),
-          },
         };
       } catch (e) {
         console.error('Error parsing saved menu preferences', e);
@@ -102,13 +92,6 @@ function MenuPlanner({
     if (initialPrefs.tolerance !== undefined) {
       delete initialPrefs.tolerance;
     }
-
-    initialPrefs.commonMenuSettings = {
-      ...defaultPreferences.commonMenuSettings,
-      ...(profilePrefs.commonMenuSettings || {}),
-      ...(initialPrefs.commonMenuSettings || {}),
-      linkedUserRecipes: [],
-    };
 
     return initialPrefs;
   });
@@ -140,11 +123,6 @@ function MenuPlanner({
     userProfile
   );
 
-  const linkedUserProps = useLinkedUsers(
-    userProfile,
-    preferences,
-    setPreferences
-  );
 
   const handleGenerateMenu = useCallback(() => {
     generateMenu();
@@ -163,7 +141,6 @@ function MenuPlanner({
             preferences={preferences}
             setPreferences={setPreferences}
             availableTags={availableTags}
-            linkedUserProps={linkedUserProps}
           />
           <Button
             onClick={handleGenerateMenu}

--- a/src/components/NewMenuModal.jsx
+++ b/src/components/NewMenuModal.jsx
@@ -1,0 +1,72 @@
+import React, { useState } from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter, DialogTrigger, DialogClose } from '@/components/ui/dialog.jsx';
+import { Button } from '@/components/ui/button.jsx';
+import { Input } from '@/components/ui/input.jsx';
+import { Checkbox } from '@/components/ui/Checkbox.jsx';
+
+function NewMenuModal({ onCreate, friends = [] }) {
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState('');
+  const [isShared, setIsShared] = useState(false);
+  const [selectedIds, setSelectedIds] = useState([]);
+
+  const toggleId = (id) => {
+    setSelectedIds((prev) =>
+      prev.includes(id) ? prev.filter((p) => p !== id) : [...prev, id]
+    );
+  };
+
+  const handleCreate = () => {
+    onCreate({ name, isShared, participantIds: selectedIds });
+    setName('');
+    setIsShared(false);
+    setSelectedIds([]);
+    setOpen(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button>Créer un menu</Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Nouveau menu</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4">
+          <Input
+            placeholder="Nom du menu"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+          <label className="flex items-center space-x-2">
+            <Checkbox checked={isShared} onChange={setIsShared} />
+            <span>Menu commun</span>
+          </label>
+          {isShared && (
+            <div className="space-y-2 max-h-40 overflow-y-auto p-2 border rounded-md">
+              {friends.map((f) => (
+                <label key={f.id} className="flex items-center space-x-2">
+                  <Checkbox
+                    checked={selectedIds.includes(f.id)}
+                    onChange={() => toggleId(f.id)}
+                  />
+                  <span>{f.username || f.id}</span>
+                </label>
+              ))}
+              {friends.length === 0 && <p className="text-sm">Aucun ami disponible</p>}
+            </div>
+          )}
+        </div>
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="outline">Annuler</Button>
+          </DialogClose>
+          <Button onClick={handleCreate}>Créer</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default NewMenuModal;

--- a/src/components/layout/MainAppLayout.jsx
+++ b/src/components/layout/MainAppLayout.jsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button';
 import {
   PlusCircle,
   Calendar,
+  ClipboardList,
   ShoppingCart,
   LogOut,
   LogIn,
@@ -100,6 +101,12 @@ export default function MainAppLayout({
                   label: 'Recettes',
                   icon: PlusCircle,
                   path: '/app/recipes',
+                },
+                {
+                  id: 'menus',
+                  label: 'Mes Menus',
+                  icon: ClipboardList,
+                  path: '/app/menus',
                 },
                 {
                   id: 'menu',

--- a/src/components/menu_planner/MenuPreferencesModal.jsx
+++ b/src/components/menu_planner/MenuPreferencesModal.jsx
@@ -20,17 +20,7 @@ function MenuPreferencesModal({
   preferences,
   setPreferences,
   availableTags,
-  linkedUserProps,
 }) {
-  const {
-    newLinkedUserTag,
-    setNewLinkedUserTag,
-    isLinkingUser,
-    handleAddLinkedUser,
-    handleToggleCommonMenu,
-    handleLinkedUserRatioChange,
-    handleRemoveLinkedUser,
-  } = linkedUserProps;
 
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
@@ -55,13 +45,6 @@ function MenuPreferencesModal({
             preferences={preferences}
             setPreferences={setPreferences}
             availableTags={availableTags}
-            newLinkedUserTag={newLinkedUserTag}
-            setNewLinkedUserTag={setNewLinkedUserTag}
-            isLinkingUser={isLinkingUser}
-            handleAddLinkedUser={handleAddLinkedUser}
-            handleToggleCommonMenu={handleToggleCommonMenu}
-            handleLinkedUserRatioChange={handleLinkedUserRatioChange}
-            handleRemoveLinkedUser={handleRemoveLinkedUser}
           />
         </ScrollArea>
         <DialogFooter>

--- a/src/components/menu_planner/MenuPreferencesPanel.jsx
+++ b/src/components/menu_planner/MenuPreferencesPanel.jsx
@@ -3,16 +3,12 @@ import { Button } from '@/components/ui/button.jsx';
 import { Input } from '@/components/ui/input.jsx';
 import { Label } from '@/components/ui/label.jsx';
 import { Switch } from '@/components/ui/switch.jsx';
-import { Slider } from '@/components/ui/slider.jsx';
 import {
   Plus,
   ChevronDown,
   ChevronUp,
   Trash2,
   Users,
-  Link,
-  Unlink,
-  Info,
 } from 'lucide-react';
 import { motion } from 'framer-motion';
 import {
@@ -26,20 +22,8 @@ import {
 } from '@/components/ui/dialog.jsx';
 import MealTypeSelector from '@/components/MealTypeSelector';
 import TagPreferencesForm from '@/components/menu_planner/TagPreferencesForm.jsx';
-import CommonMenuSettings from '@/components/menu_planner/CommonMenuSettings.jsx';
 
-function MenuPreferencesPanel({
-  preferences,
-  setPreferences,
-  availableTags,
-  newLinkedUserTag,
-  setNewLinkedUserTag,
-  isLinkingUser,
-  handleAddLinkedUser,
-  handleToggleCommonMenu,
-  handleLinkedUserRatioChange,
-  handleRemoveLinkedUser,
-}) {
+function MenuPreferencesPanel({ preferences, setPreferences, availableTags }) {
   const addMeal = () => {
     const newMealNumber = (preferences.meals?.length || 0) + 1;
     setPreferences({
@@ -183,16 +167,7 @@ function MenuPreferencesPanel({
         </div>
       </div>
 
-      <CommonMenuSettings
-        preferences={preferences}
-        newLinkedUserTag={newLinkedUserTag}
-        setNewLinkedUserTag={setNewLinkedUserTag}
-        isLinkingUser={isLinkingUser}
-        handleAddLinkedUser={handleAddLinkedUser}
-        handleToggleCommonMenu={handleToggleCommonMenu}
-        handleLinkedUserRatioChange={handleLinkedUserRatioChange}
-        handleRemoveLinkedUser={handleRemoveLinkedUser}
-      />
+
 
       <div className="space-y-4 pt-4 border-t border-pastel-border/70">
         <div className="flex justify-between items-center">

--- a/src/components/menu_planner/WeeklyMenuView.jsx
+++ b/src/components/menu_planner/WeeklyMenuView.jsx
@@ -92,17 +92,7 @@ function WeeklyMenuView({
       ? mealPreference.types
       : [];
 
-    let recipesToFilter = [...safeRecipes];
-    if (
-      preferences.commonMenuSettings.enabled &&
-      Array.isArray(preferences.commonMenuSettings.linkedUserRecipes) &&
-      preferences.commonMenuSettings.linkedUserRecipes.length > 0
-    ) {
-      recipesToFilter = [
-        ...recipesToFilter,
-        ...preferences.commonMenuSettings.linkedUserRecipes,
-      ];
-    }
+    const recipesToFilter = [...safeRecipes];
 
     const uniqueRecipeMap = new Map();
     recipesToFilter.forEach((r) => {
@@ -128,7 +118,6 @@ function WeeklyMenuView({
     recipeToReplaceInfo,
     searchTermModal,
     preferences.meals,
-    preferences.commonMenuSettings,
   ]);
 
   const totalMenuCost = useMemo(

--- a/src/hooks/useFriendsList.js
+++ b/src/hooks/useFriendsList.js
@@ -1,0 +1,40 @@
+import { useEffect, useState } from 'react';
+import { supabase } from '@/lib/supabase';
+
+export function useFriendsList(session) {
+  const [friends, setFriends] = useState([]);
+
+  useEffect(() => {
+    const fetchFriends = async () => {
+      if (!session?.user?.id) return;
+      const { data: relationships, error } = await supabase
+        .from('user_relationships')
+        .select('requester_id, addressee_id')
+        .eq('status', 'accepted')
+        .or(`requester_id.eq.${session.user.id},addressee_id.eq.${session.user.id}`);
+      if (error) {
+        console.error('Error fetching friends:', error);
+        return;
+      }
+      const ids = [
+        ...new Set(
+          relationships.map((r) =>
+            r.requester_id === session.user.id ? r.addressee_id : r.requester_id
+          )
+        ),
+      ];
+      if (ids.length === 0) {
+        setFriends([]);
+        return;
+      }
+      const { data: users } = await supabase
+        .from('public_users')
+        .select('id, username')
+        .in('id', ids);
+      setFriends(users || []);
+    };
+    fetchFriends();
+  }, [session]);
+
+  return friends;
+}

--- a/src/hooks/useMenus.js
+++ b/src/hooks/useMenus.js
@@ -1,0 +1,52 @@
+import { useState, useEffect } from 'react';
+
+export function useMenus() {
+  const [menus, setMenus] = useState([]);
+  const [activeMenuId, setActiveMenuId] = useState(null);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('menus');
+    if (stored) {
+      try {
+        const parsed = JSON.parse(stored);
+        if (Array.isArray(parsed) && parsed.length > 0) {
+          setMenus(parsed);
+          setActiveMenuId(parsed[0].id);
+          return;
+        }
+      } catch (e) {
+        console.error('Failed to parse menus from storage', e);
+      }
+    }
+    const defaultMenu = {
+      id: 'menu-' + Date.now(),
+      name: 'Menu personnel',
+      isShared: false,
+      participantIds: [],
+      preferences: {},
+    };
+    setMenus([defaultMenu]);
+    setActiveMenuId(defaultMenu.id);
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem('menus', JSON.stringify(menus));
+  }, [menus]);
+
+  const createMenu = ({ name, isShared, participantIds }) => {
+    const newMenu = {
+      id: 'menu-' + Date.now(),
+      name: name || 'Nouveau menu',
+      isShared: !!isShared,
+      participantIds: Array.isArray(participantIds) ? participantIds : [],
+      preferences: {},
+    };
+    setMenus((prev) => [...prev, newMenu]);
+    setActiveMenuId(newMenu.id);
+    return newMenu;
+  };
+
+  const activeMenu = menus.find((m) => m.id === activeMenuId) || null;
+
+  return { menus, activeMenu, activeMenuId, setActiveMenuId, createMenu };
+}

--- a/src/pages/MenusPage.jsx
+++ b/src/pages/MenusPage.jsx
@@ -1,14 +1,36 @@
-import React, { useState } from 'react';
-import { Checkbox } from '@/components/ui/Checkbox';
+import React from 'react';
+import { useMenus } from '@/hooks/useMenus.js';
+import { useFriendsList } from '@/hooks/useFriendsList.js';
+import NewMenuModal from '@/components/NewMenuModal.jsx';
+import { Button } from '@/components/ui/button.jsx';
 
-export default function MenusPage() {
-  const [checked, setChecked] = useState(false);
+export default function MenusPage({ session }) {
+  const { menus, activeMenuId, setActiveMenuId, createMenu } = useMenus();
+  const friends = useFriendsList(session);
+
   return (
-    <div className="p-6 space-x-2">
-      <label className="flex items-center space-x-2">
-        <Checkbox checked={checked} onChange={setChecked} />
-        <span>Activer une option</span>
-      </label>
+    <div className="p-6 space-y-4">
+      <div className="flex justify-between items-center">
+        <h2 className="text-2xl font-bold">Mes menus</h2>
+        <NewMenuModal onCreate={createMenu} friends={friends} />
+      </div>
+      <ul className="space-y-2">
+        {menus.map((m) => (
+          <li key={m.id} className="flex items-center justify-between bg-pastel-card p-3 rounded-md">
+            <span>
+              {m.name}
+              {m.isShared && ' (commun)'}
+            </span>
+            {activeMenuId === m.id ? (
+              <span className="text-sm">Actif</span>
+            ) : (
+              <Button size="sm" onClick={() => setActiveMenuId(m.id)}>
+                Activer
+              </Button>
+            )}
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add `useMenus` and `useFriendsList` hooks
- add `NewMenuModal` and `MenusPage` for managing menus
- update navigation with new **Mes Menus** tab
- remove old common menu preferences

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857f0f31d38832d8bd45da86e3366a2