### PR TITLE
Fix server env vars and token logging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@ VITE_SUPABASE_ANON_KEY=your-anon-key
 
 # Backend (API)
 SUPABASE_URL=https://xxxxx.supabase.co
+SUPABASE_ANON_KEY=your-anon-key
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 
 OPENAI_API_KEY=

--- a/src/lib/openai.js
+++ b/src/lib/openai.js
@@ -31,7 +31,11 @@ export const estimateRecipePrice = async (
       'x-subscription-tier': subscriptionTier,
     };
     const token = session?.access_token ?? session;
-    if (token) headers.Authorization = `Bearer ${token}`;
+    if (token) {
+      headers.Authorization = `Bearer ${token}`;
+    } else {
+      console.error('Missing access token for /api/estimate-cost request');
+    }
 
     const response = await fetch('/api/estimate-cost', {
       method: 'POST',


### PR DESCRIPTION
## Summary
- add missing `SUPABASE_ANON_KEY` for backend in `.env.example`
- warn when calling `/api/estimate-cost` without an access token

## Testing
- `npm run lint` *(fails: many errors)*
- `npx vitest run` *(fails: warnings and no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6858781f3a28832d9bea57b3f578a77f