### PR TITLE
Fix weekly menu fetch dependency

### DIFF
--- a/src/hooks/useWeeklyMenu.js
+++ b/src/hooks/useWeeklyMenu.js
@@ -75,7 +75,7 @@ export function useWeeklyMenu(session, currentMenuId = null) {
         setLoading(false);
       }
     },
-    [userId, toast, safeSetWeeklyMenu]
+    [userId, toast, safeSetWeeklyMenu, menuId]
   );
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- ensure weekly menu fetch uses the current menu id

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68584b981ca4832d88b7876c650ec347