### PR TITLE
Fix vercel rewrites and CSP

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,17 +5,13 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://js.stripe.com; frame-src 'self' https://js.stripe.com https://hooks.stripe.com; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data: https://*.supabase.co https://*.blob.core.windows.net; connect-src 'self' https://*.supabase.co https://*.stripe.com https://*.vercel.app"
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://js.stripe.com; frame-src https://js.stripe.com https://hooks.stripe.com https://m.stripe.com; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data: https://*.supabase.co https://*.blob.core.windows.net; connect-src 'self' https://*.supabase.co https://*.stripe.com https://*.vercel.app"
         }
       ]
     }
   ],
   "rewrites": [
-    { "source": "/(.*)", "destination": "/" }
-  ]
-  ,
-  "rewrites": [
     { "source": "/api/:path*", "destination": "/api/:path*" },
-    { "source": "/:path*", "destination": "/index.html" }
+    { "source": "/:path*", "destination": "/" }
   ]
 }


### PR DESCRIPTION
## Summary
- clean up `vercel.json` rewrites
- expand CSP with Stripe domains

## Testing
- `npm run test` *(fails: 1 test file, 2 tests)*

------
https://chatgpt.com/codex/tasks/task_e_685d368baaac832d9b8398b9d8679dbd