### PR TITLE
Fix recipe update maybeSingle

### DIFF
--- a/src/hooks/useRecipes.jsx
+++ b/src/hooks/useRecipes.jsx
@@ -265,13 +265,19 @@ export function useRecipes(session, subscriptionTier) {
         delete payload.user;
         delete payload.public_users;
 
+        console.log('Updating recipe with', {
+          id: recipeId,
+          user_id: session.user.id,
+          data: payload,
+        });
+
         const { data: updatedRecipeResult, error } = await supabase
           .from('recipes')
           .update(payload)
           .eq('id', recipeId)
           .eq('user_id', session.user.id)
           .select(baseRecipeSelect)
-          .single();
+          .maybeSingle();
 
         if (error) {
           console.error(


### PR DESCRIPTION
## Summary
- avoid PostgREST PGRST116 error by using `maybeSingle` for recipe update
- add temporary debug log for recipe update parameters

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_68584a3ee604832d953cd2b67dd19a45