### PR TITLE
Add menu deletion with confirmation

### DIFF
--- a/src/pages/MenusPage.jsx
+++ b/src/pages/MenusPage.jsx
@@ -1,22 +1,30 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState, useCallback } from 'react';
 import { supabase } from '@/lib/supabase';
 import NewMenuModal from '@/components/NewMenuModal.jsx';
 import { Button } from '@/components/ui/button.jsx';
 
-function MenuCard({ menu, isActive, onActivate }) {
+function MenuCard({ menu, isActive, onActivate, onDelete }) {
   return (
     <li className="flex items-center justify-between bg-pastel-card p-3 rounded-md">
       <span>
         {menu.name}
         {menu.is_shared && ' (commun)'}
       </span>
-      {isActive ? (
-        <span className="text-sm">Actif</span>
-      ) : (
-        <Button size="sm" onClick={() => onActivate(menu.id)}>
-          Activer
-        </Button>
-      )}
+      <div className="flex items-center gap-2">
+        {isActive ? (
+          <span className="text-sm">Actif</span>
+        ) : (
+          <Button size="sm" onClick={() => onActivate(menu.id)}>
+            Activer
+          </Button>
+        )}
+        <button
+          className="text-red-600 hover:bg-red-100 rounded px-2"
+          onClick={() => onDelete(menu.id)}
+        >
+          ×
+        </button>
+      </div>
     </li>
   );
 }
@@ -27,29 +35,35 @@ export default function MenusPage({ session }) {
   const [participatingMenus, setParticipatingMenus] = useState([]);
   const [activeMenuId, setActiveMenuId] = useState(null);
 
-  useEffect(() => {
-    if (!userId) return;
+  const fetchMenus = useCallback(async () => {
+    if (!userId) return { created: [], participants: [] };
 
-    supabase
+    const { data: created } = await supabase
       .from('weekly_menus')
       .select('*')
-      .eq('user_id', userId)
-      .then(({ data }) => {
-        setCreatedMenus(data || []);
-        if (data && data.length > 0 && !activeMenuId) {
-          setActiveMenuId(data[0].id);
-        }
-      });
+      .eq('user_id', userId);
 
-    supabase
+    const { data: partData } = await supabase
       .from('menu_participants')
       .select('menu_id, weekly_menus(*)')
-      .eq('user_id', userId)
-      .then(({ data }) => {
-        const menus = data?.map((d) => d.weekly_menus).filter(Boolean) || [];
-        setParticipatingMenus(menus);
-      });
+      .eq('user_id', userId);
+
+    const partMenus = partData?.map((d) => d.weekly_menus).filter(Boolean) || [];
+
+    setCreatedMenus(created || []);
+    setParticipatingMenus(partMenus);
+
+    return { created: created || [], participants: partMenus };
   }, [userId]);
+
+  useEffect(() => {
+    if (!userId) return;
+    fetchMenus().then(({ created }) => {
+      if (created.length > 0 && !activeMenuId) {
+        setActiveMenuId(created[0].id);
+      }
+    });
+  }, [userId, activeMenuId, fetchMenus]);
 
   const allMenus = useMemo(() => {
     const ids = new Set();
@@ -59,6 +73,19 @@ export default function MenusPage({ session }) {
       return true;
     });
   }, [createdMenus, participatingMenus]);
+
+  const handleDelete = async (menuId) => {
+    if (!confirm('Es-tu sûr de vouloir supprimer ce menu ?')) return;
+
+    await supabase.from('weekly_menus').delete().eq('id', menuId);
+
+    const { created, participants } = await fetchMenus();
+    const combined = [...created, ...participants];
+
+    if (activeMenuId === menuId) {
+      setActiveMenuId(combined[0]?.id || null);
+    }
+  };
 
   return (
     <div className="p-6 space-y-4">
@@ -73,6 +100,7 @@ export default function MenusPage({ session }) {
             menu={m}
             isActive={activeMenuId === m.id}
             onActivate={setActiveMenuId}
+            onDelete={handleDelete}
           />
         ))}
       </ul>


### PR DESCRIPTION
## Summary
- add delete button on menu cards
- refactor menu loading logic
- delete weekly menus via Supabase and refresh list

## Testing
- `npm run lint` *(fails: 524 errors)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68582375ff58832d82c9b1105270a211