### PR TITLE
Fix shopping list uses active menu

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,6 +11,7 @@ import MainAppLayout from '@/components/layout/MainAppLayout';
 import LoadingScreen from '@/components/layout/LoadingScreen';
 import { useRecipes } from '@/hooks/useRecipes.jsx';
 import { useWeeklyMenu } from '@/hooks/useWeeklyMenu.js';
+import { useMenus } from '@/hooks/useMenus.js';
 import { useSession } from '@/hooks/useSession.js';
 import { useUserProfile } from '@/hooks/useUserProfile.js';
 import { usePendingFriendRequests } from '@/hooks/usePendingFriendRequests.js';
@@ -57,13 +58,21 @@ function App() {
   } = useRecipes(session, userProfile?.subscription_tier);
 
   const {
+    menus,
+    loading: menusLoading,
+    selectedMenuId,
+    setSelectedMenuId,
+    refreshMenus,
+  } = useMenus(session);
+
+  const {
     weeklyMenu,
     menuName,
     setWeeklyMenu: saveUserWeeklyMenuHook,
     updateMenuName,
     deleteMenu: deleteWeeklyMenu,
     loading: weeklyMenuLoading,
-  } = useWeeklyMenu(session);
+  } = useWeeklyMenu(session, selectedMenuId);
 
   const { pendingCount, refreshPendingFriendRequests } =
     usePendingFriendRequests(session);
@@ -158,8 +167,18 @@ function App() {
           userProfile={userProfile}
           recipes={recipes}
           recipesLoading={recipesLoading}
+          menus={menus}
+          menusLoading={menusLoading}
+          selectedMenuId={selectedMenuId}
+          setSelectedMenuId={setSelectedMenuId}
+          refreshMenus={refreshMenus}
           weeklyMenu={weeklyMenu}
           weeklyMenuLoading={weeklyMenuLoading}
+          menuName={menuName}
+          isShared={isShared}
+          saveUserWeeklyMenuHook={saveUserWeeklyMenuHook}
+          updateMenuName={updateMenuName}
+          deleteWeeklyMenu={deleteWeeklyMenu}
           showRecipeForm={showRecipeForm}
           editingRecipe={editingRecipe}
           openRecipeFormForAdd={openRecipeForm}

--- a/src/components/AppRoutes.jsx
+++ b/src/components/AppRoutes.jsx
@@ -19,8 +19,18 @@ export default function AppRoutes({
   userProfile,
   recipes,
   recipesLoading,
+  menus,
+  menusLoading,
+  selectedMenuId,
+  setSelectedMenuId,
+  refreshMenus,
   weeklyMenu,
   weeklyMenuLoading,
+  menuName,
+  isShared,
+  saveUserWeeklyMenuHook,
+  updateMenuName,
+  deleteWeeklyMenu,
   showRecipeForm,
   editingRecipe,
   openRecipeFormForAdd,
@@ -116,6 +126,17 @@ export default function AppRoutes({
               session={session}
               userProfile={userProfile}
               recipes={recipes}
+              menus={menus}
+              menusLoading={menusLoading}
+              selectedMenuId={selectedMenuId}
+              setSelectedMenuId={setSelectedMenuId}
+              refreshMenus={refreshMenus}
+              weeklyMenu={weeklyMenu}
+              menuName={menuName}
+              isShared={isShared}
+              setWeeklyMenu={saveUserWeeklyMenuHook}
+              updateMenuName={updateMenuName}
+              deleteMenu={deleteWeeklyMenu}
             />
           ) : (
             <Navigate to="/app/recipes" replace />

--- a/src/pages/MenuPage.jsx
+++ b/src/pages/MenuPage.jsx
@@ -3,8 +3,6 @@ import MenuPlanner from '@/components/MenuPlanner';
 import MenuTabs from '@/components/MenuTabs.jsx';
 import { getSupabase } from '@/lib/supabase';
 import { initialWeeklyMenuState } from '@/lib/menu';
-import { useMenus } from '@/hooks/useMenus.js';
-import { useWeeklyMenu } from '@/hooks/useWeeklyMenu.js';
 import { useFriendsList } from '@/hooks/useFriendsList.js';
 import { useMenuParticipants } from '@/hooks/useMenuParticipants.js';
 import SignedImage from '@/components/SignedImage';
@@ -12,20 +10,22 @@ import { DEFAULT_AVATAR_URL } from '@/lib/images';
 
 const supabase = getSupabase();
 
-export default function MenuPage({ session, userProfile, recipes }) {
-  const { menus, selectedMenuId, setSelectedMenuId, refreshMenus } =
-    useMenus(session);
-
+export default function MenuPage({
+  session,
+  userProfile,
+  recipes,
+  menus = [],
+  selectedMenuId,
+  setSelectedMenuId,
+  refreshMenus,
+  weeklyMenu,
+  menuName,
+  isShared,
+  setWeeklyMenu,
+  updateMenuName,
+  deleteMenu,
+}) {
   const friends = useFriendsList(session);
-
-  const {
-    weeklyMenu,
-    menuName,
-    isShared,
-    setWeeklyMenu,
-    updateMenuName,
-    deleteMenu,
-  } = useWeeklyMenu(session, selectedMenuId);
 
   const participants = useMenuParticipants(isShared ? selectedMenuId : null);
 


### PR DESCRIPTION
## Summary
- track the current menu globally
- load weekly menu by selected menu id
- pass menu data and handlers to MenuPage via AppRoutes
- refresh shopping list when menu changes

## Testing
- `npm test`
- `npm run lint` *(fails: react/prop-types issues)*

------
https://chatgpt.com/codex/tasks/task_e_685a8698a824832db79da885864f2f48