### PR TITLE
Add useMenus hook to manage menu list and selection

### DIFF
--- a/src/hooks/useMenus.js
+++ b/src/hooks/useMenus.js
@@ -1,0 +1,102 @@
+import { useState, useEffect, useCallback } from 'react';
+import { supabase } from '@/lib/supabase';
+import { useToast } from '@/components/ui/use-toast';
+
+export function useMenus(session) {
+  const userId = session?.user?.id;
+  const { toast } = useToast();
+  const [menus, setMenus] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [selectedMenuId, setSelectedMenuId] = useState(null);
+
+  const storageKey = `selectedMenuId-${userId || 'guest'}`;
+
+  const fetchMenus = useCallback(async () => {
+    if (!userId) return;
+    setLoading(true);
+    try {
+      const { data: ownerMenus, error: ownerError } = await supabase
+        .from('weekly_menus')
+        .select('id, user_id, name, updated_at')
+        .eq('user_id', userId)
+        .order('created_at');
+
+      if (ownerError && ownerError.code !== 'PGRST116') {
+        throw ownerError;
+      }
+
+      const { data: participantRows, error: participantError } = await supabase
+        .from('menu_participants')
+        .select('menu_id')
+        .eq('user_id', userId);
+
+      if (participantError && participantError.code !== 'PGRST116') {
+        throw participantError;
+      }
+
+      const participantIds = (participantRows || []).map((r) => r.menu_id);
+      let participantMenus = [];
+      if (participantIds.length > 0) {
+        const { data, error } = await supabase
+          .from('weekly_menus')
+          .select('id, user_id, name, updated_at')
+          .in('id', participantIds);
+        if (error) throw error;
+        participantMenus = data || [];
+      }
+
+      const combined = [...(ownerMenus || []), ...participantMenus];
+      const unique = [];
+      const seen = new Set();
+      for (const m of combined) {
+        if (!seen.has(m.id)) {
+          seen.add(m.id);
+          unique.push(m);
+        }
+      }
+
+      setMenus(unique);
+    } catch (err) {
+      console.error('Erreur chargement menus:', err);
+      toast({
+        title: 'Erreur',
+        description: 'Impossible de charger les menus: ' + err.message,
+        variant: 'destructive',
+      });
+      setMenus([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [userId, toast]);
+
+  useEffect(() => {
+    const storedId = localStorage.getItem(storageKey);
+    if (storedId) {
+      setSelectedMenuId(storedId);
+    }
+  }, [storageKey]);
+
+  useEffect(() => {
+    fetchMenus();
+  }, [fetchMenus]);
+
+  useEffect(() => {
+    if (menus.length === 0) {
+      setSelectedMenuId(null);
+      return;
+    }
+    if (!selectedMenuId || !menus.some((m) => m.id === selectedMenuId)) {
+      setSelectedMenuId(menus[0].id);
+    }
+  }, [menus, selectedMenuId]);
+
+  useEffect(() => {
+    if (selectedMenuId) {
+      localStorage.setItem(storageKey, selectedMenuId);
+    } else {
+      localStorage.removeItem(storageKey);
+    }
+  }, [selectedMenuId, storageKey]);
+
+  return { menus, loading, selectedMenuId, setSelectedMenuId, refreshMenus: fetchMenus };
+}

--- a/src/pages/MenuPage.jsx
+++ b/src/pages/MenuPage.jsx
@@ -1,21 +1,15 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import MenuPlanner from '@/components/MenuPlanner';
 import MenuTabs from '@/components/MenuTabs.jsx';
-import { useMenuList } from '@/hooks/useMenuList.js';
+import { useMenus } from '@/hooks/useMenus.js';
 import { useWeeklyMenu } from '@/hooks/useWeeklyMenu.js';
 
 export default function MenuPage({ session, userProfile, recipes }) {
-  const { menus, refreshMenus } = useMenuList(session);
-  const [activeMenuId, setActiveMenuId] = useState(null);
+  const { menus, selectedMenuId, setSelectedMenuId, refreshMenus } =
+    useMenus(session);
 
   const { weeklyMenu, menuName, setWeeklyMenu, updateMenuName, deleteMenu } =
-    useWeeklyMenu(session, activeMenuId);
-
-  useEffect(() => {
-    if (!activeMenuId && Array.isArray(menus) && menus.length > 0) {
-      setActiveMenuId(menus[0].id);
-    }
-  }, [menus, activeMenuId]);
+    useWeeklyMenu(session, selectedMenuId);
 
   const handleRename = async (id, name) => {
     await updateMenuName(name, id);
@@ -25,9 +19,9 @@ export default function MenuPage({ session, userProfile, recipes }) {
   const handleDelete = async (id) => {
     await deleteMenu(id);
     refreshMenus();
-    if (id === activeMenuId) {
+    if (id === selectedMenuId) {
       const remaining = menus.filter((m) => m.id !== id);
-      setActiveMenuId(remaining[0]?.id || null);
+      setSelectedMenuId(remaining[0]?.id || null);
     }
   };
 
@@ -35,8 +29,8 @@ export default function MenuPage({ session, userProfile, recipes }) {
     <div className="p-6 space-y-4">
       <MenuTabs
         menus={menus}
-        activeMenuId={activeMenuId}
-        onSelect={setActiveMenuId}
+        activeMenuId={selectedMenuId}
+        onSelect={setSelectedMenuId}
         currentUserId={session?.user?.id}
         onRename={handleRename}
         onDelete={handleDelete}
@@ -47,8 +41,8 @@ export default function MenuPage({ session, userProfile, recipes }) {
         setWeeklyMenu={setWeeklyMenu}
         userProfile={userProfile}
         menuName={menuName}
-        onUpdateMenuName={(name) => handleRename(activeMenuId, name)}
-        onDeleteMenu={() => handleDelete(activeMenuId)}
+        onUpdateMenuName={(name) => handleRename(selectedMenuId, name)}
+        onDeleteMenu={() => handleDelete(selectedMenuId)}
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- implement new `useMenus` hook to load menus for owner and participant
- manage `selectedMenuId` state within the hook with localStorage persistence
- refactor `MenuPage` to use the new hook

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685832b32758832dbc9a900df09228cc