### PR TITLE
Refactor menu tabs UI

### DIFF
--- a/src/__tests__/menuTabs.test.jsx
+++ b/src/__tests__/menuTabs.test.jsx
@@ -13,14 +13,17 @@ function Wrapper() {
   const [menus, setMenus] = useState(sampleMenus);
   const [activeId, setActiveId] = useState(sampleMenus[0].id);
 
-  const handleRename = (id, name) => {
-    setMenus((prev) =>
-      prev.map((m) => (m.id === id ? { ...m, name } : m))
-    );
-  };
-
   const handleDelete = (id) => {
     setMenus((prev) => prev.filter((m) => m.id !== id));
+  };
+
+  const handleCreate = () => {
+    const newId = String(menus.length + 1);
+    setMenus((prev) => [
+      ...prev,
+      { id: newId, user_id: 'user1', name: 'Menu sans titre' },
+    ]);
+    setActiveId(newId);
   };
 
   return (
@@ -29,8 +32,8 @@ function Wrapper() {
       activeMenuId={activeId}
       onSelect={setActiveId}
       currentUserId="user1"
-      onRename={handleRename}
       onDelete={handleDelete}
+      onCreate={handleCreate}
     />
   );
 }
@@ -66,25 +69,26 @@ describe('MenuTabs', () => {
     expect(onSelect).toHaveBeenCalledWith('2');
   });
 
-  it('suppression et renommage modifient le state', () => {
+  it('supprime un menu au clic sur la croix', () => {
     render(<Wrapper />);
-
-    vi.spyOn(window, 'prompt').mockReturnValue('Menu Renommé');
-    const tab1 = screen.getByRole('tab', { name: 'Menu 1' });
-    const renameBtn = within(tab1).getByLabelText('Renommer');
-    fireEvent.click(renameBtn);
-    expect(
-      screen.getByRole('tab', { name: 'Menu Renommé' })
-    ).toBeInTheDocument();
 
     vi.spyOn(window, 'confirm').mockReturnValue(true);
     const deleteBtn = within(
-      screen.getByRole('tab', { name: 'Menu Renommé' })
+      screen.getByRole('tab', { name: 'Menu 1' })
     ).getByLabelText('Supprimer');
     fireEvent.click(deleteBtn);
     expect(
-      screen.queryByRole('tab', { name: 'Menu Renommé' })
+      screen.queryByRole('tab', { name: 'Menu 1' })
     ).not.toBeInTheDocument();
+  });
+
+  it('cree un nouveau menu via le bouton', () => {
+    render(<Wrapper />);
+    const createBtn = screen.getByRole('button', { name: '+ Nouveau menu' });
+    fireEvent.click(createBtn);
+    expect(
+      screen.getByRole('tab', { name: 'Menu sans titre' })
+    ).toBeInTheDocument();
   });
 
   it('affiche un message et un bouton quand la liste est vide', () => {
@@ -93,6 +97,8 @@ describe('MenuTabs', () => {
     expect(
       screen.getByText('Aucun menu disponible pour le moment')
     ).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Créer un menu' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Créer un menu' })
+    ).toBeInTheDocument();
   });
 });

--- a/src/components/MenuPlanner.jsx
+++ b/src/components/MenuPlanner.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { Button } from '@/components/ui/button.jsx';
-import { RotateCw, Pencil, X } from 'lucide-react';
+import { RotateCw, Pencil } from 'lucide-react';
 import MenuPreferencesModal from '@/components/menu_planner/MenuPreferencesModal.jsx';
 import WeeklyMenuView from '@/components/menu_planner/WeeklyMenuView.jsx';
 import { useMenuGeneration } from '@/hooks/useMenuGeneration.js';
