### PR TITLE
Add shared menu classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,15 @@ Recipe prices are estimated with OpenAI only when required. A new estimate is
 requested when a recipe is created or when its ingredients or base servings
 change during editing. Existing estimates are reused otherwise.
 
+## UI helpers
+
+Two utility classes in `src/index.css` style shared menus:
+
+- `.shared-menu` applies mint colors.
+- `.shared-menu-active` switches the background to salmon when active.
+
+The `MenuTabs` component uses these classes to highlight menus shared with you.
+
 ## 🔐 Configuration des variables d'environnement
 
 La clé `OPENAI_API_KEY` doit être fournie uniquement aux fonctions côté serveur.

--- a/src/__tests__/menuTabs.test.jsx
+++ b/src/__tests__/menuTabs.test.jsx
@@ -123,8 +123,7 @@ describe('MenuTabs', () => {
     );
 
     const tab = screen.getByRole('tab', { name: 'Menu 1' });
-    expect(tab).toHaveClass('border-pastel-mint');
-    expect(tab).toHaveClass('text-pastel-mint');
-    expect(tab).toHaveClass('data-[state=active]:bg-pastel-mint');
+    expect(tab).toHaveClass('shared-menu');
+    expect(tab).toHaveClass('data-[state=active]:shared-menu-active');
   });
 });

--- a/src/components/MenuTabs.jsx
+++ b/src/components/MenuTabs.jsx
@@ -35,8 +35,9 @@ export default function MenuTabs({
             Array.isArray(menu.shared_with_ids) &&
             menu.shared_with_ids.includes(currentUserId);
           const isShared = menu.is_shared || sharedWithCurrent;
+          // Shared menus use mint and salmon helper classes
           const colorClasses = isShared
-            ? 'border-pastel-mint text-pastel-mint hover:bg-pastel-mint/10 data-[state=active]:bg-pastel-mint'
+            ? 'shared-menu data-[state=active]:shared-menu-active'
             : 'border-pastel-primary text-pastel-primary hover:bg-pastel-primary/10 data-[state=active]:bg-pastel-primary';
           return (
             <TabsTrigger

--- a/src/index.css
+++ b/src/index.css
@@ -181,3 +181,13 @@
 ::-webkit-scrollbar-thumb:hover {
   background: hsla(var(--pastel-muted-foreground), 0.8);
 }
+
+@layer components {
+  /* Mint and salmon helpers for shared menus */
+  .shared-menu {
+    @apply border-pastel-mint text-pastel-mint hover:bg-pastel-mint/10;
+  }
+  .shared-menu-active {
+    @apply bg-pastel-salmon text-white;
+  }
+}


### PR DESCRIPTION
## Summary
- define `.shared-menu` and `.shared-menu-active` Tailwind helpers
- update MenuTabs to use the new classes
- document helper usage in README
- adjust tests

## Testing
- `npm run test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_685aa79ce4d8832d99e8391ee1fe43f6