### PR TITLE
Implement menu rename feature

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -62,6 +62,7 @@ function App() {
     activeMenuId,
     setActiveMenuId,
     createMenu,
+    renameMenu,
   } = useMenus();
 
   const {
@@ -167,6 +168,7 @@ function App() {
           activeMenuId={activeMenuId}
           setActiveMenuId={setActiveMenuId}
           createMenu={createMenu}
+          renameMenu={renameMenu}
           weeklyMenu={weeklyMenu}
           weeklyMenuLoading={weeklyMenuLoading}
           saveUserWeeklyMenuHook={saveUserWeeklyMenuHook}

--- a/src/components/AppRoutes.jsx
+++ b/src/components/AppRoutes.jsx
@@ -24,6 +24,7 @@ export default function AppRoutes({
   activeMenuId,
   setActiveMenuId,
   createMenu,
+  renameMenu,
   weeklyMenu,
   weeklyMenuLoading,
   showRecipeForm,
@@ -133,6 +134,7 @@ export default function AppRoutes({
               activeMenuId={activeMenuId}
               setActiveMenuId={setActiveMenuId}
               createMenu={createMenu}
+              renameMenu={renameMenu}
               weeklyMenu={weeklyMenu}
               setWeeklyMenu={saveUserWeeklyMenuHook}
             />

--- a/src/hooks/useMenus.js
+++ b/src/hooks/useMenus.js
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { supabase } from '@/lib/supabase';
 
 export function useMenus() {
   const [menus, setMenus] = useState([]);
@@ -46,7 +47,28 @@ export function useMenus() {
     return newMenu;
   };
 
+  const renameMenu = async (menuId, newName) => {
+    setMenus((prev) =>
+      prev.map((m) => (m.id === menuId ? { ...m, name: newName } : m))
+    );
+    try {
+      await supabase
+        .from('weekly_menus')
+        .update({ name: newName })
+        .eq('id', menuId);
+    } catch (error) {
+      console.error('Failed to rename menu:', error);
+    }
+  };
+
   const activeMenu = menus.find((m) => m.id === activeMenuId) || null;
 
-  return { menus, activeMenu, activeMenuId, setActiveMenuId, createMenu };
+  return {
+    menus,
+    activeMenu,
+    activeMenuId,
+    setActiveMenuId,
+    createMenu,
+    renameMenu,
+  };
 }

--- a/src/pages/MenuPage.jsx
+++ b/src/pages/MenuPage.jsx
@@ -1,8 +1,10 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs.jsx';
 import MenuPlanner from '@/components/MenuPlanner';
 import NewMenuModal from '@/components/NewMenuModal.jsx';
 import { useFriendsList } from '@/hooks/useFriendsList.js';
+import { Input } from '@/components/ui/input.jsx';
+import { Edit2 } from 'lucide-react';
 
 export default function MenuPage({
   session,
@@ -12,19 +14,72 @@ export default function MenuPage({
   activeMenuId,
   setActiveMenuId,
   createMenu,
+  renameMenu,
   weeklyMenu,
   setWeeklyMenu,
 }) {
   const friends = useFriendsList(session);
+  const [editingId, setEditingId] = useState(null);
+  const [editName, setEditName] = useState('');
+
+  const startEdit = (menu) => {
+    setEditingId(menu.id);
+    setEditName(menu.name || '');
+  };
+
+  const submitEdit = async () => {
+    if (!editingId) return;
+    const trimmed = editName.trim();
+    if (trimmed) {
+      await renameMenu(editingId, trimmed);
+    }
+    setEditingId(null);
+  };
 
   return (
     <div className="p-6 space-y-4">
       <Tabs value={activeMenuId} onValueChange={setActiveMenuId}>
         <TabsList className="flex flex-wrap gap-2 overflow-x-auto">
           {menus.map((m) => (
-            <TabsTrigger key={m.id} value={m.id} className="whitespace-nowrap">
-              {m.name}
-              {m.isShared && ' (commun)'}
+            <TabsTrigger
+              key={m.id}
+              value={m.id}
+              className="whitespace-nowrap flex items-center gap-1"
+            >
+              {editingId === m.id ? (
+                <Input
+                  value={editName}
+                  onChange={(e) => setEditName(e.target.value)}
+                  onBlur={submitEdit}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      e.preventDefault();
+                      submitEdit();
+                    } else if (e.key === 'Escape') {
+                      setEditingId(null);
+                    }
+                  }}
+                  className="h-6 px-1 py-0 text-sm"
+                />
+              ) : (
+                <>
+                  <span>
+                    {m.name}
+                    {m.isShared && ' (commun)'}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      startEdit(m);
+                    }}
+                    className="ml-1 text-xs hover:text-pastel-foreground"
+                  >
+                    <Edit2 className="w-3 h-3" />
+                  </button>
+                </>
+              )}
             </TabsTrigger>
           ))}
           <NewMenuModal


### PR DESCRIPTION
## Summary
- allow editing of menu names inline
- push updated names to supabase
- pass renameMenu handler through App into MenuPage

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_68582360e238832dbc59c367ccf5b8a2