### PR TITLE
Fix shared menu tab styling

### DIFF
--- a/src/components/MenuTabs.jsx
+++ b/src/components/MenuTabs.jsx
@@ -31,10 +31,11 @@ export default function MenuTabs({
     >
       <TabsList className="flex overflow-x-auto items-center gap-2">
         {menus.map((menu) => {
-          const sharedWithCurrent = Array.isArray(menu.shared_with_ids) &&
+          const sharedWithCurrent =
+            Array.isArray(menu.shared_with_ids) &&
             menu.shared_with_ids.includes(currentUserId);
           const colorClasses = sharedWithCurrent
-            ? 'border-pastel-secondary text-pastel-secondary hover:bg-pastel-secondary/10 data-[state=active]:bg-pastel-secondary'
+            ? 'border-pastel-mint text-pastel-mint hover:bg-pastel-mint/10 data-[state=active]:bg-pastel-mint'
             : 'border-pastel-primary text-pastel-primary hover:bg-pastel-primary/10 data-[state=active]:bg-pastel-primary';
           return (
             <TabsTrigger
@@ -43,7 +44,7 @@ export default function MenuTabs({
               className={cn(
                 'relative group whitespace-nowrap rounded-md px-3 py-1 text-sm transition-all focus:outline-none focus-visible:ring-0 flex items-center',
                 colorClasses,
-                'data-[state=active]:text-white data-[state=active]:font-semibold data-[state=active]:border-none data-[state=active]:shadow-none'
+                'data-[state=active]:text-white data-[state=active]:font-semibold data-[state=active]:border-none'
               )}
             >
               {menu.name || 'Menu'}

--- a/src/index.css
+++ b/src/index.css
@@ -53,6 +53,14 @@
     --pastel-accent-hover: hsl(35 60% 57%);
     --pastel-accent-text: hsl(var(--accent-foreground));
 
+    --pastel-mint-raw: 142 55% 82%;
+    --pastel-mint: hsl(var(--pastel-mint-raw));
+    --pastel-mint-text: hsl(0 0% 100%);
+
+    --pastel-salmon-raw: 22 93% 89%;
+    --pastel-salmon: hsl(var(--pastel-salmon-raw));
+    --pastel-salmon-text: hsl(0 0% 100%);
+
     --pastel-muted: hsl(var(--muted));
     --pastel-muted-foreground: hsl(var(--muted-foreground));
 
@@ -87,7 +95,9 @@
   }
 
   html {
-    transition: background-color 0.3s ease, color 0.3s ease;
+    transition:
+      background-color 0.3s ease,
+      color 0.3s ease;
   }
 
   .dark {
@@ -123,6 +133,14 @@
     --pastel-tertiary-hover: hsl(190 40% 60%);
 
     --pastel-accent-hover: hsl(35 55% 60%);
+
+    --pastel-mint-raw: 142 40% 35%;
+    --pastel-mint: hsl(var(--pastel-mint-raw));
+    --pastel-mint-text: hsl(0 0% 100%);
+
+    --pastel-salmon-raw: 22 65% 40%;
+    --pastel-salmon: hsl(var(--pastel-salmon-raw));
+    --pastel-salmon-text: hsl(0 0% 100%);
 
     --pastel-highlight-raw: 220 20% 35%;
     --pastel-highlight-border: hsl(220 20% 40%);

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -79,6 +79,8 @@ export default {
           hover: 'hsl(var(--pastel-accent-raw) / 0.9)',
           text: 'hsl(var(--pastel-accent-text))',
         },
+        'pastel-mint': '#b6eac9',
+        'pastel-salmon': '#fddcc9',
         'pastel-muted': 'hsl(var(--pastel-muted))',
         'pastel-muted-foreground': 'hsl(var(--pastel-muted-foreground))',
         'pastel-highlight': 'hsl(var(--pastel-highlight-raw))',


### PR DESCRIPTION
## Summary
- add mint and salmon pastel colors to Tailwind theme
- expose variables for the new colors in CSS for both light and dark modes
- update `MenuTabs` to use the mint color for shared menus and restore the active shadow

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a9ac8e054832d85e1208f9ed560bd