### PR TITLE
Add alias for credits purchase API

### DIFF
--- a/api/buy-ia-credits.ts
+++ b/api/buy-ia-credits.ts
@@ -1,0 +1,1 @@
+export { default } from './purchase-credits';

--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -10,4 +10,5 @@ All API routes are under `api/` and are deployed as serverless functions.
 | `api/generate-image` | Generates a DALL·E image, uploads it to Supabase and returns the file path. |
 | `api/update-profile` | Updates fields in `public_user_view` for the current user. |
 | `api/purchase-credits` | Starts a Stripe Checkout session to buy extra AI credits. |
+| `api/buy-ia-credits` | Alias for `api/purchase-credits`. |
 | `api/stripe/webhook` | Deno function that updates subscription metadata after Stripe events. |


### PR DESCRIPTION
## Summary
- expose `/api/buy-ia-credits` as an alias of `/api/purchase-credits`
- document the alias in API overview

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d52630ef4832db291a13f71ce2c6f