### PR TITLE
Fix visibility filter for user profiles

### DIFF
--- a/src/__tests__/userProfileRecipes.test.jsx
+++ b/src/__tests__/userProfileRecipes.test.jsx
@@ -18,10 +18,16 @@ vi.mock('../lib/supabase', () => {
     q.select = vi.fn(() => q);
     q.eq = vi.fn((col, val) => {
       if (col === 'visibility') recipeFilterCalls.eq = [col, val];
+      if (col === 'visibility') {
+        returnData = returnData.filter((r) => r.visibility === val);
+      }
       return q;
     });
     q.in = vi.fn((col, val) => {
       if (col === 'visibility') recipeFilterCalls.in = [col, val];
+      if (col === 'visibility') {
+        returnData = returnData.filter((r) => val.includes(r.visibility));
+      }
       return q;
     });
     q.or = vi.fn(() => q);
@@ -82,9 +88,9 @@ vi.mock('../components/FriendActionButton.jsx', () => ({
 }));
 
 describe('UserProfilePage recipe visibility', () => {
-  it('shows private recipes when users are friends', async () => {
+  it('does not show private recipes when users are friends', async () => {
     const session = { user: { id: 'user1' } };
-    const { findByText } = render(
+    const { queryByText, findByText } = render(
       <MemoryRouter initialEntries={['/user2']}>
         <Routes>
           <Route
@@ -95,10 +101,11 @@ describe('UserProfilePage recipe visibility', () => {
       </MemoryRouter>
     );
 
-    expect(await findByText('Private Recipe')).toBeInTheDocument();
+    await findByText('Public Recipe');
+    expect(queryByText('Private Recipe')).not.toBeInTheDocument();
     expect(recipeFilterCalls.in).toEqual([
       'visibility',
-      ['private', 'public', 'friends_only'],
+      ['public', 'friends_only'],
     ]);
   });
 });

--- a/src/pages/UserProfilePage.jsx
+++ b/src/pages/UserProfilePage.jsx
@@ -91,7 +91,6 @@ export default function UserProfilePage({
         // Owner can see all their recipes
       } else if (currentRelationshipStatus === 'friends') {
         recipesQuery = recipesQuery.in('visibility', [
-          'private',
           'public',
           'friends_only',
         ]);


### PR DESCRIPTION
## Summary
- prevent private recipes from appearing on public profiles
- update UserProfilePage test for new filter

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d1e22feac832d94a7bd09d94e2ba3