### PR TITLE
Fix Supabase auth headers for Storage

### DIFF
--- a/src/hooks/useSession.js
+++ b/src/hooks/useSession.js
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import { supabase } from '@/lib/supabase';
+import { supabase, initializeSupabase } from '@/lib/supabase';
 import { useToast } from '@/components/ui/use-toast.js';
 
 export function useSession() {
@@ -13,8 +13,10 @@ export function useSession() {
       const {
         data: { session: currentSession },
       } = await supabase.auth.getSession();
+      initializeSupabase(currentSession);
       setSession(currentSession);
     } catch (error) {
+      initializeSupabase(null);
       setSession(null);
     } finally {
       setLoading(false);
@@ -30,6 +32,7 @@ export function useSession() {
         title: 'Déconnexion réussie',
         description: 'Vous avez été déconnecté.',
       });
+      initializeSupabase(null);
       setSession(null);
     } catch (error) {
       toast({
@@ -49,6 +52,7 @@ export function useSession() {
       data: { subscription },
     } = supabase.auth.onAuthStateChange(async (_event, newSession) => {
       setLoading(true);
+      initializeSupabase(newSession);
       setSession(newSession);
       setLoading(false);
     });

--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -5,4 +5,14 @@ if (!supabaseUrl) throw new Error('VITE_SUPABASE_URL is not defined');
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
 if (!supabaseAnonKey) throw new Error('VITE_SUPABASE_ANON_KEY is not defined');
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+export let supabase = createClient(supabaseUrl, supabaseAnonKey);
+
+export function initializeSupabase(session) {
+  supabase = createClient(supabaseUrl, supabaseAnonKey, {
+    global: {
+      headers: {
+        Authorization: `Bearer ${session?.access_token}`,
+      },
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- create a helper to (re)initialize Supabase with the current session token
- update session hook to refresh the client with Authorization header

## Testing
- `npm test --silent -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68584a4f3fac832d909b4090148b6e28