### PR TITLE
Add SignedImage fetch mocking test

### DIFF
--- a/src/__tests__/signedImage.test.jsx
+++ b/src/__tests__/signedImage.test.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import SignedImage from '../components/SignedImage.jsx';
+import { DEFAULT_IMAGE_URL } from '../lib/images.js';
+
+// Helper to mock fetch responses
+function mockFetch(response) {
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response));
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('SignedImage', () => {
+  it('uses the signed URL returned by the API', async () => {
+    const signedUrl = 'https://example.com/signed.jpg';
+    mockFetch({ ok: true, json: () => Promise.resolve({ url: signedUrl }) });
+
+    render(<SignedImage bucket="recipe-images" path="image.jpg" alt="image" />);
+
+    const img = await screen.findByRole('img');
+    expect(img).toHaveAttribute('src', signedUrl);
+  });
+
+  it('falls back to default image when API fails', async () => {
+    mockFetch({ ok: false });
+
+    render(<SignedImage bucket="recipe-images" path="image.jpg" alt="image" />);
+
+    const img = await screen.findByRole('img');
+    expect(img).toHaveAttribute('src', DEFAULT_IMAGE_URL);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test for `SignedImage` component
- verify image uses API signed URL or falls back on error

## Testing
- `npx vitest run src/__tests__/signedImage.test.jsx`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_685aa0966e80832dbc19333f6ee3bb28