### PR TITLE
Add bucket whitelist for signed URLs

### DIFF
--- a/api/getSignedImageUrl.ts
+++ b/api/getSignedImageUrl.ts
@@ -20,6 +20,11 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return res.status(400).json({ error: 'Invalid path or bucket' });
   }
 
+  const allowedBuckets = ['recipe-images', 'avatars'];
+  if (!allowedBuckets.includes(bucket)) {
+    return res.status(400).json({ error: 'Invalid bucket' });
+  }
+
   try {
     const { data, error } = await supabaseAdmin.storage
       .from(bucket)


### PR DESCRIPTION
## Summary
- restrict `getSignedImageUrl` to known buckets only

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685aa09a91e0832d88e6bddbdeaabc2e