### PR TITLE
Fix menu name handling on creation

### DIFF
--- a/src/pages/MenuPage.jsx
+++ b/src/pages/MenuPage.jsx
@@ -27,14 +27,14 @@ export default function MenuPage({ session, userProfile, recipes }) {
     }
   };
 
-  const handleCreate = async () => {
+  const handleCreate = async ({ name } = {}) => {
     const userId = session?.user?.id;
     if (!userId) return;
     const { data, error } = await supabase
       .from('weekly_menus')
       .insert({
         user_id: userId,
-        name: 'Menu sans titre',
+        name: name || 'Menu sans titre',
         menu_data: initialWeeklyMenuState(),
       })
       .select('id')


### PR DESCRIPTION
## Summary
- allow `handleCreate` to accept a name argument
- insert the given name when creating a new menu

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_68584818e8c4832d8335e64cefde395e