### PR TITLE
Fix recipe update when recipe not found

### DIFF
--- a/src/hooks/useRecipes.jsx
+++ b/src/hooks/useRecipes.jsx
@@ -292,6 +292,15 @@ export function useRecipes(session, subscriptionTier) {
           throw error;
         }
 
+        if (!updatedRecipeResult) {
+          toast({
+            title: 'Erreur',
+            description: 'Recette introuvable.',
+            variant: 'destructive',
+          });
+          return false;
+        }
+
         const { data: user } = await supabase
           .from('public_user_view')
           .select('id, username, avatar_url, bio, subscription_tier')


### PR DESCRIPTION
## Summary
- handle null recipe update result to show an error toast

## Testing
- `npm test`
- `npm run lint` *(fails: 518 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68596f1926d0832d89755059dc953082