### PR TITLE
Améliorer UX absence menus

### DIFF
--- a/src/__tests__/menuTabs.test.jsx
+++ b/src/__tests__/menuTabs.test.jsx
@@ -86,4 +86,13 @@ describe('MenuTabs', () => {
       screen.queryByRole('tab', { name: 'Menu Renommé' })
     ).not.toBeInTheDocument();
   });
+
+  it('affiche un message et un bouton quand la liste est vide', () => {
+    render(<MenuTabs menus={[]} onCreate={() => {}} />);
+
+    expect(
+      screen.getByText('Aucun menu disponible pour le moment')
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Créer un menu' })).toBeInTheDocument();
+  });
 });

--- a/src/components/MenuTabs.jsx
+++ b/src/components/MenuTabs.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs.jsx';
 import { Pencil, X } from 'lucide-react';
+import NewMenuModal from '@/components/NewMenuModal.jsx';
 
 export default function MenuTabs({
   menus = [],
@@ -9,7 +10,18 @@ export default function MenuTabs({
   currentUserId,
   onRename,
   onDelete,
+  onCreate,
 }) {
+  if (!menus || menus.length === 0) {
+    return (
+      <div className="text-center py-12 px-6 bg-pastel-card rounded-xl shadow-pastel-soft space-y-4">
+        <p className="text-xl text-pastel-muted-foreground">
+          Aucun menu disponible pour le moment
+        </p>
+        <NewMenuModal onCreate={onCreate} />
+      </div>
+    );
+  }
   return (
     <Tabs
       value={activeMenuId || ''}


### PR DESCRIPTION
## Notes
- Added fallback UI in `MenuTabs` when no menus are available
- Includes new test verifying message and button display

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685838a6252c832d9b593a45c83d27ad