### PR TITLE
Update CSP for Stripe Checkout

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,7 +5,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://js.stripe.com; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data: https://*.supabase.co https://*.blob.core.windows.net; connect-src 'self' https://*.supabase.co https://*.stripe.com https://*.vercel.app"
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://js.stripe.com; frame-src 'self' https://js.stripe.com https://hooks.stripe.com; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data: https://*.supabase.co https://*.blob.core.windows.net; connect-src 'self' https://*.supabase.co https://*.stripe.com https://*.vercel.app"
         }
       ]
     }


### PR DESCRIPTION
## Summary
- allow Stripe Checkout scripts and frames in CSP

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685d2d172688832da88b49d72ff59ee1