### PR TITLE
Implement shared menu enhancements

### DIFF
--- a/src/components/MenuTabs.jsx
+++ b/src/components/MenuTabs.jsx
@@ -36,6 +36,11 @@ export default function MenuTabs({
             className="relative group whitespace-nowrap rounded-md px-3 py-1 text-sm transition-all focus:outline-none focus-visible:ring-0 border border-pastel-primary text-pastel-primary hover:bg-pastel-primary/10 data-[state=active]:bg-pastel-primary data-[state=active]:text-white data-[state=active]:font-semibold data-[state=active]:border-none data-[state=active]:shadow-none"
           >
             {menu.name || 'Menu'}
+            {menu.is_shared && (
+              <span className="ml-2 bg-pastel-tertiary text-white text-xs rounded-full px-1.5 py-0.5">
+                Partagé
+              </span>
+            )}
             {menu.user_id === currentUserId && (
               <button
                 aria-label="Supprimer"

--- a/src/components/NewMenuModal.jsx
+++ b/src/components/NewMenuModal.jsx
@@ -1,5 +1,13 @@
 import React, { useState } from 'react';
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter, DialogTrigger, DialogClose } from '@/components/ui/dialog.jsx';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  DialogTrigger,
+  DialogClose,
+} from '@/components/ui/dialog.jsx';
 import { Button } from '@/components/ui/button.jsx';
 import { Input } from '@/components/ui/input.jsx';
 import { Checkbox } from '@/components/ui/Checkbox.jsx';
@@ -29,7 +37,10 @@ function NewMenuModal({ onCreate, friends = [], trigger }) {
       <DialogTrigger asChild>
         {trigger || <Button>Créer un menu</Button>}
       </DialogTrigger>
-      <DialogContent className="max-w-md">
+      <DialogContent
+        className="max-w-md"
+        overlayClassName="bg-background/80 backdrop-blur-sm"
+      >
         <DialogHeader>
           <DialogTitle>Nouveau menu</DialogTitle>
         </DialogHeader>
@@ -54,7 +65,9 @@ function NewMenuModal({ onCreate, friends = [], trigger }) {
                   <span>{f.username || f.id}</span>
                 </label>
               ))}
-              {friends.length === 0 && <p className="text-sm">Aucun ami disponible</p>}
+              {friends.length === 0 && (
+                <p className="text-sm">Aucun ami disponible</p>
+              )}
             </div>
           )}
         </div>

