### PR TITLE
Centralize Supabase configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ STRIPE_PREMIUM_PRICE_ID=<your-premium-price-id>
 These values are injected by Vite and used by the app at runtime.
 Additional documentation is available in the [docs](docs) directory.
 
+All Supabase URLs used by the application are defined in
+`src/config/constants.ts`. Any new interaction with Supabase should import these
+constants instead of hard coding URLs. The buckets currently in use are
+`recipe-images` and `avatars`.
+
 `STRIPE_PUBLISHABLE_KEY` is the public key used by the browser to initialize Stripe.
 `STRIPE_STANDARD_PRICE_ID` and `STRIPE_PREMIUM_PRICE_ID` correspond to the price identifiers for your Standard and Premium subscription plans.
 You can find all three in the Stripe dashboard: the publishable key under **Developers > API keys** and the price IDs on each product's pricing page.
@@ -50,6 +55,8 @@ npx ts-node scripts/test-zod.ts
 
 Some tests rely on a small image stored in Supabase. Upload any PNG to the
 `recipe-images` bucket at `public/test-image.png`.
+The bucket name corresponds to `SUPABASE_BUCKETS.recipes` from
+`src/config/constants.ts`.
 
 Example with the Supabase CLI:
 

--- a/api/getSignedImageUrl.ts
+++ b/api/getSignedImageUrl.ts
@@ -1,5 +1,6 @@
 import { VercelRequest, VercelResponse } from '@vercel/node';
 import { createClient } from '@supabase/supabase-js';
+import { SUPABASE_BUCKETS } from '../src/config/constants';
 
 const supabaseUrl = process.env.VITE_SUPABASE_URL;
 if (!supabaseUrl) throw new Error('VITE_SUPABASE_URL is not defined');
@@ -14,13 +15,13 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   }
 
   const path = req.query.path;
-  const bucket = req.query.bucket || 'recipe-images';
+  const bucket = (req.query.bucket as string) || SUPABASE_BUCKETS.recipes;
 
   if (!path || typeof path !== 'string' || typeof bucket !== 'string') {
     return res.status(400).json({ error: 'Invalid path or bucket' });
   }
 
