### PR TITLE
Fix user_tag queries to use public_users

### DIFF
--- a/src/components/account/ProfileInformationForm.jsx
+++ b/src/components/account/ProfileInformationForm.jsx
@@ -114,7 +114,7 @@ export default function ProfileInformationForm({
 
   const checkTagAvailability = async (tag) => {
     const { data, error } = await supabase
-      .from('user_links')
+      .from('public_users')
       .select('id')
       .eq('user_tag', tag);
     if (error) {
@@ -144,7 +144,7 @@ export default function ProfileInformationForm({
     setLoading(true);
     try {
       const { data, error: checkError } = await supabase
-        .from('user_links')
+        .from('public_users')
         .select('id')
         .eq('user_tag', trimmed);
       if (checkError) throw checkError;
@@ -154,7 +154,7 @@ export default function ProfileInformationForm({
         return;
       }
       const { error } = await supabase
-        .from('user_links')
+        .from('public_users')
         .update({ user_tag: trimmed })
         .eq('id', session.user.id);
       if (error) throw error;


### PR DESCRIPTION
## Summary
- centralize user_tag lookups in the `public_users` table

## Testing
- `npm test`
- `npm run lint` *(fails: many prop-type errors)*

------
https://chatgpt.com/codex/tasks/task_e_6857f1ea5204832d9c077cde07fb0643