### PR TITLE
Refresh signed image URLs

### DIFF
--- a/src/lib/images.js
+++ b/src/lib/images.js
@@ -5,11 +5,24 @@ export const DEFAULT_AVATAR_URL = 'https://placehold.co/100x100?text=Avatar';
 
 const supabase = getSupabase();
 
-export async function getSignedImageUrl(bucket, path, fallback = DEFAULT_IMAGE_URL) {
+export async function getSignedImageUrl(
+  bucket,
+  path,
+  fallback = DEFAULT_IMAGE_URL
+) {
   if (!path) return fallback;
-  if (path.startsWith('http')) return path;
+
+  const match = path.match(/\/storage\/v1\/object\/sign\/([^?]+)/);
+  const objectPath = match ? match[1] : path;
+
+  if (!match && path.startsWith('http')) {
+    return path;
+  }
+
   try {
-    const { data, error } = await supabase.storage.from(bucket).createSignedUrl(path, 3600);
+    const { data, error } = await supabase.storage
+      .from(bucket)
+      .createSignedUrl(objectPath, 3600);
     if (error) throw error;
     return data.signedUrl;
   } catch (err) {

--- a/src/pages/UserProfilePage.jsx
+++ b/src/pages/UserProfilePage.jsx
@@ -4,6 +4,8 @@ import { getSupabase } from '@/lib/supabase';
 import UserRecipeList from '@/components/UserRecipeList.jsx';
 import LoadingScreen from '@/components/layout/LoadingScreen';
 import { UserCircle, ArrowLeft } from 'lucide-react';
+import SignedImage from '@/components/SignedImage';
+import { DEFAULT_AVATAR_URL } from '@/lib/images';
 import { Button } from '@/components/ui/button';
 import { useToast } from '@/components/ui/use-toast';
 import RecipeDetailModal from '@/components/RecipeDetailModal';
@@ -187,9 +189,11 @@ export default function UserProfilePage({
         <div className="bg-pastel-card p-6 sm:p-8 rounded-xl shadow-pastel-soft">
           <div className="flex flex-col sm:flex-row items-center sm:items-start gap-6 mb-8">
             {profileData.avatar_url ? (
-              <img
-                src={profileData.avatar_url}
+              <SignedImage
+                bucket="avatars"
+                path={profileData.avatar_url}
                 alt={`Avatar de ${profileData.username}`}
+                fallback={DEFAULT_AVATAR_URL}
                 className="w-32 h-32 rounded-full object-cover border-4 border-pastel-primary shadow-lg"
               />
             ) : (


### PR DESCRIPTION
## Summary
- handle regeneration of expired Supabase URLs in `getSignedImageUrl`
- display user avatars with `SignedImage` so URLs stay valid

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685a8dbb13b4832daa62ec435e8d2bc3