### PR TITLE
Fix Supabase init when session missing

### DIFF
--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -2,19 +2,28 @@ import { createClient } from '@supabase/supabase-js';
 
 let supabase = null;
 
-export const getSupabase = () => {
+export const getSupabase = (accessToken) => {
   if (!supabase) {
     const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
     if (!supabaseUrl) throw new Error('VITE_SUPABASE_URL is not defined');
     const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
     if (!supabaseAnonKey) throw new Error('VITE_SUPABASE_ANON_KEY is not defined');
-    supabase = createClient(supabaseUrl, supabaseAnonKey);
+
+    const options = accessToken !== undefined ? {
+      global: {
+        headers: accessToken
+          ? { Authorization: `Bearer ${accessToken}` }
+          : undefined,
+      },
+    } : undefined;
+
+    supabase = createClient(supabaseUrl, supabaseAnonKey, options);
   }
   return supabase;
 };
 
 export function initializeSupabase(session) {
-  const client = getSupabase();
+  const client = getSupabase(session?.access_token);
   if (session?.access_token && session?.refresh_token) {
     client.auth.setSession({
       access_token: session.access_token,


### PR DESCRIPTION
## Summary
- allow passing a token when initializing supabase
- only send Authorization header if the token is present

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68588f1640ac832da565d05c95d45a25