### PR TITLE
Regenerate recipe image URLs via new API endpoint

### DIFF
--- a/api/getSignedImageUrl.ts
+++ b/api/getSignedImageUrl.ts
@@ -1,0 +1,33 @@
+import { VercelRequest, VercelResponse } from '@vercel/node';
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.VITE_SUPABASE_URL;
+if (!supabaseUrl) throw new Error('VITE_SUPABASE_URL is not defined');
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!serviceRoleKey) throw new Error('SUPABASE_SERVICE_ROLE_KEY is not defined');
+
+const supabaseAdmin = createClient(supabaseUrl, serviceRoleKey);
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const path = req.query.path;
+  const bucket = req.query.bucket || 'recipe-images';
+
+  if (!path || typeof path !== 'string' || typeof bucket !== 'string') {
+    return res.status(400).json({ error: 'Invalid path or bucket' });
+  }
+
+  try {
+    const { data, error } = await supabaseAdmin.storage
+      .from(bucket)
+      .createSignedUrl(path, 3600);
+    if (error) throw error;
+    return res.status(200).json({ url: data.signedUrl });
+  } catch (err) {
+    console.error('getSignedImageUrl error:', err.message);
+    return res.status(500).json({ error: 'Internal Server Error' });
+  }
+}

--- a/src/lib/images.js
+++ b/src/lib/images.js
@@ -1,9 +1,5 @@
-import { getSupabase } from './supabase';
-
 export const DEFAULT_IMAGE_URL = 'https://placehold.co/600x400?text=Image';
 export const DEFAULT_AVATAR_URL = 'https://placehold.co/100x100?text=Avatar';
-
-const supabase = getSupabase();
 
 export async function getSignedImageUrl(
   bucket,
@@ -20,11 +16,11 @@ export async function getSignedImageUrl(
   }
 
   try {
-    const { data, error } = await supabase.storage
-      .from(bucket)
-      .createSignedUrl(objectPath, 3600);
-    if (error) throw error;
-    return data.signedUrl;
+    const params = new URLSearchParams({ bucket, path: objectPath });
+    const response = await fetch(`/api/getSignedImageUrl?${params.toString()}`);
+    if (!response.ok) throw new Error('Request failed');
+    const { url } = await response.json();
+    return url;
   } catch (err) {
     console.error('getSignedImageUrl error:', err.message);
     return fallback;


### PR DESCRIPTION
## Summary
- add `/api/getSignedImageUrl` endpoint that signs images with Supabase
- use the endpoint from `getSignedImageUrl` helper so recipe images always have a fresh URL

## Testing
- `npm test`
- `npm run lint` *(fails: many lint errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_685a906922fc832daa03f7380fcadc50