### PR TITLE
Update getSignedImageUrl bucket check

### DIFF
--- a/api/getSignedImageUrl.ts
+++ b/api/getSignedImageUrl.ts
@@ -20,9 +20,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return res.status(400).json({ error: 'Invalid path or bucket' });
   }
 
-  const allowedBuckets = ['recipe-images', 'avatars'];
-  if (!allowedBuckets.includes(bucket)) {
-    return res.status(400).json({ error: 'Invalid bucket' });
+  if (bucket !== 'recipe-images') {
+    return res.status(403).json({ error: 'Bucket not allowed' });
   }
 
   try {


### PR DESCRIPTION
## Summary
- forbid any bucket other than `recipe-images`

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_685ac4c7c784832d94c19ad94cbee599