### PR TITLE
Fix Supabase initialization loops

### DIFF
--- a/src/components/Auth.jsx
+++ b/src/components/Auth.jsx
@@ -1,9 +1,11 @@
 import React, { useState } from 'react';
-import { supabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 import { Button } from '@/components/ui/button';
 import { useToast } from '@/components/ui/use-toast';
 import { X } from 'lucide-react';
 import SignUpForm from '@/components/SignUpForm';
+
+const supabase = getSupabase();
 
 export default function Auth({ onClose }) {
   const [loading, setLoading] = useState(false);

--- a/src/components/FriendActionButton.jsx
+++ b/src/components/FriendActionButton.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { useToast } from '@/components/ui/use-toast';
-import { supabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 import { acceptFriendRequest } from '@/lib/friends';
 import {
   Loader2,
@@ -11,6 +11,8 @@ import {
   MessageCircle,
 } from 'lucide-react';
 import useSessionRequired from '@/hooks/useSessionRequired';
+
+const supabase = getSupabase();
 
 export default function FriendActionButton({
   session,

--- a/src/components/FriendsTab.jsx
+++ b/src/components/FriendsTab.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { supabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 import { acceptFriendRequest } from '@/lib/friends';
 import { Button } from '@/components/ui/button';
 import { useToast } from '@/components/ui/use-toast';
@@ -23,6 +23,8 @@ import {
   DialogTrigger,
   DialogClose,
 } from '@/components/ui/dialog.jsx';
+
+const supabase = getSupabase();
 
 export default function FriendsTab({ session, userProfile, onRequestsChange }) {
   const { toast } = useToast();

--- a/src/components/MyPublicProfile.jsx
+++ b/src/components/MyPublicProfile.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { supabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 import RecipeList from '@/components/RecipeList';
 import LoadingScreen from '@/components/layout/LoadingScreen';
 import { UserCircle, ShieldCheck } from 'lucide-react';
@@ -7,6 +7,8 @@ import { useToast } from '@/components/ui/use-toast';
 import RecipeDetailModal from '@/components/RecipeDetailModal';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { formatRecipe } from '@/lib/formatRecipe';
+
+const supabase = getSupabase();
 
 export default function MyPublicProfile({
   session,

--- a/src/components/RecipeForm.jsx
+++ b/src/components/RecipeForm.jsx
@@ -5,7 +5,7 @@ import { X, Loader2, Eye, EyeOff, Users, Globe } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import TagManager from '@/components/TagManager';
 import { generateTagSuggestions } from '@/lib/tagSuggestions';
-import { supabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 import { useToast } from '@/components/ui/use-toast';
 import { useNavigate } from 'react-router-dom';
 import RecipeFormImageHandler from '@/components/RecipeFormImageHandler';
@@ -15,6 +15,8 @@ import RecipeIngredientsManager from '@/components/form/RecipeIngredientsManager
 import RecipeInstructionsManager from '@/components/form/RecipeInstructionsManager';
 import RecipeMetaFields from '@/components/form/RecipeMetaFields';
 import { estimateRecipePrice } from '@/lib/openai';
+
+const supabase = getSupabase();
 import {
   Select,
   SelectContent,

--- a/src/components/SignUpForm.jsx
+++ b/src/components/SignUpForm.jsx
@@ -1,8 +1,10 @@
 import React, { useState } from 'react';
-import { supabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 import { Button } from '@/components/ui/button';
 import { useToast } from '@/components/ui/use-toast';
 import { X, ArrowLeft } from 'lucide-react';
+
+const supabase = getSupabase();
 
 export default function SignUpForm({ onClose, onBackToLogin }) {
   const [loading, setLoading] = useState(false);

--- a/src/components/TagManager.jsx
+++ b/src/components/TagManager.jsx
@@ -3,8 +3,10 @@ import { Button } from '@/components/ui/button';
 import { X, Trash2 } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useToast } from '@/components/ui/use-toast';
-import { supabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 import useSessionRequired from '@/hooks/useSessionRequired';
+
+const supabase = getSupabase();
 
 function TagManager({
   onClose,

--- a/src/components/account/EmailForm.jsx
+++ b/src/components/account/EmailForm.jsx
@@ -1,11 +1,13 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { supabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Loader2 } from 'lucide-react';
 import { useToast } from '@/components/ui/use-toast';
+
+const supabase = getSupabase();
 
 export default function EmailForm({ session, onProfileUpdate }) {
   const { toast } = useToast();

--- a/src/components/account/PasswordChangeForm.jsx
+++ b/src/components/account/PasswordChangeForm.jsx
@@ -1,10 +1,12 @@
 import React, { useState } from 'react';
-import { supabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Loader2 } from 'lucide-react';
 import { useToast } from '@/components/ui/use-toast';
+
+const supabase = getSupabase();
 
 export default function PasswordChangeForm() {
   const { toast } = useToast();

--- a/src/components/account/ProfileInformationForm.jsx
+++ b/src/components/account/ProfileInformationForm.jsx
@@ -1,11 +1,13 @@
 import React, { useState, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
-import { supabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Loader2, UserCircle } from 'lucide-react';
 import { useToast } from '@/components/ui/use-toast';
+
+const supabase = getSupabase();
 
 const DEFAULT_AVATAR_URL = 'https://placehold.co/100x100?text=Avatar';
 

--- a/src/components/account/SubscriptionManagement.jsx
+++ b/src/components/account/SubscriptionManagement.jsx
@@ -1,10 +1,12 @@
 import React, { useState, useEffect } from 'react';
-import { supabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 import { Button } from '@/components/ui/button';
 import { useToast } from '@/components/ui/use-toast';
 import { Loader2, Star, CheckCircle, CreditCard } from 'lucide-react';
 import PropTypes from 'prop-types';
 import { loadStripe } from '@stripe/stripe-js';
+
+const supabase = getSupabase();
 
 const STRIPE_PUBLISHABLE_KEY =
   'pk_test_51RM7DtGEb36fLGJ0lbRvJ0HCxgKaCzj5iVnWXOSQvengGlpSFHKBEOmb2fYQEPUE0FuwOYZDndSj7IVRy3rijOmi00sJXXZ4sG';

--- a/src/hooks/useFriendsList.js
+++ b/src/hooks/useFriendsList.js
@@ -1,5 +1,7 @@
 import { useEffect, useState } from 'react';
-import { supabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
+
+const supabase = getSupabase();
 
 export function useFriendsList(session) {
   const [friends, setFriends] = useState([]);

--- a/src/hooks/useLinkedUsers.js
+++ b/src/hooks/useLinkedUsers.js
@@ -1,6 +1,8 @@
 import { useState, useCallback, useEffect } from 'react';
-import { supabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 import { useToast } from '@/components/ui/use-toast.js';
+
+const supabase = getSupabase();
 
 export function useLinkedUsers(userProfile, preferences, setPreferences) {
   const { toast } = useToast();

--- a/src/hooks/useMenuList.js
+++ b/src/hooks/useMenuList.js
@@ -1,6 +1,8 @@
 import { useState, useEffect, useCallback } from 'react';
-import { supabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 import { useToast } from '@/components/ui/use-toast';
+
+const supabase = getSupabase();
 
 export function useMenuList(session) {
   const [menus, setMenus] = useState([]);

--- a/src/hooks/useMenus.js
+++ b/src/hooks/useMenus.js
@@ -1,6 +1,8 @@
 import { useState, useEffect, useCallback } from 'react';
-import { supabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 import { useToast } from '@/components/ui/use-toast';
+
+const supabase = getSupabase();
 
 export function useMenus(session) {
   const userId = session?.user?.id;

--- a/src/hooks/usePendingFriendRequests.js
+++ b/src/hooks/usePendingFriendRequests.js
@@ -1,5 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
-import { supabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
+
+const supabase = getSupabase();
 
 export function usePendingFriendRequests(session) {
   const [pendingCount, setPendingCount] = useState(0);

--- a/src/hooks/usePublicRecipes.js
+++ b/src/hooks/usePublicRecipes.js
@@ -1,6 +1,8 @@
 import { useCallback, useMemo } from 'react';
-import { supabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 import { useSupabasePaginated } from './useSupabasePaginated';
+
+const supabase = getSupabase();
 
 export function usePublicRecipes(session) {
   const queryFn = useCallback(

--- a/src/hooks/useRecipes.jsx
+++ b/src/hooks/useRecipes.jsx
@@ -1,8 +1,10 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { supabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 import { useToast } from '@/components/ui/use-toast.js';
 import { ToastAction } from '@/components/ui/toast.jsx';
 import { estimateRecipePrice } from '@/lib/openai';
+
+const supabase = getSupabase();
 
 export function useRecipes(session, subscriptionTier) {
   const [recipes, setRecipes] = useState([]);

--- a/src/hooks/useSession.js
+++ b/src/hooks/useSession.js
@@ -1,6 +1,8 @@
 import { useState, useEffect, useCallback } from 'react';
-import { supabase, initializeSupabase } from '@/lib/supabase';
+import { getSupabase, initializeSupabase } from '@/lib/supabase';
 import { useToast } from '@/components/ui/use-toast.js';
+
+const supabase = getSupabase();
 
 export function useSession() {
   const [session, setSession] = useState(undefined);

--- a/src/hooks/useSessionRequired.js
+++ b/src/hooks/useSessionRequired.js
@@ -1,6 +1,8 @@
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { supabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
+
+const supabase = getSupabase();
 
 export default function useSessionRequired() {
   const navigate = useNavigate();

--- a/src/hooks/useUserProfile.js
+++ b/src/hooks/useUserProfile.js
@@ -1,6 +1,8 @@
 import { useState, useEffect, useCallback } from 'react';
-import { supabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 import { useToast } from '@/components/ui/use-toast.js';
+
+const supabase = getSupabase();
 
 export function useUserProfile(session) {
   const [userProfile, setUserProfile] = useState(undefined);

--- a/src/hooks/useUserSearch.js
+++ b/src/hooks/useUserSearch.js
@@ -1,5 +1,7 @@
 import { useState, useCallback } from 'react';
-import { supabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
+
+const supabase = getSupabase();
 
 export function useUserSearch(session) {
   const [results, setResults] = useState([]);

--- a/src/hooks/useWeeklyMenu.js
+++ b/src/hooks/useWeeklyMenu.js
@@ -1,7 +1,9 @@
 import { useState, useEffect, useCallback } from 'react';
-import { supabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 import { useToast } from '@/components/ui/use-toast';
 import { initialWeeklyMenuState } from '@/lib/menu';
+
+const supabase = getSupabase();
 
 function isValidUUID(value) {
   return (

--- a/src/lib/friends.js
+++ b/src/lib/friends.js
@@ -1,4 +1,6 @@
-import { supabase } from './supabase';
+import { getSupabase } from './supabase';
+
+const supabase = getSupabase();
 
 export async function acceptFriendRequest(relationshipId, userId) {
   const { error } = await supabase

--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -1,18 +1,26 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
-if (!supabaseUrl) throw new Error('VITE_SUPABASE_URL is not defined');
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
-if (!supabaseAnonKey) throw new Error('VITE_SUPABASE_ANON_KEY is not defined');
+let supabase = null;
 
-export let supabase = createClient(supabaseUrl, supabaseAnonKey);
+export const getSupabase = () => {
+  if (!supabase) {
+    const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+    if (!supabaseUrl) throw new Error('VITE_SUPABASE_URL is not defined');
+    const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+    if (!supabaseAnonKey) throw new Error('VITE_SUPABASE_ANON_KEY is not defined');
+    supabase = createClient(supabaseUrl, supabaseAnonKey);
+  }
+  return supabase;
+};
 
 export function initializeSupabase(session) {
-  supabase = createClient(supabaseUrl, supabaseAnonKey, {
-    global: {
-      headers: {
-        Authorization: `Bearer ${session?.access_token}`,
-      },
-    },
-  });
+  const client = getSupabase();
+  if (session?.access_token && session?.refresh_token) {
+    client.auth.setSession({
+      access_token: session.access_token,
+      refresh_token: session.refresh_token,
+    });
+  } else {
+    client.auth.signOut();
+  }
 }

--- a/src/lib/tagSuggestions.js
+++ b/src/lib/tagSuggestions.js
@@ -1,4 +1,6 @@
-import { supabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
+
+const supabase = getSupabase();
 
 const COMMON_TAGS = {
   'petit-dejeuner': [

--- a/src/pages/MenuPage.jsx
+++ b/src/pages/MenuPage.jsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import MenuPlanner from '@/components/MenuPlanner';
 import MenuTabs from '@/components/MenuTabs.jsx';
-import { supabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 import { initialWeeklyMenuState } from '@/lib/menu';
 import { useMenus } from '@/hooks/useMenus.js';
 import { useWeeklyMenu } from '@/hooks/useWeeklyMenu.js';
+
+const supabase = getSupabase();
 
 export default function MenuPage({ session, userProfile, recipes }) {
   const { menus, selectedMenuId, setSelectedMenuId, refreshMenus } =

--- a/src/pages/UserProfilePage.jsx
+++ b/src/pages/UserProfilePage.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { useParams, Link, useLocation, useNavigate } from 'react-router-dom';
-import { supabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 import UserRecipeList from '@/components/UserRecipeList.jsx';
 import LoadingScreen from '@/components/layout/LoadingScreen';
 import { UserCircle, ArrowLeft } from 'lucide-react';
@@ -9,6 +9,8 @@ import { useToast } from '@/components/ui/use-toast';
 import RecipeDetailModal from '@/components/RecipeDetailModal';
 import FriendActionButton from '@/components/FriendActionButton.jsx';
 import { formatRecipe } from '@/lib/formatRecipe';
+
+const supabase = getSupabase();
 
 export default function UserProfilePage({
   session,


### PR DESCRIPTION
## Summary
- create a Supabase singleton in `src/lib/supabase.js`
- update hooks and components to use `getSupabase()`
- keep auth initialization via `initializeSupabase`

## Testing
- `npm test` *(fails: "validateDOMNesting" warnings)*
- `npm run lint` *(fails: 518 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6858862c9ff0832da9f474a8be6e3104