### PR TITLE
Configure getSignedImageUrl runtime

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -9,5 +9,10 @@
         }
       ]
     }
-  ]
+  ],
+  "functions": {
+    "api/getSignedImageUrl.ts": {
+      "runtime": "vercel-node@canary"
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- configure `api/getSignedImageUrl.ts` runtime in `vercel.json`

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ad94ec1c0832db77c8aaa24e1adf3