### PR TITLE
Add backend env test endpoint

### DIFF
--- a/api/test-env.ts
+++ b/api/test-env.ts
@@ -1,0 +1,26 @@
+import { VercelRequest, VercelResponse } from '@vercel/node';
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  const supabaseUrl = process.env.SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  const urlDefined = Boolean(supabaseUrl);
+  const keyDefined = Boolean(serviceRoleKey);
+
+  if (urlDefined && keyDefined) {
+    return res.status(200).json({
+      status: 'success',
+      SUPABASE_URL: supabaseUrl,
+      SUPABASE_SERVICE_ROLE_KEY: '✔ définie (masquée)',
+    });
+  }
+
+  return res.status(500).json({
+    status: 'error',
+    message: "Variables d'environnement manquantes.",
+    SUPABASE_URL: urlDefined ? supabaseUrl : 'non définie',
+    SUPABASE_SERVICE_ROLE_KEY: keyDefined
+      ? '✔ définie (masquée)'
+      : 'non définie',
+  });
+}


### PR DESCRIPTION
## Summary
- add `api/test-env.ts` to verify Supabase env variables

## Testing
- `npm test`
- `npm run lint` *(fails: 538 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685c372fe4fc832da36e812beec24bb2