### PR TITLE
Fix CSP with Supabase and document project reference

### DIFF
--- a/docs/supabase-project-ref.md
+++ b/docs/supabase-project-ref.md
@@ -1,0 +1,3 @@
+# Supabase project reference
+
+This project uses the Supabase project `bunolnhegwzhxqxymmet`.

--- a/vercel.json
+++ b/vercel.json
@@ -5,7 +5,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' https://js.stripe.com; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data: https://*.supabase.co https://*.blob.core.windows.net; connect-src 'self' https://bunolnhegwzhxqxymmet.supabase.co https://js.stripe.com"
+          "value": "default-src 'self'; script-src 'self' https://js.stripe.com; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data: https://*.supabase.co https://*.blob.core.windows.net; connect-src 'self' https://*.supabase.co https://*.stripe.com"
         }
       ]
     }


### PR DESCRIPTION
## Summary
- allow Supabase and Stripe in Content Security Policy
- document the Supabase project reference for future updates

## Testing
- `npm test`
- `npm run lint` *(fails: react/prop-types and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_685abac96870832d904ab624527bf782