### PR TITLE
Update docs for shared menus

### DIFF
--- a/docs/data-model.sql
+++ b/docs/data-model.sql
@@ -23,8 +23,15 @@ create table weekly_menus (
   user_id uuid references auth.users(id) on delete cascade,
   name text not null,
   menu_data jsonb not null,
+  is_shared boolean default false,
   created_at timestamptz default now(),
   updated_at timestamptz default now()
+);
+
+create table menu_participants (
+  menu_id uuid references weekly_menus(id) on delete cascade,
+  user_id uuid references auth.users(id) on delete cascade,
+  primary key (menu_id, user_id)
 );
 
 create table user_relationships (

--- a/docs/rls-policies.md
+++ b/docs/rls-policies.md
@@ -8,7 +8,22 @@ The project relies on Supabase RLS to secure most tables.
 - "friends_only" recipes are visible to linked users.
 
 ## weekly_menus
-- Only the owner (column `user_id`) can read or modify a menu.
+- The owner (column `user_id`) can read and modify their menu.
+- Users referenced in `menu_participants` can read a shared menu.
+
+```sql
+create policy "allow menu owner" on weekly_menus
+  for all using ( auth.uid() = user_id );
+
+create policy "allow menu participants" on weekly_menus
+  for select using (
+    auth.uid() = user_id
+    or exists (
+      select 1 from menu_participants mp
+      where mp.menu_id = id and mp.user_id = auth.uid()
+    )
+  );
+```
 
 ## user_relationships
 - Rows are visible to the requester and the addressee only.


### PR DESCRIPTION
## Summary
- document the `menu_participants` table
- outline the policies that let participants read shared menus

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685a9396b3e4832d914c9f15a2b2f53a