### PR TITLE
Fix shared menu creation

### DIFF
--- a/src/__tests__/menuTabs.test.jsx
+++ b/src/__tests__/menuTabs.test.jsx
@@ -89,6 +89,8 @@ describe('MenuTabs', () => {
     render(<Wrapper />);
     const createBtn = screen.getByRole('button', { name: '+ Nouveau menu' });
     fireEvent.click(createBtn);
+    const confirm = screen.getByRole('button', { name: 'Créer' });
+    fireEvent.click(confirm);
     expect(
       screen.getByRole('tab', { name: 'Menu sans titre' })
     ).toBeInTheDocument();

--- a/src/components/MenuTabs.jsx
+++ b/src/components/MenuTabs.jsx
@@ -52,13 +52,18 @@ export default function MenuTabs({
             )}
           </TabsTrigger>
         ))}
-        <button
-          type="button"
-          onClick={() => onCreate && onCreate()}
-          className="ml-2 px-3 py-1 text-sm border-2 border-dashed border-pastel-primary rounded-md whitespace-nowrap hover:bg-pastel-primary hover:text-white"
-        >
-          + Nouveau menu
-        </button>
+        <NewMenuModal
+          onCreate={onCreate}
+          friends={friends}
+          trigger={
+            <button
+              type="button"
+              className="ml-2 px-3 py-1 text-sm border-2 border-dashed border-pastel-primary rounded-md whitespace-nowrap hover:bg-pastel-primary hover:text-white"
+            >
+              + Nouveau menu
+            </button>
+          }
+        />
       </TabsList>
     </Tabs>
   );

--- a/src/pages/MenuPage.jsx
+++ b/src/pages/MenuPage.jsx
@@ -32,7 +32,7 @@ export default function MenuPage({ session, userProfile, recipes }) {
     }
   };
 
-  const handleCreate = async ({ name, isShared = false, participantIds = [] } = {}) => {
+  const handleCreate = async ({ name, isShared, participantIds } = {}) => {
     const userId = session?.user?.id;
     if (!userId) return;
 
@@ -54,14 +54,12 @@ export default function MenuPage({ session, userProfile, recipes }) {
       return;
     }
 
-    if (isShared && participantIds.length > 0 && data?.id) {
-      const rows = participantIds.map((id) => ({ menu_id: data.id, user_id: id }));
-      const { error: participantsError } = await supabase
-        .from('menu_participants')
-        .insert(rows);
-      if (participantsError) {
-        console.error('Erreur ajout participants:', participantsError);
-      }
+    if (isShared && Array.isArray(participantIds)) {
+      const rows = participantIds.map((userId) => ({
+        menu_id: data.id,
+        user_id: userId,
+      }));
+      await supabase.from('menu_participants').insert(rows);
     }
 
     await refreshMenus();


### PR DESCRIPTION
## Summary
- correctly insert menu participants for shared menus
- retrieve friends list in `MenuPage` and pass to `MenuTabs`
- trigger `NewMenuModal` from `MenuTabs` when creating a menu
- update menu creation test to work with modal

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_6859a76ea97c832db9d2a793b8727e9a