--- a/src/hooks/useMenuList.js
+++ b/src/hooks/useMenuList.js
@@ -16,7 +16,7 @@ export function useMenuList(session) {
     try {
       const { data: ownerMenus, error: ownerError } = await supabase
         .from('weekly_menus')
-        .select('id, user_id, name, updated_at')
+        .select('id, user_id, name, updated_at, is_shared')
         .eq('user_id', userId)
         .order('created_at');
 
@@ -38,7 +38,7 @@ export function useMenuList(session) {
       if (participantIds.length > 0) {
         const { data, error } = await supabase
           .from('weekly_menus')
-          .select('id, user_id, name, updated_at')
+          .select('id, user_id, name, updated_at, is_shared')
           .in('id', participantIds);
         if (error) throw error;
         participantMenus = data || [];

--- a/src/hooks/useMenuParticipants.js
+++ b/src/hooks/useMenuParticipants.js
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react';
+import { getSupabase } from '@/lib/supabase';
+
+const supabase = getSupabase();
+
+export function useMenuParticipants(menuId) {
+  const [participants, setParticipants] = useState([]);
+
+  useEffect(() => {
+    const fetchParticipants = async () => {
+      if (!menuId) {
+        setParticipants([]);
+        return;
+      }
+
+      const { data: rows, error } = await supabase
+        .from('menu_participants')
+        .select('user_id')
+        .eq('menu_id', menuId);
+
+      if (error) {
+        console.error('Error fetching menu participants:', error);
+        setParticipants([]);
+        return;
+      }
+
+      const ids = (rows || []).map((r) => r.user_id);
+      if (ids.length === 0) {
+        setParticipants([]);
+        return;
+      }
+
+      const { data: users } = await supabase
+        .from('public_user_view')
+        .select('id, username, avatar_url')
+        .in('id', ids);
+
+      setParticipants(users || []);
+    };
+
+    fetchParticipants();
+  }, [menuId]);
+
+  return participants;
+}

--- a/src/hooks/useMenus.js
+++ b/src/hooks/useMenus.js
@@ -19,7 +19,7 @@ export function useMenus(session) {
     try {
       const { data: ownerMenus, error: ownerError } = await supabase
         .from('weekly_menus')
-        .select('id, user_id, name, updated_at')
+        .select('id, user_id, name, updated_at, is_shared')
         .eq('user_id', userId)
         .order('created_at');
 
@@ -41,7 +41,7 @@ export function useMenus(session) {
       if (participantIds.length > 0) {
         const { data, error } = await supabase
           .from('weekly_menus')
-          .select('id, user_id, name, updated_at')
+          .select('id, user_id, name, updated_at, is_shared')
           .in('id', participantIds);
         if (error) throw error;
         participantMenus = data || [];
@@ -100,5 +100,11 @@ export function useMenus(session) {
     }
   }, [selectedMenuId, storageKey]);
 
-  return { menus, loading, selectedMenuId, setSelectedMenuId, refreshMenus: fetchMenus };
+  return {
+    menus,
+    loading,
+    selectedMenuId,
+    setSelectedMenuId,
+    refreshMenus: fetchMenus,
+  };
 }

--- a/src/hooks/useWeeklyMenu.js
+++ b/src/hooks/useWeeklyMenu.js
@@ -18,6 +18,7 @@ export function useWeeklyMenu(session, currentMenuId = null) {
   const [weeklyMenu, setWeeklyMenu] = useState(initialWeeklyMenuState());
   const [menuName, setMenuName] = useState('Menu de la semaine');
   const [menuId, setMenuId] = useState(currentMenuId);
+  const [isShared, setIsShared] = useState(false);
   const [loading, setLoading] = useState(false);
   const { toast } = useToast();
   const userId = session?.user?.id;
@@ -33,6 +34,7 @@ export function useWeeklyMenu(session, currentMenuId = null) {
       data.every((day) => Array.isArray(day))
     ) {
       setWeeklyMenu(data);
+      setIsShared(false);
     } else if (
       data &&
       typeof data === 'object' &&
@@ -43,8 +45,10 @@ export function useWeeklyMenu(session, currentMenuId = null) {
       setWeeklyMenu(data.menu_data);
       if (data.name) setMenuName(data.name);
       if (data.id) setMenuId(data.id);
+      if (typeof data.is_shared === 'boolean') setIsShared(data.is_shared);
     } else {
       setWeeklyMenu(initialWeeklyMenuState());
+      setIsShared(false);
     }
   }, []);
 
@@ -55,7 +59,9 @@ export function useWeeklyMenu(session, currentMenuId = null) {
       try {
         const { data, error } = await supabase
           .from('weekly_menus')
-          .select('id, user_id, name, menu_data, created_at, updated_at')
+          .select(
+            'id, user_id, name, menu_data, is_shared, created_at, updated_at'
+          )
           .eq(id ? 'id' : 'user_id', id || userId)
           .maybeSingle();
 
@@ -147,7 +153,9 @@ export function useWeeklyMenu(session, currentMenuId = null) {
         const { data: upserted, error: upsertError } = await supabase
           .from('weekly_menus')
           .upsert(upsertData)
-          .select('id, user_id, name, menu_data, created_at, updated_at')
+          .select(
+            'id, user_id, name, menu_data, is_shared, created_at, updated_at'
+          )
           .single();
 
         if (upsertError) throw upsertError;
@@ -232,6 +240,7 @@ export function useWeeklyMenu(session, currentMenuId = null) {
   return {
     weeklyMenu,
     menuName,
+    isShared,
     setWeeklyMenu: saveWeeklyMenuToSupabase,
     updateMenuName: updateWeeklyMenuName,
     deleteMenu: deleteWeeklyMenu,

--- a/src/pages/MenuPage.jsx
+++ b/src/pages/MenuPage.jsx
@@ -6,6 +6,9 @@ import { initialWeeklyMenuState } from '@/lib/menu';
 import { useMenus } from '@/hooks/useMenus.js';
 import { useWeeklyMenu } from '@/hooks/useWeeklyMenu.js';
 import { useFriendsList } from '@/hooks/useFriendsList.js';
+import { useMenuParticipants } from '@/hooks/useMenuParticipants.js';
+import SignedImage from '@/components/SignedImage';
+import { DEFAULT_AVATAR_URL } from '@/lib/images';
 
 const supabase = getSupabase();
 
@@ -15,8 +18,16 @@ export default function MenuPage({ session, userProfile, recipes }) {
 
   const friends = useFriendsList(session);
 
-  const { weeklyMenu, menuName, setWeeklyMenu, updateMenuName, deleteMenu } =
-    useWeeklyMenu(session, selectedMenuId);
+  const {
+    weeklyMenu,
+    menuName,
+    isShared,
+    setWeeklyMenu,
+    updateMenuName,
+    deleteMenu,
+  } = useWeeklyMenu(session, selectedMenuId);
+
+  const participants = useMenuParticipants(isShared ? selectedMenuId : null);
 
   const handleRename = async (id, name) => {
     await updateMenuName(name, id);
@@ -77,6 +88,29 @@ export default function MenuPage({ session, userProfile, recipes }) {
         onCreate={handleCreate}
         friends={friends}
       />
+      {isShared && participants.length > 0 && (
+        <div className="bg-pastel-card p-4 rounded-lg shadow-pastel-soft flex flex-wrap items-center gap-3">
+          <span className="font-semibold text-pastel-text">Participants :</span>
+          {participants.map((p) => (
+            <div key={p.id} className="flex items-center gap-2">
+              {p.avatar_url ? (
+                <SignedImage
+                  bucket="avatars"
+                  path={p.avatar_url}
+                  alt={p.username}
+                  fallback={DEFAULT_AVATAR_URL}
+                  className="w-8 h-8 rounded-full object-cover border border-pastel-border"
+                />
+              ) : (
+                <span className="w-8 h-8 rounded-full bg-pastel-muted flex items-center justify-center text-xs text-pastel-muted-foreground">
+                  {p.username?.charAt(0) || 'U'}
+                </span>
+              )}
+              <span className="text-sm">{p.username}</span>
+            </div>
+          ))}
+        </div>
+      )}
       <MenuPlanner
         recipes={recipes}
         weeklyMenu={weeklyMenu}


### PR DESCRIPTION
## Summary
- tweak menu creation modal overlay for better readability
- show a "Partagé" badge on shared menu tabs
- expose shared flag and add participant fetch hook
- display participants on shared menu page

## Testing
- `npm test`
- `npm run lint` *(fails: `react/no-unescaped-entities`, `no-undef`, etc.)*
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_6859b111ec58832d9ed1c928fd3117a7