### PR TITLE
Fix overlay style for NewMenuModal

### DIFF
--- a/src/__tests__/newMenuModalStyle.test.jsx
+++ b/src/__tests__/newMenuModalStyle.test.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, fireEvent, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import NewMenuModal from '../components/NewMenuModal.jsx';
+
+// Simple style test to ensure overlay classes are applied
+
+describe('NewMenuModal overlay style', () => {
+  it('applies the expected overlay classes', () => {
+    render(<NewMenuModal onCreate={() => {}} friends={[]} />);
+    const trigger = screen.getByRole('button', { name: 'Créer un menu' });
+    fireEvent.click(trigger);
+
+    const overlay = document.querySelector('.backdrop-blur-sm');
+    expect(overlay).toBeInTheDocument();
+    expect(overlay).toHaveClass('bg-black/30');
+    expect(overlay).toHaveClass('dark:bg-black/60');
+  });
+});

--- a/src/components/NewMenuModal.jsx
+++ b/src/components/NewMenuModal.jsx
@@ -38,8 +38,8 @@ function NewMenuModal({ onCreate, friends = [], trigger }) {
         {trigger || <Button>Créer un menu</Button>}
       </DialogTrigger>
       <DialogContent
-        className="max-w-md"
-        overlayClassName="bg-background/80 backdrop-blur-sm"
+        className="max-w-md bg-white dark:bg-neutral-900 text-black dark:text-neutral-100"
+        overlayClassName="backdrop-blur-sm bg-black/30 dark:bg-black/60"
       >
         <DialogHeader>
           <DialogTitle>Nouveau menu</DialogTitle>


### PR DESCRIPTION
## Summary
- make NewMenuModal use the same overlay classes as MenuPreferencesModal
- ensure DialogContent provides solid color classes
- add a style test checking the overlay class

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685aa0fd614c832d8f7cae2493743a5e