### PR TITLE
Fix constant import path

### DIFF
--- a/api/generate-image.ts
+++ b/api/generate-image.ts
@@ -7,7 +7,7 @@ import {
   SUPABASE_BUCKETS,
   SUPABASE_URL,
   SUPABASE_SERVICE_ROLE_KEY,
-} from '../../src/config/constants';
+} from '../src/config/constants';
 
 const supabaseUrl = SUPABASE_URL;
 if (!supabaseUrl) throw new Error('VITE_SUPABASE_URL is not defined');


### PR DESCRIPTION
## Summary
- fix import path for Supabase constants in serverless function

## Testing
- `npm test` *(fails: npm not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bfa64b790832dbe7bcfeab2b5f069