### PR TITLE
Fix constants imports for API

### DIFF
--- a/api/generate-image.ts
+++ b/api/generate-image.ts
@@ -3,7 +3,11 @@ import OpenAI from 'openai';
 import { getUserFromRequest } from '../src/utils/auth.js';
 import generateRecipeImagePrompt from '../src/lib/recipeImagePrompt.js';
 import { createClient } from '@supabase/supabase-js';
-import { SUPABASE_BUCKETS } from './_shared/constants';
+
+const SUPABASE_BUCKETS = {
+  recipes: 'recipe-images',
+  avatars: 'avatars',
+} as const;
 
 const supabaseUrl = process.env.VITE_SUPABASE_URL;
 if (!supabaseUrl) throw new Error('VITE_SUPABASE_URL is not defined');

--- a/api/getSignedImageUrl.ts
+++ b/api/getSignedImageUrl.ts
@@ -1,6 +1,10 @@
 import { VercelRequest, VercelResponse } from '@vercel/node';
 import { createClient } from '@supabase/supabase-js';
-import { SUPABASE_BUCKETS } from './_shared/constants';
+
+const SUPABASE_BUCKETS = {
+  recipes: 'recipe-images',
+  avatars: 'avatars',
+} as const;
 
 const supabaseUrl = process.env.VITE_SUPABASE_URL;
 if (!supabaseUrl) throw new Error('VITE_SUPABASE_URL is not defined');


### PR DESCRIPTION
## Summary
- embed `SUPABASE_BUCKETS` directly in `generate-image.ts`
- embed `SUPABASE_BUCKETS` directly in `getSignedImageUrl.ts`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c448870e8832daf44bd1469bfa926