### PR TITLE
Fix Supabase env variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,9 @@
-VITE_SUPABASE_URL=your-supabase-url
-VITE_SUPABASE_ANON_KEY=your-supabase-anon-key
+# Frontend (Vite)
+VITE_SUPABASE_URL=https://xxxxx.supabase.co
+VITE_SUPABASE_ANON_KEY=your-anon-key
+
+# Backend (API)
+SUPABASE_URL=https://xxxxx.supabase.co
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+
 OPENAI_API_KEY=

--- a/api/access-key.ts
+++ b/api/access-key.ts
@@ -2,8 +2,8 @@ import { VercelRequest, VercelResponse } from '@vercel/node';
 import { createClient } from '@supabase/supabase-js';
 import { getUserFromRequest } from '../src/utils/auth.js';
 
-const supabaseUrl = process.env.VITE_SUPABASE_URL;
-if (!supabaseUrl) throw new Error('VITE_SUPABASE_URL is not defined');
+const supabaseUrl = process.env.SUPABASE_URL;
+if (!supabaseUrl) throw new Error('SUPABASE_URL is not defined');
 const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 if (!serviceRoleKey)
   throw new Error('SUPABASE_SERVICE_ROLE_KEY is not defined');

--- a/api/generate-description.ts
+++ b/api/generate-description.ts
@@ -4,8 +4,8 @@ import { z } from 'zod';
 import { getUserFromRequest } from '../src/utils/auth.js';
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = process.env.VITE_SUPABASE_URL;
-if (!supabaseUrl) throw new Error('VITE_SUPABASE_URL is not defined');
+const supabaseUrl = process.env.SUPABASE_URL;
+if (!supabaseUrl) throw new Error('SUPABASE_URL is not defined');
 const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 if (!serviceRoleKey) throw new Error('SUPABASE_SERVICE_ROLE_KEY is not defined');
 

--- a/api/generate-image.ts
+++ b/api/generate-image.ts
@@ -3,8 +3,8 @@ import OpenAI from 'openai';
 import { getUserFromRequest } from '../src/utils/auth.js';
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = process.env.VITE_SUPABASE_URL;
-if (!supabaseUrl) throw new Error('VITE_SUPABASE_URL is not defined');
+const supabaseUrl = process.env.SUPABASE_URL;
+if (!supabaseUrl) throw new Error('SUPABASE_URL is not defined');
 const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 if (!serviceRoleKey) throw new Error('SUPABASE_SERVICE_ROLE_KEY is not defined');
 

--- a/api/update-profile.ts
+++ b/api/update-profile.ts
@@ -2,8 +2,8 @@ import { VercelRequest, VercelResponse } from '@vercel/node';
 import { createClient } from '@supabase/supabase-js';
 import { getUserFromRequest } from '../src/utils/auth.js';
 
-const supabaseUrl = process.env.VITE_SUPABASE_URL;
-if (!supabaseUrl) throw new Error('VITE_SUPABASE_URL is not defined');
+const supabaseUrl = process.env.SUPABASE_URL;
+if (!supabaseUrl) throw new Error('SUPABASE_URL is not defined');
 const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 if (!serviceRoleKey)
   throw new Error('SUPABASE_SERVICE_ROLE_KEY is not defined');

--- a/pages/api/stripe/webhook.ts
+++ b/pages/api/stripe/webhook.ts
@@ -6,8 +6,8 @@ import { Readable } from 'stream';
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || '', {
   apiVersion: '2024-04-10',
 });
-const supabaseUrl = process.env.VITE_SUPABASE_URL;
-if (!supabaseUrl) throw new Error('VITE_SUPABASE_URL is not defined');
+const supabaseUrl = process.env.SUPABASE_URL;
+if (!supabaseUrl) throw new Error('SUPABASE_URL is not defined');
 const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 if (!serviceRoleKey)
   throw new Error('SUPABASE_SERVICE_ROLE_KEY is not defined');

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -1,7 +1,7 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = process.env.VITE_SUPABASE_URL;
-if (!supabaseUrl) throw new Error('VITE_SUPABASE_URL is not defined');
+const supabaseUrl = process.env.SUPABASE_URL;
+if (!supabaseUrl) throw new Error('SUPABASE_URL is not defined');
 const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 if (!serviceRoleKey)
   throw new Error('SUPABASE_SERVICE_ROLE_KEY is not defined');

--- a/stripe/webhook.ts
+++ b/stripe/webhook.ts
@@ -6,8 +6,8 @@ import { Readable } from 'stream';
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || '', {
   apiVersion: '2024-04-10',
 });
-const supabaseUrl = process.env.VITE_SUPABASE_URL;
-if (!supabaseUrl) throw new Error('VITE_SUPABASE_URL is not defined');
+const supabaseUrl = process.env.SUPABASE_URL;
+if (!supabaseUrl) throw new Error('SUPABASE_URL is not defined');
 const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 if (!serviceRoleKey)
   throw new Error('SUPABASE_SERVICE_ROLE_KEY is not defined');


### PR DESCRIPTION
## Summary
- rely only on VITE vars on the client
- use SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY on all server files
- update example env file

## Testing
- `npm run lint` *(fails: 520 errors)*
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685851d96398832d978707a3de8d4135