### PR TITLE
Fix selected menu sync

### DIFF
--- a/src/hooks/useWeeklyMenu.js
+++ b/src/hooks/useWeeklyMenu.js
@@ -20,6 +20,10 @@ export function useWeeklyMenu(session, currentMenuId = null) {
   const { toast } = useToast();
   const userId = session?.user?.id;
 
+  useEffect(() => {
+    setMenuId(currentMenuId);
+  }, [currentMenuId]);
+
   const safeSetWeeklyMenu = useCallback((data) => {
     if (
       Array.isArray(data) &&


### PR DESCRIPTION
## Summary
- sync `useWeeklyMenu` with selected tab

## Testing
- `npm test --silent`
- `npm run lint` *(fails: many react/prop-types errors)*

------
https://chatgpt.com/codex/tasks/task_e_685841b4858c832db4d851a36d94987a