### PR TITLE
Fix missing isShared prop

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -68,6 +68,7 @@ function App() {
   const {
     weeklyMenu,
     menuName,
+    isShared,
     setWeeklyMenu: saveUserWeeklyMenuHook,
     updateMenuName,
     deleteMenu: deleteWeeklyMenu,


### PR DESCRIPTION
## Summary
- destructure `isShared` from `useWeeklyMenu` in `App.jsx`

## Testing
- `npm run test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_685a89dd5558832dad6daef3645329db