### PR TITLE
Implement menu renaming

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -58,7 +58,9 @@ function App() {
 
   const {
     weeklyMenu,
+    menuName,
     setWeeklyMenu: saveUserWeeklyMenuHook,
+    updateMenuName,
     loading: weeklyMenuLoading,
   } = useWeeklyMenu(session);
 
@@ -156,8 +158,10 @@ function App() {
           recipes={recipes}
           recipesLoading={recipesLoading}
           weeklyMenu={weeklyMenu}
+          menuName={menuName}
           weeklyMenuLoading={weeklyMenuLoading}
           saveUserWeeklyMenuHook={saveUserWeeklyMenuHook}
+          updateMenuName={updateMenuName}
           showRecipeForm={showRecipeForm}
           editingRecipe={editingRecipe}
           openRecipeFormForAdd={openRecipeForm}

--- a/src/components/AppRoutes.jsx
+++ b/src/components/AppRoutes.jsx
@@ -20,6 +20,7 @@ export default function AppRoutes({
   recipes,
   recipesLoading,
   weeklyMenu,
+  menuName,
   weeklyMenuLoading,
   showRecipeForm,
   editingRecipe,
@@ -33,6 +34,7 @@ export default function AppRoutes({
   setSelectedRecipeForDetail,
   handleProfileUpdated,
   refreshPendingFriendRequests,
+  updateMenuName,
 }) {
   const recipePageTitle = useMemo(() => {
     if (
@@ -123,6 +125,8 @@ export default function AppRoutes({
               recipes={recipes}
               weeklyMenu={weeklyMenu}
               setWeeklyMenu={saveUserWeeklyMenuHook}
+              menuName={menuName}
+              updateMenuName={updateMenuName}
             />
           ) : (
             <Navigate to="/app/recipes" replace />

--- a/src/components/MenuPlanner.jsx
+++ b/src/components/MenuPlanner.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { Button } from '@/components/ui/button.jsx';
-import { RotateCw } from 'lucide-react';
+import { RotateCw, Pencil } from 'lucide-react';
 import MenuPreferencesModal from '@/components/menu_planner/MenuPreferencesModal.jsx';
 import WeeklyMenuView from '@/components/menu_planner/WeeklyMenuView.jsx';
 import { useMenuGeneration } from '@/hooks/useMenuGeneration.js';
@@ -22,6 +22,8 @@ function MenuPlanner({
   weeklyMenu: propWeeklyMenu,
   setWeeklyMenu,
   userProfile,
+  menuName,
+  onUpdateMenuName,
 }) {
   const [internalWeeklyMenu, setInternalWeeklyMenu] = useState(
     Array.isArray(propWeeklyMenu) && propWeeklyMenu.length === 7
@@ -29,6 +31,12 @@ function MenuPlanner({
       : initialWeeklyMenuState()
   );
   const [isPreferencesModalOpen, setIsPreferencesModalOpen] = useState(false);
+  const [isEditingName, setIsEditingName] = useState(false);
+  const [tempName, setTempName] = useState(menuName || '');
+
+  useEffect(() => {
+    setTempName(menuName || '');
+  }, [menuName]);
 
   useEffect(() => {
     setInternalWeeklyMenu(
@@ -128,11 +136,47 @@ function MenuPlanner({
     generateMenu();
   }, [generateMenu]);
 
+  const submitNameChange = async () => {
+    if (!tempName.trim()) {
+      setTempName(menuName || '');
+      setIsEditingName(false);
+      return;
+    }
+    const success = await onUpdateMenuName?.(tempName.trim());
+    if (success !== false) {
+      setIsEditingName(false);
+    }
+  };
+
   return (
     <div className="space-y-8">
       <div className="flex flex-col sm:flex-row justify-between items-center gap-4 bg-pastel-card p-6 rounded-xl shadow-pastel-soft">
-        <h2 className="text-2xl sm:text-3xl font-bold text-pastel-primary">
-          Menu de la semaine
+        <h2 className="text-2xl sm:text-3xl font-bold text-pastel-primary flex items-center gap-2">
+          {isEditingName ? (
+            <input
+              value={tempName}
+              onChange={(e) => setTempName(e.target.value)}
+              onBlur={submitNameChange}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') submitNameChange();
+                if (e.key === 'Escape') {
+                  setTempName(menuName || '');
+                  setIsEditingName(false);
+                }
+              }}
+              className="bg-transparent border-b border-pastel-border focus:outline-none text-2xl sm:text-3xl font-bold"
+            />
+          ) : (
+            <>
+              <span>{menuName || 'Menu de la semaine'}</span>
+              <button
+                onClick={() => setIsEditingName(true)}
+                className="text-pastel-muted-foreground hover:text-pastel-primary"
+              >
+                <Pencil className="w-4 h-4" />
+              </button>
+            </>
+          )}
         </h2>
         <div className="flex flex-wrap gap-3">
           <MenuPreferencesModal

--- a/src/pages/MenuPage.jsx
+++ b/src/pages/MenuPage.jsx
@@ -7,6 +7,8 @@ export default function MenuPage({
   recipes,
   weeklyMenu,
   setWeeklyMenu,
+  menuName,
+  updateMenuName,
 }) {
   return (
     <div className="p-6">
@@ -15,6 +17,8 @@ export default function MenuPage({
         weeklyMenu={weeklyMenu}
         setWeeklyMenu={setWeeklyMenu}
         userProfile={userProfile}
+        menuName={menuName}
+        onUpdateMenuName={updateMenuName}
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- add menu name state and update functions in `useWeeklyMenu`
- expose menu name editing through `MenuPlanner`
- thread new props from `App` down to `MenuPage` and `AppRoutes`

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685827865368832d86ce3da79a75cdd7