### PR TITLE
Use env vars directly in backend Supabase calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ These values are injected by Vite and used by the app at runtime.
 Additional documentation is available in the [docs](docs) directory.
 
 All Supabase URLs used by the application are defined in
-`src/config/constants.client.ts` for the frontend and
-`api/config/constants.server.ts` for the backend. Any new interaction with
+`src/config/constants.client.ts`. Any new interaction with
 Supabase should import these constants instead of hard coding URLs. The buckets currently in use are
 `recipe-images` and `avatars`.
 

--- a/api/access-key.ts
+++ b/api/access-key.ts
@@ -1,14 +1,9 @@
 import { VercelRequest, VercelResponse } from '@vercel/node';
 import { createClient } from '@supabase/supabase-js';
 import { getUserFromRequest } from '../src/utils/auth.js';
-import {
-  SUPABASE_URL,
-  SUPABASE_SERVICE_ROLE_KEY,
-} from '../config/constants.server';
-
-const supabaseUrl = SUPABASE_URL;
-if (!supabaseUrl) throw new Error('SUPABASE_URL is not defined');
-const serviceRoleKey = SUPABASE_SERVICE_ROLE_KEY;
+const supabaseUrl = process.env.VITE_SUPABASE_URL;
+if (!supabaseUrl) throw new Error('VITE_SUPABASE_URL is not defined');
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 if (!serviceRoleKey)
   throw new Error('SUPABASE_SERVICE_ROLE_KEY is not defined');
 

--- a/api/config/buckets.ts
+++ b/api/config/buckets.ts
@@ -1,0 +1,4 @@
+export const SUPABASE_BUCKETS = {
+  recipes: 'recipe-images',
+  avatars: 'avatars',
+} as const;

--- a/api/config/constants.server.ts
+++ b/api/config/constants.server.ts
@@ -1,7 +1,0 @@
-export const SUPABASE_URL = process.env.SUPABASE_URL!;
-export const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY!;
-
-export const SUPABASE_BUCKETS = {
-  recipes: 'recipe-images',
-  avatars: 'avatars',
-} as const;

--- a/api/generate-description.ts
+++ b/api/generate-description.ts
@@ -3,14 +3,9 @@ import OpenAI from 'openai';
 import { z } from 'zod';
 import { getUserFromRequest } from '../src/utils/auth.js';
 import { createClient } from '@supabase/supabase-js';
-import {
-  SUPABASE_URL,
-  SUPABASE_SERVICE_ROLE_KEY,
-} from '../config/constants.server';
-
-const supabaseUrl = SUPABASE_URL;
-if (!supabaseUrl) throw new Error('SUPABASE_URL is not defined');
-const serviceRoleKey = SUPABASE_SERVICE_ROLE_KEY;
+const supabaseUrl = process.env.VITE_SUPABASE_URL;
+if (!supabaseUrl) throw new Error('VITE_SUPABASE_URL is not defined');
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 if (!serviceRoleKey) throw new Error('SUPABASE_SERVICE_ROLE_KEY is not defined');
 
 const supabaseAdmin = createClient(supabaseUrl, serviceRoleKey);

--- a/api/generate-image.ts
+++ b/api/generate-image.ts
@@ -3,15 +3,11 @@ import OpenAI from 'openai';
 import { getUserFromRequest } from '../src/utils/auth.js';
 import generateRecipeImagePrompt from '../src/lib/recipeImagePrompt.js';
 import { createClient } from '@supabase/supabase-js';
-import {
-  SUPABASE_BUCKETS,
-  SUPABASE_URL,
-  SUPABASE_SERVICE_ROLE_KEY,
-} from '../config/constants.server';
+import { SUPABASE_BUCKETS } from '../config/buckets';
 
-const supabaseUrl = SUPABASE_URL;
-if (!supabaseUrl) throw new Error('SUPABASE_URL is not defined');
-const serviceRoleKey = SUPABASE_SERVICE_ROLE_KEY;
+const supabaseUrl = process.env.VITE_SUPABASE_URL;
+if (!supabaseUrl) throw new Error('VITE_SUPABASE_URL is not defined');
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 if (!serviceRoleKey) throw new Error('SUPABASE_SERVICE_ROLE_KEY is not defined');
 
 const supabaseAdmin = createClient(supabaseUrl, serviceRoleKey);

--- a/api/getSignedImageUrl.ts
+++ b/api/getSignedImageUrl.ts
@@ -1,14 +1,10 @@
 import { VercelRequest, VercelResponse } from '@vercel/node';
 import { createClient } from '@supabase/supabase-js';
-import {
-  SUPABASE_BUCKETS,
-  SUPABASE_URL,
-  SUPABASE_SERVICE_ROLE_KEY,
-} from '../config/constants.server';
+import { SUPABASE_BUCKETS } from '../config/buckets';
 
-const supabaseUrl = SUPABASE_URL;
-if (!supabaseUrl) throw new Error('SUPABASE_URL is not defined');
-const serviceRoleKey = SUPABASE_SERVICE_ROLE_KEY;
+const supabaseUrl = process.env.VITE_SUPABASE_URL;
+if (!supabaseUrl) throw new Error('VITE_SUPABASE_URL is not defined');
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 if (!serviceRoleKey) throw new Error('SUPABASE_SERVICE_ROLE_KEY is not defined');
 
 const supabaseAdmin = createClient(supabaseUrl, serviceRoleKey);

--- a/api/update-profile.ts
+++ b/api/update-profile.ts
@@ -1,14 +1,9 @@
 import { VercelRequest, VercelResponse } from '@vercel/node';
 import { createClient } from '@supabase/supabase-js';
 import { getUserFromRequest } from '../src/utils/auth.js';
-import {
-  SUPABASE_URL,
-  SUPABASE_SERVICE_ROLE_KEY,
-} from '../config/constants.server';
-
-const supabaseUrl = SUPABASE_URL;
-if (!supabaseUrl) throw new Error('SUPABASE_URL is not defined');
-const serviceRoleKey = SUPABASE_SERVICE_ROLE_KEY;
+const supabaseUrl = process.env.VITE_SUPABASE_URL;
+if (!supabaseUrl) throw new Error('VITE_SUPABASE_URL is not defined');
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 if (!serviceRoleKey)
   throw new Error('SUPABASE_SERVICE_ROLE_KEY is not defined');
 

--- a/scripts/validate-config.ts
+++ b/scripts/validate-config.ts
@@ -14,7 +14,6 @@ async function main() {
       'dist/**',
       'build/**',
       '**/src/config/constants.client.ts',
-      '**/api/config/constants.server.ts',
     ],
   });
 
@@ -25,8 +24,7 @@ async function main() {
     for (const pattern of patterns) {
       if (
         pattern.test(content) &&
-        file !== 'src/config/constants.client.ts' &&
-        file !== 'api/config/constants.server.ts'
+        file !== 'src/config/constants.client.ts'
       ) {
         console.error(`Hardcoded Supabase URL found in ${file}`);
         hasHardcoded = true;
@@ -37,7 +35,7 @@ async function main() {
 
   if (hasHardcoded) {
     console.error(
-      'Supabase URLs should be defined in src/config/constants.client.ts or api/config/constants.server.ts'
+      'Supabase URLs should be defined in src/config/constants.client.ts'
     );
     process.exit(1);
   } else {


### PR DESCRIPTION
## Summary
- remove backend constants module and import env vars directly
- update API handlers to read VITE_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY
- keep SUPABASE_BUCKETS in a lightweight module
- fix config validation script and docs

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c31ab1b68832dab1bd4b7c119060e