### PR TITLE
Standardize Supabase anon env var

### DIFF
--- a/src/components/RecipeForm.jsx
+++ b/src/components/RecipeForm.jsx
@@ -590,7 +590,7 @@ function RecipeForm({
         headers: {
           'Content-Type': 'application/json',
           Authorization: `Bearer ${session.access_token}`,
-          apikey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+          apikey: import.meta.env.VITE_SUPABASE_ANON_KEY,
           'x-subscription-tier': subscriptionTier,
         },
         body: JSON.stringify({

--- a/src/lib/openai.js
+++ b/src/lib/openai.js
@@ -5,7 +5,7 @@ export const generateRecipe = async (prompt, subscriptionTier = 'standard') => {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        apikey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+        apikey: import.meta.env.VITE_SUPABASE_ANON_KEY,
         'x-subscription-tier': subscriptionTier,
       },
       body: JSON.stringify({ prompt }),


### PR DESCRIPTION
## Summary
- read Supabase anon key from `import.meta.env.VITE_SUPABASE_ANON_KEY`
- use the Vite env variable in RecipeForm too

## Testing
- `npm run test`
- `npm run lint` *(fails: many prop-types errors)*

------
https://chatgpt.com/codex/tasks/task_e_68585ec06394832d8d38a7501cdec2e3