### PR TITLE
Corriger l'import de SUPABASE_BUCKETS dans les API

### DIFF
--- a/api/generate-image.ts
+++ b/api/generate-image.ts
@@ -3,7 +3,7 @@ import OpenAI from 'openai';
 import { getUserFromRequest } from '../src/utils/auth.js';
 import generateRecipeImagePrompt from '../src/lib/recipeImagePrompt.js';
 import { createClient } from '@supabase/supabase-js';
-import { SUPABASE_BUCKETS } from './config/buckets';
+import { SUPABASE_BUCKETS } from '../../src/config/constants';
 
 const supabaseUrl = process.env.VITE_SUPABASE_URL;
 if (!supabaseUrl) throw new Error('VITE_SUPABASE_URL is not defined');

--- a/api/getSignedImageUrl.ts
+++ b/api/getSignedImageUrl.ts
@@ -1,6 +1,6 @@
 import { VercelRequest, VercelResponse } from '@vercel/node';
 import { createClient } from '@supabase/supabase-js';
-import { SUPABASE_BUCKETS } from './config/buckets';
+import { SUPABASE_BUCKETS } from '../../src/config/constants';
 
 const supabaseUrl = process.env.VITE_SUPABASE_URL;
 if (!supabaseUrl) throw new Error('VITE_SUPABASE_URL is not defined');

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,3 +1,4 @@
+// Shared constants for backend code
 export const SUPABASE_BUCKETS = {
   recipes: 'recipe-images',
   avatars: 'avatars',


### PR DESCRIPTION
## Summary
- centralize SUPABASE_BUCKETS in `src/config/constants.ts`
- update API functions to import from the new path

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685c3dd58e04832d94817d411314dc87