### PR TITLE
Fix active shared menu tab styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,6 @@ Once uploaded, the image will be publicly available at
 Its location is referenced in `tests/fixtures/recipe-image.json` and used by the
 `SignedImage` tests.
 
-
 ## Price estimation
 
 Recipe prices are estimated with OpenAI only when required. A new estimate is
@@ -87,29 +86,28 @@ change during editing. Existing estimates are reused otherwise.
 Two utility classes in `src/index.css` style shared menus:
 
 - `.shared-menu` applies mint colors.
-- `.shared-menu-active` switches the background to salmon when active.
 
-The `MenuTabs` component uses these classes to highlight menus shared with you.
+The `MenuTabs` component uses `.shared-menu` and the
+`data-[state=active]:bg-pastel-mint` utility to highlight the active shared
+menu with a full green background.
 
 ## 🔐 Configuration des variables d'environnement
 
 La clé `OPENAI_API_KEY` doit être fournie uniquement aux fonctions côté serveur.
 
 - **Vercel** : ajoutez `OPENAI_API_KEY` dans les variables d'environnement du projet pour les routes API Node.js.
-- **Supabase** : renseignez `OPENAI_API_KEY` dans *Project Settings > Functions > Environment Variables* pour les fonctions Deno.
+- **Supabase** : renseignez `OPENAI_API_KEY` dans _Project Settings > Functions > Environment Variables_ pour les fonctions Deno.
 
 Cette clé ne doit jamais être exposée au client ; n'utilisez donc pas de préfixe `VITE_`.
 
 # ENV
-OPENAI_API_KEY=sk-...
 
+OPENAI_API_KEY=sk-...
 
 ## Prompt templates
 
 Des exemples de prompts pour générer des images de recettes sont disponibles dans [prompt-templates.md](docs/prompt-templates.md).
 
-
 ## License
 
 This project is released under the [MIT License](LICENSE).
-

--- a/src/__tests__/menuTabs.test.jsx
+++ b/src/__tests__/menuTabs.test.jsx
@@ -128,7 +128,7 @@ describe('MenuTabs', () => {
 
     const tab = screen.getByRole('tab', { name: 'Menu 1' });
     expect(tab).toHaveClass('shared-menu');
-    expect(tab).toHaveClass('data-[state=active]:shared-menu-active');
+    expect(tab).toHaveClass('data-[state=active]:bg-pastel-mint');
   });
 
   it("n'affiche pas le bouton supprimer pour un menu partagé par un autre utilisateur", () => {

--- a/src/components/MenuTabs.jsx
+++ b/src/components/MenuTabs.jsx
@@ -32,9 +32,9 @@ export default function MenuTabs({
       <TabsList className="flex overflow-x-auto items-center gap-2">
         {menus.map((menu) => {
           const isShared = menu.is_shared === true;
-          // Shared menus use mint and salmon helper classes
+          // Shared menus turn mint when active
           const colorClasses = isShared
-            ? 'shared-menu data-[state=active]:shared-menu-active'
+            ? 'shared-menu data-[state=active]:bg-pastel-mint data-[state=active]:text-white'
             : 'border-pastel-primary text-pastel-primary hover:bg-pastel-primary/10 data-[state=active]:bg-pastel-primary';
           return (
             <TabsTrigger

--- a/src/index.css
+++ b/src/index.css
@@ -183,11 +183,8 @@
 }
 
 @layer components {
-  /* Mint and salmon helpers for shared menus */
+  /* Mint helpers for shared menus */
   .shared-menu {
     @apply border-pastel-mint text-pastel-mint hover:bg-pastel-mint/10;
-  }
-  .shared-menu-active {
-    @apply bg-pastel-salmon text-white;
   }
 }


### PR DESCRIPTION
## Summary
- highlight shared menu tabs with a mint background when active
- document mint styling in README
- adjust test expectation

## Testing
- `npm run lint` *(fails: many prop-type errors)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685d1f339ab0832dae39c31b6a8085f4