### PR TITLE
Implement menu deletion

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -61,6 +61,7 @@ function App() {
     menuName,
     setWeeklyMenu: saveUserWeeklyMenuHook,
     updateMenuName,
+    deleteMenu: deleteWeeklyMenu,
     loading: weeklyMenuLoading,
   } = useWeeklyMenu(session);
 
@@ -162,6 +163,7 @@ function App() {
           weeklyMenuLoading={weeklyMenuLoading}
           saveUserWeeklyMenuHook={saveUserWeeklyMenuHook}
           updateMenuName={updateMenuName}
+          deleteMenu={deleteWeeklyMenu}
           showRecipeForm={showRecipeForm}
           editingRecipe={editingRecipe}
           openRecipeFormForAdd={openRecipeForm}

--- a/src/components/AppRoutes.jsx
+++ b/src/components/AppRoutes.jsx
@@ -35,6 +35,7 @@ export default function AppRoutes({
   handleProfileUpdated,
   refreshPendingFriendRequests,
   updateMenuName,
+  deleteMenu,
 }) {
   const recipePageTitle = useMemo(() => {
     if (
@@ -127,6 +128,7 @@ export default function AppRoutes({
               setWeeklyMenu={saveUserWeeklyMenuHook}
               menuName={menuName}
               updateMenuName={updateMenuName}
+              deleteMenu={deleteMenu}
             />
           ) : (
             <Navigate to="/app/recipes" replace />

--- a/src/components/MenuPlanner.jsx
+++ b/src/components/MenuPlanner.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { Button } from '@/components/ui/button.jsx';
-import { RotateCw, Pencil } from 'lucide-react';
+import { RotateCw, Pencil, X } from 'lucide-react';
 import MenuPreferencesModal from '@/components/menu_planner/MenuPreferencesModal.jsx';
 import WeeklyMenuView from '@/components/menu_planner/WeeklyMenuView.jsx';
 import { useMenuGeneration } from '@/hooks/useMenuGeneration.js';
@@ -24,6 +24,7 @@ function MenuPlanner({
   userProfile,
   menuName,
   onUpdateMenuName,
+  onDeleteMenu,
 }) {
   const [internalWeeklyMenu, setInternalWeeklyMenu] = useState(
     Array.isArray(propWeeklyMenu) && propWeeklyMenu.length === 7
@@ -148,6 +149,15 @@ function MenuPlanner({
     }
   };
 
+  const handleDeleteMenu = async () => {
+    if (!onDeleteMenu) return;
+    const confirmed = window.confirm(
+      'Es-tu sûr de vouloir supprimer ce menu ?'
+    );
+    if (!confirmed) return;
+    await onDeleteMenu();
+  };
+
   return (
     <div className="space-y-8">
       <div className="flex flex-col sm:flex-row justify-between items-center gap-4 bg-pastel-card p-6 rounded-xl shadow-pastel-soft">
@@ -174,6 +184,13 @@ function MenuPlanner({
                 className="text-pastel-muted-foreground hover:text-pastel-primary"
               >
                 <Pencil className="w-4 h-4" />
+              </button>
+              <button
+                onClick={handleDeleteMenu}
+                className="text-destructive/70 hover:text-destructive hover:bg-destructive/20 rounded-full p-1"
+                title="Supprimer le menu"
+              >
+                <X className="w-4 h-4" />
               </button>
             </>
           )}

--- a/src/hooks/useWeeklyMenu.js
+++ b/src/hooks/useWeeklyMenu.js
@@ -193,17 +193,41 @@ export function useWeeklyMenu(session) {
           description: 'Impossible de renommer le menu: ' + err.message,
           variant: 'destructive',
         });
-        return false;
-      }
-    },
-    [userId, menuId, fetchUserWeeklyMenu, toast]
-  );
+      return false;
+    }
+  },
+  [userId, menuId, fetchUserWeeklyMenu, toast]
+);
+
+  const deleteWeeklyMenu = useCallback(async () => {
+    if (!userId || !menuId) return false;
+    try {
+      const { error } = await supabase
+        .from('weekly_menus')
+        .delete()
+        .eq('id', menuId);
+
+      if (error) throw error;
+      await fetchUserWeeklyMenu();
+      toast({ title: 'Menu supprimé' });
+      return true;
+    } catch (err) {
+      console.error('Error deleting menu:', err);
+      toast({
+        title: 'Erreur',
+        description: 'Impossible de supprimer le menu: ' + err.message,
+        variant: 'destructive',
+      });
+      return false;
+    }
+  }, [userId, menuId, fetchUserWeeklyMenu, toast]);
 
   return {
     weeklyMenu,
     menuName,
     setWeeklyMenu: saveWeeklyMenuToSupabase,
     updateMenuName: updateWeeklyMenuName,
+    deleteMenu: deleteWeeklyMenu,
     loading,
   };
 }

--- a/src/pages/MenuPage.jsx
+++ b/src/pages/MenuPage.jsx
@@ -9,6 +9,7 @@ export default function MenuPage({
   setWeeklyMenu,
   menuName,
   updateMenuName,
+  deleteMenu,
 }) {
   return (
     <div className="p-6">
@@ -19,6 +20,7 @@ export default function MenuPage({
         userProfile={userProfile}
         menuName={menuName}
         onUpdateMenuName={updateMenuName}
+        onDeleteMenu={deleteMenu}
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- allow deleting weekly menus from the planner
- expose deleteMenu hook
- wire deleteMenu through MenuPage and AppRoutes
- include deletion button in MenuPlanner

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_68582a0cdd58832dbac5a775af34175c