### PR TITLE
Fix logo link

### DIFF
--- a/src/components/layout/MainAppLayout.jsx
+++ b/src/components/layout/MainAppLayout.jsx
@@ -51,7 +51,7 @@ export default function MainAppLayout({
         <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-4">
           <div className="flex justify-between items-center">
             <Link
-              to="/recettes"
+              to="/recipes"
               className="text-2xl sm:text-3xl font-bold text-pastel-primary dark:text-pastel-primary-hover flex items-center"
             >
               <Utensils className="h-7 w-7 mr-2 text-pastel-secondary dark:text-pastel-secondary-hover" />


### PR DESCRIPTION
## Summary
- redirect MealMapp logo to `/recipes` in the header

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e895e18d0832dbb1ffbc1191e7cee