@@ -132,7 +132,6 @@ function MenuPlanner({
     userProfile
   );
 
-
   const handleGenerateMenu = useCallback(() => {
     generateMenu();
   }, [generateMenu]);
@@ -161,7 +160,7 @@ function MenuPlanner({
   return (
     <div className="space-y-8">
       <div className="flex flex-col sm:flex-row justify-between items-center gap-4 bg-pastel-card p-6 rounded-xl shadow-pastel-soft">
-        <h2 className="text-2xl sm:text-3xl font-bold text-pastel-primary flex items-center gap-2">
+        <h2 className="group text-2xl sm:text-3xl font-bold text-pastel-primary flex items-center gap-2">
           {isEditingName ? (
             <input
               value={tempName}
@@ -181,16 +180,9 @@ function MenuPlanner({
               <span>{menuName || 'Menu de la semaine'}</span>
               <button
                 onClick={() => setIsEditingName(true)}
-                className="text-pastel-muted-foreground hover:text-pastel-primary"
+                className="ml-1 opacity-0 group-hover:opacity-100 text-pastel-muted-foreground hover:text-pastel-primary"
               >
                 <Pencil className="w-4 h-4" />
-              </button>
-              <button
-                onClick={handleDeleteMenu}
-                className="text-destructive/70 hover:text-destructive hover:bg-destructive/20 rounded-full p-1"
-                title="Supprimer le menu"
-              >
-                <X className="w-4 h-4" />
               </button>
             </>
           )}

--- a/src/components/MenuTabs.jsx
+++ b/src/components/MenuTabs.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs.jsx';
-import { Pencil, X } from 'lucide-react';
+import { X } from 'lucide-react';
 import NewMenuModal from '@/components/NewMenuModal.jsx';
 
 export default function MenuTabs({
@@ -8,7 +8,6 @@ export default function MenuTabs({
   activeMenuId,
   onSelect,
   currentUserId,
-  onRename,
   onDelete,
   onCreate,
 }) {
@@ -28,43 +27,37 @@ export default function MenuTabs({
       onValueChange={onSelect}
       className="w-full"
     >
-      <TabsList className="flex overflow-x-auto">
+      <TabsList className="flex overflow-x-auto items-center gap-2">
         {menus.map((menu) => (
           <TabsTrigger
             key={menu.id}
             value={menu.id}
-            className="flex items-center gap-2 whitespace-nowrap"
+            className="relative group whitespace-nowrap border border-pastel-primary-light rounded-md px-3 py-1 text-sm data-[state=active]:bg-pastel-primary data-[state=active]:text-white data-[state=active]:font-bold"
           >
-            <span>{menu.name || 'Menu'}</span>
+            {menu.name || 'Menu'}
             {menu.user_id === currentUserId && (
-              <>
-                <button
-                  aria-label="Renommer"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    const newName = window.prompt('Nouveau nom', menu.name);
-                    if (newName && onRename) onRename(menu.id, newName);
-                  }}
-                  className="text-pastel-muted-foreground hover:text-pastel-primary"
-                >
-                  <Pencil className="w-3 h-3" />
-                </button>
-                <button
-                  aria-label="Supprimer"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    if (window.confirm('Supprimer ce menu ?')) {
-                      onDelete && onDelete(menu.id);
-                    }
-                  }}
-                  className="text-destructive/70 hover:text-destructive hover:bg-destructive/20 rounded-full p-0.5"
-                >
-                  <X className="w-3 h-3" />
-                </button>
-              </>
+              <button
+                aria-label="Supprimer"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  if (window.confirm('Supprimer ce menu ?')) {
+                    onDelete && onDelete(menu.id);
+                  }
+                }}
+                className="absolute -top-1 -right-1 hidden group-hover:block text-destructive/70 hover:text-destructive bg-white rounded-full p-0.5"
+              >
+                <X className="w-3 h-3" />
+              </button>
             )}
           </TabsTrigger>
         ))}
+        <button
+          type="button"
+          onClick={() => onCreate && onCreate()}
+          className="ml-2 px-3 py-1 text-sm border-2 border-dashed border-pastel-primary rounded-md whitespace-nowrap hover:bg-pastel-primary hover:text-white"
+        >
+          + Nouveau menu
+        </button>
       </TabsList>
     </Tabs>
   );

--- a/src/pages/MenuPage.jsx
+++ b/src/pages/MenuPage.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import MenuPlanner from '@/components/MenuPlanner';
 import MenuTabs from '@/components/MenuTabs.jsx';
+import { supabase } from '@/lib/supabase';
+import { initialWeeklyMenuState } from '@/lib/menu';
 import { useMenus } from '@/hooks/useMenus.js';
 import { useWeeklyMenu } from '@/hooks/useWeeklyMenu.js';
 
@@ -25,6 +27,26 @@ export default function MenuPage({ session, userProfile, recipes }) {
     }
   };
 
+  const handleCreate = async () => {
+    const userId = session?.user?.id;
+    if (!userId) return;
+    const { data, error } = await supabase
+      .from('weekly_menus')
+      .insert({
+        user_id: userId,
+        name: 'Menu sans titre',
+        menu_data: initialWeeklyMenuState(),
+      })
+      .select('id')
+      .single();
+    if (error) {
+      console.error('Erreur creation menu:', error);
+      return;
+    }
+    await refreshMenus();
+    if (data?.id) setSelectedMenuId(data.id);
+  };
+
   return (
     <div className="p-6 space-y-4">
       <MenuTabs
@@ -32,8 +54,8 @@ export default function MenuPage({ session, userProfile, recipes }) {
         activeMenuId={selectedMenuId}
         onSelect={setSelectedMenuId}
         currentUserId={session?.user?.id}
-        onRename={handleRename}
         onDelete={handleDelete}
+        onCreate={handleCreate}
       />
       <MenuPlanner
         recipes={recipes}


### PR DESCRIPTION
## Summary
- restyle weekly menu tabs
- remove rename button from tabs and show delete icon on hover
- add inline rename in `MenuPlanner` header
- support menu creation via a `+ Nouveau menu` tab
- update tests for new behaviour

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68583ac99158832d883a2383b5e0f6b0