### PR TITLE
Add fixture and test docs for Supabase image

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,28 @@ Run the following command to execute `scripts/test-zod.ts`:
 npx ts-node scripts/test-zod.ts
 ```
 
+## Test recipe image
+
+Some tests rely on a small image stored in Supabase. Upload any PNG to the
+`recipe-images` bucket at `public/test-image.png`.
+
+Example with the Supabase CLI:
+
+```bash
+supabase storage cp ./test-image.png supabase://recipe-images/public/test-image.png
+```
+
+You can also run:
+
+```bash
+npx ts-node scripts/upload-test-image.ts ./test-image.png
+```
+
+Once uploaded, the image will be publicly available at
+`https://<project-ref>.supabase.co/storage/v1/object/public/recipe-images/public/test-image.png`.
+Its location is referenced in `tests/fixtures/recipe-image.json` and used by the
+`SignedImage` tests.
+
 
 ## Price estimation
 

--- a/scripts/upload-test-image.ts
+++ b/scripts/upload-test-image.ts
@@ -1,0 +1,39 @@
+import { createClient } from '@supabase/supabase-js';
+import fs from 'fs';
+import recipeImage from '../tests/fixtures/recipe-image.json' assert { type: 'json' };
+
+const url = process.env.VITE_SUPABASE_URL || process.env.SUPABASE_URL;
+const serviceRole = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!url || !serviceRole) {
+  console.error('VITE_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY must be set');
+  process.exit(1);
+}
+
+const filePath = process.argv[2];
+if (!filePath) {
+  console.error('Usage: ts-node scripts/upload-test-image.ts <file>');
+  process.exit(1);
+}
+
+const data = fs.readFileSync(filePath);
+
+const supabase = createClient(url, serviceRole, {
+  auth: { persistSession: false },
+});
+
+const { bucket, path } = recipeImage;
+
+async function main() {
+  const { error } = await supabase.storage.from(bucket).upload(path, data, {
+    upsert: true,
+    contentType: 'image/png',
+  });
+  if (error) {
+    console.error('Upload failed:', error.message);
+    process.exit(1);
+  }
+  console.log(`Uploaded ${filePath} to ${bucket}/${path}`);
+}
+
+main();

--- a/src/__tests__/signedImage.test.jsx
+++ b/src/__tests__/signedImage.test.jsx
@@ -3,7 +3,9 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import SignedImage from '../components/SignedImage.jsx';
-import { DEFAULT_IMAGE_URL } from '../lib/images.js';
+import * as images from '../lib/images.js';
+import recipeImage from '../../tests/fixtures/recipe-image.json';
+const { DEFAULT_IMAGE_URL } = images;
 
 // Helper to mock fetch responses
 function mockFetch(response) {
@@ -32,5 +34,22 @@ describe('SignedImage', () => {
 
     const img = await screen.findByRole('img');
     expect(img).toHaveAttribute('src', DEFAULT_IMAGE_URL);
+  });
+
+  it('loads a signed URL for the fixture path', async () => {
+    const signedUrl = 'https://example.com/fixture.png';
+    vi.spyOn(images, 'getSignedImageUrl').mockResolvedValue(signedUrl);
+
+    render(
+      <SignedImage bucket={recipeImage.bucket} path={recipeImage.path} alt="fixture" />
+    );
+
+    const img = await screen.findByRole('img');
+    expect(img).toHaveAttribute('src', signedUrl);
+    expect(images.getSignedImageUrl).toHaveBeenCalledWith(
+      recipeImage.bucket,
+      recipeImage.path,
+      DEFAULT_IMAGE_URL
+    );
   });
 });

--- a/tests/fixtures/recipe-image.json
+++ b/tests/fixtures/recipe-image.json
@@ -1,0 +1,4 @@
+{
+  "bucket": "recipe-images",
+  "path": "public/test-image.png"
+}


### PR DESCRIPTION
## Summary
- create fixture describing the sample recipe image in Supabase
- update SignedImage tests to load bucket/path from the fixture
- add a script to upload the fixture image to Supabase
- document how to upload the test image in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ab86d86f0832d86ab0010e81193a2