### PR TITLE
Unify menu page with tabs

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,6 +11,7 @@ import MainAppLayout from '@/components/layout/MainAppLayout';
 import LoadingScreen from '@/components/layout/LoadingScreen';
 import { useRecipes } from '@/hooks/useRecipes.jsx';
 import { useWeeklyMenu } from '@/hooks/useWeeklyMenu.js';
+import { useMenus } from '@/hooks/useMenus.js';
 import { useSession } from '@/hooks/useSession.js';
 import { useUserProfile } from '@/hooks/useUserProfile.js';
 import { usePendingFriendRequests } from '@/hooks/usePendingFriendRequests.js';
@@ -57,10 +58,17 @@ function App() {
   } = useRecipes(session, userProfile?.subscription_tier);
 
   const {
+    menus,
+    activeMenuId,
+    setActiveMenuId,
+    createMenu,
+  } = useMenus();
+
+  const {
     weeklyMenu,
     setWeeklyMenu: saveUserWeeklyMenuHook,
     loading: weeklyMenuLoading,
-  } = useWeeklyMenu(session);
+  } = useWeeklyMenu(session, activeMenuId);
 
   const { pendingCount, refreshPendingFriendRequests } =
     usePendingFriendRequests(session);
@@ -70,7 +78,7 @@ function App() {
 
   useEffect(() => {
     const currentPathTab = location.pathname.split('/app/')[1]?.split('/')[0];
-    const validTabs = ['recipes', 'menus', 'menu', 'shopping', 'community', 'account'];
+    const validTabs = ['recipes', 'menu', 'shopping', 'community', 'account'];
     if (validTabs.includes(currentPathTab)) {
       if (activeTab !== currentPathTab) {
         setActiveTab(currentPathTab);
@@ -155,8 +163,13 @@ function App() {
           userProfile={userProfile}
           recipes={recipes}
           recipesLoading={recipesLoading}
+          menus={menus}
+          activeMenuId={activeMenuId}
+          setActiveMenuId={setActiveMenuId}
+          createMenu={createMenu}
           weeklyMenu={weeklyMenu}
           weeklyMenuLoading={weeklyMenuLoading}
+          saveUserWeeklyMenuHook={saveUserWeeklyMenuHook}
           showRecipeForm={showRecipeForm}
           editingRecipe={editingRecipe}
           openRecipeFormForAdd={openRecipeForm}
@@ -164,7 +177,6 @@ function App() {
           handleAddRecipeSubmit={handleAddRecipeSubmit}
           handleEditRecipeSubmit={handleEditRecipeSubmit}
           deleteRecipeHook={deleteRecipeHook}
-          saveUserWeeklyMenuHook={saveUserWeeklyMenuHook}
           setEditingRecipe={setEditingRecipe}
           setSelectedRecipeForDetail={setSelectedRecipeForDetail}
           handleProfileUpdated={handleProfileUpdated}

--- a/src/components/AppRoutes.jsx
+++ b/src/components/AppRoutes.jsx
@@ -5,8 +5,7 @@ import PrivacyPolicy from '@/pages/legal/PrivacyPolicy';
 import ContactPage from '@/pages/legal/ContactPage';
 import RecipeForm from '@/components/RecipeForm';
 import RecipeList from '@/components/RecipeList';
-import MenuPlanner from '@/components/MenuPlanner';
-import MenusPage from '@/pages/MenusPage.jsx';
+import MenuPage from '@/pages/MenuPage.jsx';
 import ShoppingList from '@/components/ShoppingList';
 import AccountPage from '@/components/AccountPage';
 import CommunityPage from '@/pages/CommunityPage';
@@ -20,6 +19,10 @@ export default function AppRoutes({
   userProfile,
   recipes,
   recipesLoading,
+  menus,
+  activeMenuId,
+  setActiveMenuId,
+  createMenu,
   weeklyMenu,
   weeklyMenuLoading,
   showRecipeForm,
@@ -110,10 +113,6 @@ export default function AppRoutes({
         }
       />
       <Route
-        path="/app/menus"
-        element={<MenusPage session={session} />}
-      />
-      <Route
         path="/app/menu"
         element={
           session &&
@@ -121,11 +120,16 @@ export default function AppRoutes({
           isMenuDataEmpty(weeklyMenu) ? (
             <LoadingScreen message="Chargement du menu..." />
           ) : session ? (
-            <MenuPlanner
+            <MenuPage
+              session={session}
+              userProfile={userProfile}
               recipes={recipes}
+              menus={menus}
+              activeMenuId={activeMenuId}
+              setActiveMenuId={setActiveMenuId}
+              createMenu={createMenu}
               weeklyMenu={weeklyMenu}
               setWeeklyMenu={saveUserWeeklyMenuHook}
-              userProfile={userProfile}
             />
           ) : (
             <Navigate to="/app/recipes" replace />

--- a/src/components/NewMenuModal.jsx
+++ b/src/components/NewMenuModal.jsx
@@ -4,7 +4,7 @@ import { Button } from '@/components/ui/button.jsx';
 import { Input } from '@/components/ui/input.jsx';
 import { Checkbox } from '@/components/ui/Checkbox.jsx';
 
-function NewMenuModal({ onCreate, friends = [] }) {
+function NewMenuModal({ onCreate, friends = [], trigger }) {
   const [open, setOpen] = useState(false);
   const [name, setName] = useState('');
   const [isShared, setIsShared] = useState(false);
@@ -27,7 +27,7 @@ function NewMenuModal({ onCreate, friends = [] }) {
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
-        <Button>Créer un menu</Button>
+        {trigger || <Button>Créer un menu</Button>}
       </DialogTrigger>
       <DialogContent className="max-w-md">
         <DialogHeader>

--- a/src/pages/MenuPage.jsx
+++ b/src/pages/MenuPage.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs.jsx';
+import MenuPlanner from '@/components/MenuPlanner';
+import NewMenuModal from '@/components/NewMenuModal.jsx';
+import { useFriendsList } from '@/hooks/useFriendsList.js';
+
+export default function MenuPage({
+  session,
+  userProfile,
+  recipes,
+  menus,
+  activeMenuId,
+  setActiveMenuId,
+  createMenu,
+  weeklyMenu,
+  setWeeklyMenu,
+}) {
+  const friends = useFriendsList(session);
+
+  return (
+    <div className="p-6 space-y-4">
+      <Tabs value={activeMenuId} onValueChange={setActiveMenuId}>
+        <TabsList className="flex flex-wrap gap-2 overflow-x-auto">
+          {menus.map((m) => (
+            <TabsTrigger key={m.id} value={m.id} className="whitespace-nowrap">
+              {m.name}
+              {m.isShared && ' (commun)'}
+            </TabsTrigger>
+          ))}
+          <NewMenuModal
+            onCreate={createMenu}
+            friends={friends}
+            trigger={<TabsTrigger value="new">+ Nouveau menu</TabsTrigger>}
+          />
+        </TabsList>
+        {menus.map((m) => (
+          <TabsContent key={m.id} value={m.id} className="mt-4">
+            {activeMenuId === m.id && (
+              <MenuPlanner
+                recipes={recipes}
+                weeklyMenu={weeklyMenu}
+                setWeeklyMenu={setWeeklyMenu}
+                userProfile={userProfile}
+              />
+            )}
+          </TabsContent>
+        ))}
+        <TabsContent value="new" />
+      </Tabs>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add new MenuPage with tabs to switch between personal and shared menus
- allow NewMenuModal to specify custom trigger element
- track weekly menus per menu ID
- expose menu state in App and route to MenuPage

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6857fa1c280c832dbc858703215def10