### PR TITLE
Fix CSP and add SPA rewrites

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,9 +5,14 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' https://js.stripe.com; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data: https://*.supabase.co https://*.blob.core.windows.net; connect-src 'self' https://*.supabase.co https://*.stripe.com https://*.vercel.app"
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://js.stripe.com; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data: https://*.supabase.co https://*.blob.core.windows.net; connect-src 'self' https://*.supabase.co https://*.stripe.com https://*.vercel.app"
         }
       ]
     }
+  ]
+  ,
+  "rewrites": [
+    { "source": "/api/:path*", "destination": "/api/:path*" },
+    { "source": "/:path*", "destination": "/index.html" }
   ]
 }


### PR DESCRIPTION
## Summary
- update script-src to include `unsafe-inline` in CSP
- add rewrites so React Router routes work after refresh

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d25249f2c832db2d110e0826e8c1d