-  if (bucket !== 'recipe-images') {
+  if (bucket !== SUPABASE_BUCKETS.recipes) {
     return res.status(403).json({ error: 'Bucket not allowed' });
   }
 

--- a/scripts/validate-config.ts
+++ b/scripts/validate-config.ts
@@ -1,0 +1,36 @@
+import { glob } from 'glob';
+import fs from 'fs';
+
+const patterns = [
+  /https:\/\/[^'"`\s]+\.supabase\.co/,
+  /storage\/v1/,
+  /auth\/v1/,
+];
+
+async function main() {
+  const files = await glob('**/*.{js,jsx,ts,tsx,json}', {
+    ignore: ['node_modules/**', 'dist/**', 'build/**', '**/src/config/constants.ts'],
+  });
+
+  let hasHardcoded = false;
+
+  for (const file of files) {
+    const content = fs.readFileSync(file, 'utf8');
+    for (const pattern of patterns) {
+      if (pattern.test(content) && file !== 'src/config/constants.ts') {
+        console.error(`Hardcoded Supabase URL found in ${file}`);
+        hasHardcoded = true;
+        break;
+      }
+    }
+  }
+
+  if (hasHardcoded) {
+    console.error('Supabase URLs should be defined in src/config/constants.ts');
+    process.exit(1);
+  } else {
+    console.log('No hardcoded Supabase URLs found.');
+  }
+}
+
+main();

--- a/src/__tests__/signedImage.test.jsx
+++ b/src/__tests__/signedImage.test.jsx
@@ -5,6 +5,7 @@ import '@testing-library/jest-dom';
 import SignedImage from '../components/SignedImage.jsx';
 import * as images from '../lib/images.js';
 import recipeImage from '../../tests/fixtures/recipe-image.json';
+import { SUPABASE_BUCKETS } from '../config/constants';
 const { DEFAULT_IMAGE_URL } = images;
 
 // Helper to mock fetch responses
@@ -21,7 +22,7 @@ describe('SignedImage', () => {
     const signedUrl = 'https://example.com/signed.jpg';
     mockFetch({ ok: true, json: () => Promise.resolve({ url: signedUrl }) });
 
-    render(<SignedImage bucket="recipe-images" path="image.jpg" alt="image" />);
+    render(<SignedImage bucket={SUPABASE_BUCKETS.recipes} path="image.jpg" alt="image" />);
 
     const img = await screen.findByRole('img');
     expect(img).toHaveAttribute('src', signedUrl);
@@ -30,7 +31,7 @@ describe('SignedImage', () => {
   it('falls back to default image when API fails', async () => {
     mockFetch({ ok: false });
 
-    render(<SignedImage bucket="recipe-images" path="image.jpg" alt="image" />);
+    render(<SignedImage bucket={SUPABASE_BUCKETS.recipes} path="image.jpg" alt="image" />);
 
     const img = await screen.findByRole('img');
     expect(img).toHaveAttribute('src', DEFAULT_IMAGE_URL);

--- a/src/components/FriendsTab.jsx
+++ b/src/components/FriendsTab.jsx
@@ -15,6 +15,7 @@ import {
 import { Link } from 'react-router-dom';
 import SignedImage from '@/components/SignedImage';
 import { DEFAULT_AVATAR_URL } from '@/lib/images';
+import { SUPABASE_BUCKETS } from '@/config/constants';
 import {
   Dialog,
   DialogContent,
@@ -210,7 +211,7 @@ export default function FriendsTab({ session, userProfile, onRequestsChange }) {
                 >
                   {req.avatar_url ? (
                     <SignedImage
-                      bucket="avatars"
+                      bucket={SUPABASE_BUCKETS.avatars}
                       path={req.avatar_url}
                       alt={req.username}
                       fallback={DEFAULT_AVATAR_URL}
@@ -275,7 +276,7 @@ export default function FriendsTab({ session, userProfile, onRequestsChange }) {
                 >
                   {req.avatar_url ? (
                     <SignedImage
-                      bucket="avatars"
+                      bucket={SUPABASE_BUCKETS.avatars}
                       path={req.avatar_url}
                       alt={req.username}
                       fallback={DEFAULT_AVATAR_URL}
@@ -313,7 +314,7 @@ export default function FriendsTab({ session, userProfile, onRequestsChange }) {
                 >
                   {friend.avatar_url ? (
                     <SignedImage
-                      bucket="avatars"
+                      bucket={SUPABASE_BUCKETS.avatars}
                       path={friend.avatar_url}
                       alt={friend.username}
                       fallback={DEFAULT_AVATAR_URL}

--- a/src/components/MyPublicProfile.jsx
+++ b/src/components/MyPublicProfile.jsx
@@ -5,6 +5,7 @@ import LoadingScreen from '@/components/layout/LoadingScreen';
 import { UserCircle, ShieldCheck } from 'lucide-react';
 import SignedImage from '@/components/SignedImage';
 import { DEFAULT_AVATAR_URL } from '@/lib/images';
+import { SUPABASE_BUCKETS } from '@/config/constants';
 import { useToast } from '@/components/ui/use-toast';
 import RecipeDetailModal from '@/components/RecipeDetailModal';
 import { useNavigate, useLocation } from 'react-router-dom';
@@ -139,7 +140,7 @@ export default function MyPublicProfile({
           <div className="flex flex-col sm:flex-row items-center sm:items-center gap-6 mb-8">
             {profileData.avatar_url ? (
               <SignedImage
-                bucket="avatars"
+                bucket={SUPABASE_BUCKETS.avatars}
                 path={profileData.avatar_url}
                 alt={`Avatar de ${profileData.username}`}
                 fallback={DEFAULT_AVATAR_URL}

--- a/src/components/RecipeDetailModal.jsx
+++ b/src/components/RecipeDetailModal.jsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button';
 import { X, Clock, Users, Tag, ClipboardList, Soup } from 'lucide-react';
 import { MEAL_TYPE_OPTIONS_MAP } from '@/lib/mealTypes';
 import SignedImage from '@/components/SignedImage';
+import { SUPABASE_BUCKETS } from '@/config/constants';
 
 function RecipeDetailModal({ recipe, onClose, userProfile }) {
   const servingsPerMealPreference = useMemo(() => {
@@ -98,7 +99,7 @@ function RecipeDetailModal({ recipe, onClose, userProfile }) {
             {recipe.image_url && (
               <div className="aspect-video rounded-lg overflow-hidden border border-pastel-border bg-pastel-muted/50">
                 <SignedImage
-                  bucket="recipe-images"
+                  bucket={SUPABASE_BUCKETS.recipes}
                   path={recipe.image_url}
                   alt={`Image de ${recipe.name}`}
                   className="w-full h-full object-cover"

--- a/src/components/RecipeForm.jsx
+++ b/src/components/RecipeForm.jsx
@@ -16,6 +16,7 @@ import RecipeInstructionsManager from '@/components/form/RecipeInstructionsManag
 import RecipeMetaFields from '@/components/form/RecipeMetaFields';
 import { estimateRecipePrice } from '@/lib/openai';
 import { getSignedImageUrl } from '@/lib/images';
+import { SUPABASE_BUCKETS } from '@/config/constants';
 
 const supabase = getSupabase();
 import {
@@ -137,7 +138,7 @@ function RecipeForm({
         if (recipe.image_url.startsWith('http')) {
           setPreviewImage(recipe.image_url);
         } else {
-          getSignedImageUrl('recipe-images', recipe.image_url).then(
+          getSignedImageUrl(SUPABASE_BUCKETS.recipes, recipe.image_url).then(
             setPreviewImage
           );
         }
@@ -173,7 +174,7 @@ function RecipeForm({
               if (parsed.image_url.startsWith('http')) {
                 setPreviewImage(parsed.image_url);
               } else {
-                getSignedImageUrl('recipe-images', parsed.image_url).then(
+                getSignedImageUrl(SUPABASE_BUCKETS.recipes, parsed.image_url).then(
                   setPreviewImage
                 );
               }
@@ -349,7 +350,7 @@ function RecipeForm({
       const filePath = `${fileName}`;
 
       const { data, error: uploadError } = await supabase.storage
-        .from('recipe-images')
+        .from(SUPABASE_BUCKETS.recipes)
         .upload(filePath, selectedFile);
 
       if (uploadError) throw uploadError;

--- a/src/components/RecipeList.jsx
+++ b/src/components/RecipeList.jsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Edit2, Trash2, Star, Clock, Eye } from 'lucide-react';
 import { RECIPE_CARD_COLORS_CLASSES } from '@/lib/colors';
 import SignedImage from '@/components/SignedImage';
+import { SUPABASE_BUCKETS } from '@/config/constants';
 
 const MemoizedRecipeCard = React.memo(function RecipeCard({
   recipe,
@@ -31,7 +32,7 @@ const MemoizedRecipeCard = React.memo(function RecipeCard({
       {recipe.image_url && (
         <div className="mb-3 aspect-[16/9] rounded-lg overflow-hidden">
           <SignedImage
-            bucket="recipe-images"
+            bucket={SUPABASE_BUCKETS.recipes}
             path={recipe.image_url}
             alt={`Photo de ${recipe.name}`}
             className="w-full h-full object-cover transition-transform duration-300 group-hover:scale-105"

--- a/src/components/UserSearch.jsx
+++ b/src/components/UserSearch.jsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Search, Loader2, UserCircle } from 'lucide-react';
 import SignedImage from '@/components/SignedImage';
 import { DEFAULT_AVATAR_URL } from '@/lib/images';
+import { SUPABASE_BUCKETS } from '@/config/constants';
 import { Link } from 'react-router-dom';
 import { useUserSearch } from '@/hooks/useUserSearch';
 
@@ -41,7 +42,7 @@ export default function UserSearch({ session }) {
                 <div className="flex items-center gap-3">
                   {user.avatar_url ? (
                     <SignedImage
-                      bucket="avatars"
+                      bucket={SUPABASE_BUCKETS.avatars}
                       path={user.avatar_url}
                       alt={`Avatar de ${user.username}`}
                       fallback={DEFAULT_AVATAR_URL}

--- a/src/components/account/ProfileInformationForm.jsx
+++ b/src/components/account/ProfileInformationForm.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { getSupabase } from '@/lib/supabase';
 import { getSignedImageUrl, DEFAULT_AVATAR_URL } from '@/lib/images';
+import { SUPABASE_BUCKETS } from '@/config/constants';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -41,7 +42,7 @@ export default function ProfileInformationForm({
       setBio(userProfile.bio || '');
       setInitialBio(userProfile.bio || '');
       if (userProfile.avatar_url) {
-        getSignedImageUrl('avatars', userProfile.avatar_url, DEFAULT_AVATAR_URL).then(
+        getSignedImageUrl(SUPABASE_BUCKETS.avatars, userProfile.avatar_url, DEFAULT_AVATAR_URL).then(
           setAvatarPreview
         );
       } else {
@@ -202,7 +203,7 @@ export default function ProfileInformationForm({
       if (avatarFile) {
         const fileName = `${session.user.id}/${Date.now()}_${avatarFile.name.replace(/[^a-zA-Z0-9.]/g, '_')}`;
         const { data: uploadData, error: uploadError } = await supabase.storage
-          .from('avatars')
+          .from(SUPABASE_BUCKETS.avatars)
           .upload(fileName, avatarFile, { upsert: true });
 
         if (uploadError) throw uploadError;

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,0 +1,8 @@
+export const SUPABASE_PROJECT_URL = "https://bunolnhegwzhxqxymmet.supabase.co";
+export const SUPABASE_AUTH_URL = `${SUPABASE_PROJECT_URL}/auth/v1`;
+export const SUPABASE_STORAGE_URL = `${SUPABASE_PROJECT_URL}/storage/v1`;
+
+export const SUPABASE_BUCKETS = {
+  recipes: "recipe-images",
+  avatars: "avatars",
+} as const;

--- a/src/pages/MenuPage.jsx
+++ b/src/pages/MenuPage.jsx
@@ -7,6 +7,7 @@ import { useFriendsList } from '@/hooks/useFriendsList.js';
 import { useMenuParticipants } from '@/hooks/useMenuParticipants.js';
 import SignedImage from '@/components/SignedImage';
 import { DEFAULT_AVATAR_URL } from '@/lib/images';
+import { SUPABASE_BUCKETS } from '@/config/constants';
 
 const supabase = getSupabase();
 
@@ -95,7 +96,7 @@ export default function MenuPage({
             <div key={p.id} className="flex items-center gap-2">
               {p.avatar_url ? (
                 <SignedImage
-                  bucket="avatars"
+                  bucket={SUPABASE_BUCKETS.avatars}
                   path={p.avatar_url}
                   alt={p.username}
                   fallback={DEFAULT_AVATAR_URL}

--- a/src/pages/UserProfilePage.jsx
+++ b/src/pages/UserProfilePage.jsx
@@ -6,6 +6,7 @@ import LoadingScreen from '@/components/layout/LoadingScreen';
 import { UserCircle, ArrowLeft } from 'lucide-react';
 import SignedImage from '@/components/SignedImage';
 import { DEFAULT_AVATAR_URL } from '@/lib/images';
+import { SUPABASE_BUCKETS } from '@/config/constants';
 import { Button } from '@/components/ui/button';
 import { useToast } from '@/components/ui/use-toast';
 import RecipeDetailModal from '@/components/RecipeDetailModal';
@@ -178,7 +179,7 @@ export default function UserProfilePage({
           <div className="flex flex-col sm:flex-row items-center sm:items-start gap-6 mb-8">
             {profileData.avatar_url ? (
               <SignedImage
-                bucket="avatars"
+                bucket={SUPABASE_BUCKETS.avatars}
                 path={profileData.avatar_url}
                 alt={`Avatar de ${profileData.username}`}
                 fallback={DEFAULT_AVATAR_URL}


### PR DESCRIPTION
## Summary
- add `src/config/constants.ts` with shared Supabase URLs and bucket names
- use these constants in API and component code
- add script `scripts/validate-config.ts` to detect hard-coded Supabase URLs
- document new constants in the README

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm run test` *(fails: cancelling test run)*
- `node scripts/validate-config.ts` *(fails: requires ts-node which isn't installed)*

------
https://chatgpt.com/codex/tasks/task_e_685aced585cc832d8155db8eefc29152