### PR TITLE
Fix imports for Vercel deployment

### DIFF
--- a/api/generate-image.ts
+++ b/api/generate-image.ts
@@ -3,11 +3,15 @@ import OpenAI from 'openai';
 import { getUserFromRequest } from '../src/utils/auth.js';
 import generateRecipeImagePrompt from '../src/lib/recipeImagePrompt.js';
 import { createClient } from '@supabase/supabase-js';
-import { SUPABASE_BUCKETS } from '../src/config/constants';
+import {
+  SUPABASE_BUCKETS,
+  SUPABASE_URL,
+  SUPABASE_SERVICE_ROLE_KEY,
+} from '../src/config/constants';
 
-const supabaseUrl = process.env.VITE_SUPABASE_URL;
+const supabaseUrl = SUPABASE_URL;
 if (!supabaseUrl) throw new Error('VITE_SUPABASE_URL is not defined');
-const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const serviceRoleKey = SUPABASE_SERVICE_ROLE_KEY;
 if (!serviceRoleKey) throw new Error('SUPABASE_SERVICE_ROLE_KEY is not defined');
 
 const supabaseAdmin = createClient(supabaseUrl, serviceRoleKey);

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -2,6 +2,11 @@ export const SUPABASE_PROJECT_URL = "https://bunolnhegwzhxqxymmet.supabase.co";
 export const SUPABASE_AUTH_URL = `${SUPABASE_PROJECT_URL}/auth/v1`;
 export const SUPABASE_STORAGE_URL = `${SUPABASE_PROJECT_URL}/storage/v1`;
 
+export const SUPABASE_URL =
+  process.env.VITE_SUPABASE_URL ?? process.env.SUPABASE_URL ?? "";
+export const SUPABASE_SERVICE_ROLE_KEY =
+  process.env.SUPABASE_SERVICE_ROLE_KEY ?? "";
+
 export const SUPABASE_BUCKETS = {
   recipes: "recipe-images",
   avatars: "avatars",


### PR DESCRIPTION
## Summary
- expose SUPABASE URL and service key as constants
- use constants in `api/generate-image.ts`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685bef67d8fc832db22587643a849160