### PR TITLE
Update connect-src for vercel subdomains

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,7 +5,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' https://js.stripe.com; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data: https://*.supabase.co https://*.blob.core.windows.net; connect-src 'self' https://*.supabase.co https://*.stripe.com"
+          "value": "default-src 'self'; script-src 'self' https://js.stripe.com; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data: https://*.supabase.co https://*.blob.core.windows.net; connect-src 'self' https://*.supabase.co https://*.stripe.com https://*.vercel.app"
         }
       ]
     }


### PR DESCRIPTION
## Summary
- allow Vercel subdomains in the Content-Security-Policy header

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685ac4c4d334832da3b0586872a91a32