### PR TITLE
Update Supabase env variable names

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,8 +3,6 @@ VITE_SUPABASE_URL=https://xxxxx.supabase.co
 VITE_SUPABASE_ANON_KEY=your-anon-key
 
 # Backend (API)
-SUPABASE_URL=https://xxxxx.supabase.co
-SUPABASE_ANON_KEY=your-anon-key
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 
 OPENAI_API_KEY=

--- a/api/access-key.ts
+++ b/api/access-key.ts
@@ -2,8 +2,8 @@ import { VercelRequest, VercelResponse } from '@vercel/node';
 import { createClient } from '@supabase/supabase-js';
 import { getUserFromRequest } from '../src/utils/auth.js';
 
-const supabaseUrl = process.env.SUPABASE_URL;
-if (!supabaseUrl) throw new Error('SUPABASE_URL is not defined');
+const supabaseUrl = process.env.VITE_SUPABASE_URL;
+if (!supabaseUrl) throw new Error('VITE_SUPABASE_URL is not defined');
 const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 if (!serviceRoleKey)
   throw new Error('SUPABASE_SERVICE_ROLE_KEY is not defined');

--- a/api/generate-description.ts
+++ b/api/generate-description.ts
@@ -4,8 +4,8 @@ import { z } from 'zod';
 import { getUserFromRequest } from '../src/utils/auth.js';
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = process.env.SUPABASE_URL;
-if (!supabaseUrl) throw new Error('SUPABASE_URL is not defined');
+const supabaseUrl = process.env.VITE_SUPABASE_URL;
+if (!supabaseUrl) throw new Error('VITE_SUPABASE_URL is not defined');
 const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 if (!serviceRoleKey) throw new Error('SUPABASE_SERVICE_ROLE_KEY is not defined');
 

--- a/api/generate-image.ts
+++ b/api/generate-image.ts
@@ -3,8 +3,8 @@ import OpenAI from 'openai';
 import { getUserFromRequest } from '../src/utils/auth.js';
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = process.env.SUPABASE_URL;
-if (!supabaseUrl) throw new Error('SUPABASE_URL is not defined');
+const supabaseUrl = process.env.VITE_SUPABASE_URL;
+if (!supabaseUrl) throw new Error('VITE_SUPABASE_URL is not defined');
 const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 if (!serviceRoleKey) throw new Error('SUPABASE_SERVICE_ROLE_KEY is not defined');
 

--- a/api/update-profile.ts
+++ b/api/update-profile.ts
@@ -2,8 +2,8 @@ import { VercelRequest, VercelResponse } from '@vercel/node';
 import { createClient } from '@supabase/supabase-js';
 import { getUserFromRequest } from '../src/utils/auth.js';
 
-const supabaseUrl = process.env.SUPABASE_URL;
-if (!supabaseUrl) throw new Error('SUPABASE_URL is not defined');
+const supabaseUrl = process.env.VITE_SUPABASE_URL;
+if (!supabaseUrl) throw new Error('VITE_SUPABASE_URL is not defined');
 const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 if (!serviceRoleKey)
   throw new Error('SUPABASE_SERVICE_ROLE_KEY is not defined');

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -1,7 +1,7 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = process.env.SUPABASE_URL;
-if (!supabaseUrl) throw new Error('SUPABASE_URL is not defined');
+const supabaseUrl = process.env.VITE_SUPABASE_URL;
+if (!supabaseUrl) throw new Error('VITE_SUPABASE_URL is not defined');
 const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 if (!serviceRoleKey)
   throw new Error('SUPABASE_SERVICE_ROLE_KEY is not defined');


### PR DESCRIPTION
## Summary
- use `VITE_SUPABASE_URL` in serverless functions and auth util
- update `.env.example` variables

## Testing
- `npm run lint` *(fails: many eslint errors)*
- `CI=1 npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685880fced20832d8fa4ee5c299c84da