### PR TITLE
Improve initial load stability

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,15 @@
     <title>Mealmapp - Alpha</title>
   </head>
   <body class="bg-white text-black dark:bg-[#121212] dark:text-white transition-colors duration-300">
+    <script>
+      (function () {
+        const saved = localStorage.getItem('darkMode');
+        const prefers = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        if (saved === null ? prefers : JSON.parse(saved)) {
+          document.documentElement.classList.add('dark');
+        }
+      })();
+    </script>
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>

--- a/src/components/layout/AppBootstrapGuard.jsx
+++ b/src/components/layout/AppBootstrapGuard.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { useSession } from '@/hooks/useSession.js';
+import useHydrated from '@/hooks/useHydrated.js';
+import LoadingScreen from './LoadingScreen.jsx';
+
+export default function AppBootstrapGuard({ children }) {
+  const { loading } = useSession();
+  const hydrated = useHydrated();
+
+  if (loading || !hydrated) {
+    return <LoadingScreen />;
+  }
+
+  return <>{children}</>;
+}

--- a/src/hooks/useHydrated.js
+++ b/src/hooks/useHydrated.js
@@ -1,0 +1,11 @@
+import { useEffect, useState } from 'react';
+
+export default function useHydrated() {
+  const [hydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
+    setHydrated(true);
+  }, []);
+
+  return hydrated;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -188,3 +188,13 @@
     @apply border-pastel-mint text-pastel-mint hover:bg-pastel-mint/10;
   }
 }
+
+@media (prefers-reduced-motion: reduce) {
+  *, ::before, ::after {
+    animation: none !important;
+    transition-duration: 0s !important;
+  }
+  html {
+    transition: none;
+  }
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,11 +3,14 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from '@/App';
 import '@/index.css';
+import AppBootstrapGuard from '@/components/layout/AppBootstrapGuard.jsx';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <BrowserRouter>
-      <App />
+      <AppBootstrapGuard>
+        <App />
+      </AppBootstrapGuard>
     </BrowserRouter>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- add `useHydrated` hook for hydration detection
- show `LoadingScreen` until session and hydration complete via new `AppBootstrapGuard`
- inject early dark-mode script in `index.html`
- respect `prefers-reduced-motion` in global CSS
- wrap app with `AppBootstrapGuard`

## Testing
- `npm test`
- `npm run lint` *(fails: many prop-types and other issues)*

------
https://chatgpt.com/codex/tasks/task_e_685d30f16e28832d9afe77b8c9939599