### PR TITLE
Include session JWT in price estimation requests

### DIFF
--- a/src/components/RecipeForm.jsx
+++ b/src/components/RecipeForm.jsx
@@ -466,7 +466,8 @@ function RecipeForm({
           ingredients: cleanedNewIngredients,
           servings: parseInt(formData.servings, 10) || 1,
         },
-        userProfile.subscription_tier
+        userProfile.subscription_tier,
+        session
       );
     }
 

--- a/src/hooks/useRecipes.jsx
+++ b/src/hooks/useRecipes.jsx
@@ -102,7 +102,8 @@ export function useRecipes(session, subscriptionTier) {
                 : [],
               servings: parseInt(recipe.servings, 10) || 1,
             },
-            subscriptionTier
+            subscriptionTier,
+            session
           );
 
           if (estimated !== null) {

--- a/src/lib/openai.js
+++ b/src/lib/openai.js
@@ -22,15 +22,20 @@ export const generateRecipe = async (prompt, subscriptionTier = 'standard') => {
 
 export const estimateRecipePrice = async (
   recipe,
-  subscriptionTier = 'standard'
+  subscriptionTier = 'standard',
+  session
 ) => {
   try {
+    const headers = {
+      'Content-Type': 'application/json',
+      'x-subscription-tier': subscriptionTier,
+    };
+    const token = session?.access_token ?? session;
+    if (token) headers.Authorization = `Bearer ${token}`;
+
     const response = await fetch('/api/estimate-cost', {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'x-subscription-tier': subscriptionTier,
-      },
+      headers,
       body: JSON.stringify({ recipe }),
     });
 


### PR DESCRIPTION
## Summary
- pass session token to price estimation API calls
- include `Authorization` header in `estimateRecipePrice`

## Testing
- `npm run test`
- `npx ts-node scripts/test-zod.ts` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6858510e5fe0832da5c93abcf5fe87f9