### PR TITLE
Fix friend badge color style

### DIFF
--- a/src/components/FriendActionButton.jsx
+++ b/src/components/FriendActionButton.jsx
@@ -138,19 +138,21 @@ export default function FriendActionButton({
     );
   } else {
     const isFriend = status === 'friends';
+    const variant = isFriend ? (hover ? 'destructive' : 'secondary') : 'default';
     content = (
-      <button
+      <Button
         onClick={handleAction}
         onMouseEnter={() => setHover(true)}
         onMouseLeave={() => setHover(false)}
-        className={`mt-4 flex items-center gap-2 px-4 py-1.5 rounded-md border transition-all ${isFriend ? 'bg-green-600 text-white hover:bg-red-600' : 'bg-purple-600 text-white hover:bg-purple-700'}`}
+        variant={variant}
+        className="mt-4 w-40 rounded-full px-3 py-1.5 flex items-center gap-2"
       >
         {isFriend
           ? hover
             ? '❌ Retirer l\u2019ami'
             : '✔️ Vous êtes amis'
           : '➕ Demander en ami'}
-      </button>
+      </Button>
     );
   }
 


### PR DESCRIPTION
## Summary
- restyle friend button to use Button variants from theme

## Testing
- `npm run lint` *(fails: `'process' is not defined` etc.)*
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685d1e53dc30832da7c30e70e48b5b3f