### PR TITLE
Implement per-menu preferences

### DIFF
--- a/docs/data-model.sql
+++ b/docs/data-model.sql
@@ -34,6 +34,15 @@ create table menu_participants (
   primary key (menu_id, user_id)
 );
 
+create table weekly_menu_preferences (
+  menu_id uuid primary key references weekly_menus(id) on delete cascade,
+  portions_per_meal integer default 4,
+  daily_calories_limit integer default 2200,
+  weekly_budget numeric default 0,
+  daily_meal_structure text[],
+  tag_preferences text[]
+);
+
 create table user_relationships (
   id uuid primary key default uuid_generate_v4(),
   requester_id uuid references auth.users(id) on delete cascade,

--- a/docs/features.md
+++ b/docs/features.md
@@ -11,6 +11,7 @@
 
 ## Menu Planner
 - Weekly menu stored in the `weekly_menus` table.
+- Menu specific preferences stored in `weekly_menu_preferences`.
 - Calculates total cost and calories per week.
 
 ## AI Features

--- a/docs/rls-policies.md
+++ b/docs/rls-policies.md
@@ -25,6 +25,23 @@ create policy "allow menu participants" on weekly_menus
   );
 ```
 
+## weekly_menu_preferences
+- Linked one-to-one with `weekly_menus` via `menu_id`.
+- The menu owner and participants can read and update the preferences.
+
+```sql
+create policy "allow owner" on weekly_menu_preferences
+  for all using (
+    auth.uid() = (
+      select user_id from weekly_menus wm where wm.id = menu_id
+    )
+    or exists (
+      select 1 from menu_participants mp
+      where mp.menu_id = menu_id and mp.user_id = auth.uid()
+    )
+  );
+```
+
 ## user_relationships
 - Rows are visible to the requester and the addressee only.
 - Updates are restricted so that each participant can update the status of a relationship.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -69,6 +69,8 @@ function App() {
     weeklyMenu,
     menuName,
     isShared,
+    preferences,
+    updatePreferences,
     setWeeklyMenu: saveUserWeeklyMenuHook,
     updateMenuName,
     deleteMenu: deleteWeeklyMenu,
@@ -177,6 +179,8 @@ function App() {
           weeklyMenuLoading={weeklyMenuLoading}
           menuName={menuName}
           isShared={isShared}
+          menuPreferences={preferences}
+          updateMenuPreferences={updatePreferences}
           saveUserWeeklyMenuHook={saveUserWeeklyMenuHook}
           updateMenuName={updateMenuName}
           deleteWeeklyMenu={deleteWeeklyMenu}

--- a/src/components/AppRoutes.jsx
+++ b/src/components/AppRoutes.jsx
@@ -28,6 +28,8 @@ export default function AppRoutes({
   weeklyMenuLoading,
   menuName,
   isShared,
+  menuPreferences,
+  updateMenuPreferences,
   saveUserWeeklyMenuHook,
   updateMenuName,
   deleteWeeklyMenu,
@@ -134,6 +136,8 @@ export default function AppRoutes({
               weeklyMenu={weeklyMenu}
               menuName={menuName}
               isShared={isShared}
+              preferences={menuPreferences}
+              updatePreferences={updateMenuPreferences}
               setWeeklyMenu={saveUserWeeklyMenuHook}
               updateMenuName={updateMenuName}
               deleteMenu={deleteWeeklyMenu}

--- a/src/components/menu_planner/MenuPreferencesPanel.jsx
+++ b/src/components/menu_planner/MenuPreferencesPanel.jsx
@@ -1,275 +1,101 @@
 import React from 'react';
-import { Button } from '@/components/ui/button.jsx';
 import { Input } from '@/components/ui/input.jsx';
 import { Label } from '@/components/ui/label.jsx';
-import { Switch } from '@/components/ui/switch.jsx';
-import {
-  Plus,
-  ChevronDown,
-  ChevronUp,
-  Trash2,
-  Users,
-} from 'lucide-react';
-import { motion } from 'framer-motion';
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogDescription,
-  DialogFooter,
-  DialogTrigger,
-} from '@/components/ui/dialog.jsx';
-import MealTypeSelector from '@/components/MealTypeSelector';
-import TagPreferencesForm from '@/components/menu_planner/TagPreferencesForm.jsx';
+import { Button } from '@/components/ui/button.jsx';
 
 function MenuPreferencesPanel({ preferences, setPreferences, availableTags }) {
+  const update = (field, value) => {
+    setPreferences({ ...preferences, [field]: value });
+  };
+
+  const updateMeal = (index, value) => {
+    const arr = [...(preferences.daily_meal_structure || [])];
+    arr[index] = value;
+    update('daily_meal_structure', arr);
+  };
+
   const addMeal = () => {
-    const newMealNumber = (preferences.meals?.length || 0) + 1;
-    setPreferences({
-      ...preferences,
-      meals: [
-        ...(preferences.meals || []),
-        {
-          id: Date.now(),
-          types: [],
-          enabled: true,
-          mealNumber: newMealNumber,
-        },
-      ],
-    });
+    update('daily_meal_structure', [...(preferences.daily_meal_structure || []), '']);
   };
 
   const removeMeal = (index) => {
-    const newMeals = [...(preferences.meals || [])];
-    newMeals.splice(index, 1);
-    const renumberedMeals = newMeals.map((meal, idx) => ({
-      ...meal,
-      mealNumber: idx + 1,
-    }));
-    setPreferences({ ...preferences, meals: renumberedMeals });
+    const arr = [...(preferences.daily_meal_structure || [])];
+    arr.splice(index, 1);
+    update('daily_meal_structure', arr);
   };
 
-  const toggleMealType = (mealIndex, type) => {
-    const newMeals = [...(preferences.meals || [])];
-    const currentTypes = newMeals[mealIndex].types || [];
-    const typeIndex = currentTypes.indexOf(type);
-
-    if (typeIndex === -1) {
-      newMeals[mealIndex].types = [...currentTypes, type];
-    } else {
-      newMeals[mealIndex].types = currentTypes.filter((t) => t !== type);
-    }
-
-    setPreferences({ ...preferences, meals: newMeals });
-  };
-
-  const moveMeal = (index, direction) => {
-    const newMeals = [...(preferences.meals || [])];
-    let targetIndex;
-    if (direction === 'up' && index > 0) {
-      targetIndex = index - 1;
-    } else if (direction === 'down' && index < newMeals.length - 1) {
-      targetIndex = index + 1;
-    } else {
-      return;
-    }
-    [newMeals[index], newMeals[targetIndex]] = [
-      newMeals[targetIndex],
-      newMeals[index],
-    ];
-    const renumberedMeals = newMeals.map((meal, idx) => ({
-      ...meal,
-      mealNumber: idx + 1,
-    }));
-    setPreferences({ ...preferences, meals: renumberedMeals });
-  };
-
-  const handleServingsPerMealChange = (e) => {
-    const value = parseInt(e.target.value, 10);
-    setPreferences({ ...preferences, servingsPerMeal: value > 0 ? value : 1 });
+  const toggleTag = (tag) => {
+    const set = new Set(preferences.tag_preferences || []);
+    if (set.has(tag)) set.delete(tag); else set.add(tag);
+    update('tag_preferences', Array.from(set));
   };
 
   return (
-    <motion.div
-      initial={{ opacity: 0, height: 0 }}
-      animate={{ opacity: 1, height: 'auto' }}
-      exit={{ opacity: 0, height: 0 }}
-      transition={{ duration: 0.3 }}
-      className="bg-pastel-card p-6 rounded-xl shadow-pastel-soft mb-8 space-y-6 overflow-hidden"
-    >
-      <h3 className="text-xl font-semibold text-pastel-primary">
-        Préférences du menu
-      </h3>
-
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-        <div className="space-y-2">
-          <Label
-            htmlFor="servingsPerMeal"
-            className="block text-base font-medium mb-1.5 flex items-center"
-          >
-            <Users className="w-4 h-4 mr-2 text-pastel-secondary" /> Portions
-            par repas (défaut)
-          </Label>
-          <Input
-            id="servingsPerMeal"
-            type="number"
-            value={preferences.servingsPerMeal || 4}
-            onChange={handleServingsPerMealChange}
-            min="1"
-            step="1"
-            className="max-w-xs"
-          />
-        </div>
-        <div className="space-y-2">
-          <Label
-            htmlFor="maxCalories"
-            className="block text-base font-medium mb-1.5"
-          >
-            Calories max. par jour
-          </Label>
-          <Input
-            id="maxCalories"
-            type="number"
-            value={preferences.maxCalories || 2200}
-            onChange={(e) =>
-              setPreferences({
-                ...preferences,
-                maxCalories: parseInt(e.target.value) || 0,
-              })
-            }
-            min="500"
-            step="50"
-            className="max-w-xs"
-          />
-        </div>
-        <div className="space-y-2">
-          <Label
-            htmlFor="weeklyBudget"
-            className="block text-base font-medium mb-1.5"
-          >
-            Budget hebdomadaire (€)
-          </Label>
-          <Input
-            id="weeklyBudget"
-            type="number"
-            value={preferences.weeklyBudget || 35}
-            onChange={(e) =>
-              setPreferences({
-                ...preferences,
-                weeklyBudget: parseFloat(e.target.value) || 0,
-              })
-            }
-            min="0"
-            step="0.5"
-            className="max-w-xs"
-          />
-        </div>
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <Label htmlFor="portions">Portions par repas</Label>
+        <Input
+          id="portions"
+          type="number"
+          min="1"
+          value={preferences.portions_per_meal ?? 4}
+          onChange={(e) => update('portions_per_meal', parseInt(e.target.value) || 0)}
+        />
       </div>
-
-
-
-      <div className="space-y-4 pt-4 border-t border-pastel-border/70">
-        <div className="flex justify-between items-center">
-          <Label className="text-base font-medium">
-            Composition des repas quotidiens
-          </Label>
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            onClick={addMeal}
-            className="shadow-pastel-button hover:shadow-pastel-button-hover"
-          >
-            <Plus className="w-4 h-4 mr-1.5" /> Ajouter un repas
-          </Button>
-        </div>
-
-        <div className="space-y-4">
-          {(preferences.meals || []).map((meal, index) => (
-            <motion.div
-              key={meal.id || index}
-              initial={{ opacity: 0, y: -10 }}
-              animate={{ opacity: 1, y: 0 }}
-              className="space-y-4 bg-pastel-card p-4 rounded-xl shadow-pastel-soft"
+      <div className="space-y-2">
+        <Label htmlFor="calories">Calories max par jour</Label>
+        <Input
+          id="calories"
+          type="number"
+          value={preferences.daily_calories_limit ?? 2200}
+          onChange={(e) => update('daily_calories_limit', parseInt(e.target.value) || 0)}
+        />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="budget">Budget hebdo (€)</Label>
+        <Input
+          id="budget"
+          type="number"
+          value={preferences.weekly_budget ?? 35}
+          onChange={(e) => update('weekly_budget', parseFloat(e.target.value) || 0)}
+        />
+      </div>
+      <div className="space-y-2">
+        <Label>Structure des repas quotidiens</Label>
+        {(preferences.daily_meal_structure || []).map((m, idx) => (
+          <div key={idx} className="flex gap-2 items-center">
+            <Input
+              type="text"
+              value={m}
+              onChange={(e) => updateMeal(idx, e.target.value)}
+              className="flex-grow"
+            />
+            <Button type="button" variant="ghost" onClick={() => removeMeal(idx)}>
+              X
+            </Button>
+          </div>
+        ))}
+        <Button type="button" variant="outline" size="sm" onClick={addMeal}>
+          Ajouter un élément
+        </Button>
+      </div>
+      <div className="space-y-2">
+        <Label>Tags préférés</Label>
+        <div className="flex flex-wrap gap-2">
+          {(availableTags || []).map((tag) => (
+            <Button
+              key={tag}
+              type="button"
+              variant={preferences.tag_preferences?.includes(tag) ? 'secondary' : 'outline'}
+              onClick={() => toggleTag(tag)}
+              className="px-2 py-1 text-sm"
             >
-              <div className="flex items-center justify-between">
-                <div className="flex items-center gap-2">
-                  <div className="flex flex-col">
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon"
-                      onClick={() => moveMeal(index, 'up')}
-                      disabled={index === 0}
-                      className="h-7 w-7"
-                    >
-                      {' '}
-                      <ChevronUp className="w-4 h-4" />{' '}
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon"
-                      onClick={() => moveMeal(index, 'down')}
-                      disabled={index === (preferences.meals || []).length - 1}
-                      className="h-7 w-7"
-                    >
-                      {' '}
-                      <ChevronDown className="w-4 h-4" />{' '}
-                    </Button>
-                  </div>
-                  <Label className="font-medium text-pastel-text/90">
-                    Repas {meal.mealNumber}
-                  </Label>
-                </div>
-                <div className="flex items-center gap-2">
-                  <Button
-                    type="button"
-                    variant={meal.enabled ? 'secondary' : 'outline'}
-                    size="sm"
-                    onClick={() => {
-                      const newMeals = [...(preferences.meals || [])];
-                      newMeals[index] = {
-                        ...newMeals[index],
-                        enabled: !meal.enabled,
-                      };
-                      setPreferences({ ...preferences, meals: newMeals });
-                    }}
-                    className="min-w-[90px]"
-                  >
-                    {meal.enabled ? 'Activé' : 'Désactivé'}
-                  </Button>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon"
-                    onClick={() => removeMeal(index)}
-                    className="text-red-500 hover:bg-red-500/10 hover:text-red-600 h-8 w-8"
-                  >
-                    {' '}
-                    <Trash2 className="w-4 h-4" />{' '}
-                  </Button>
-                </div>
-              </div>
-
-              <div className="pt-2 border-t border-pastel-border/70">
-                <MealTypeSelector
-                  selectedTypes={meal.types || []}
-                  onToggle={(type) => toggleMealType(index, type)}
-                />
-              </div>
-            </motion.div>
+              {tag}
+            </Button>
           ))}
         </div>
       </div>
-
-      <TagPreferencesForm
-        preferences={preferences}
-        setPreferences={setPreferences}
-        availableTags={availableTags}
-      />
-    </motion.div>
+    </div>
   );
 }
 

--- a/src/components/menu_planner/WeeklyMenuView.jsx
+++ b/src/components/menu_planner/WeeklyMenuView.jsx
@@ -54,7 +54,7 @@ function WeeklyMenuView({
 
     const defaultPlannedServings =
       userProfile?.preferences?.servingsPerMeal ||
-      preferences.servingsPerMeal ||
+      preferences.portions_per_meal ||
       4;
 
     if (updatedMenu[dayIndex]?.[mealIndex]) {
@@ -62,8 +62,6 @@ function WeeklyMenuView({
         ...newRecipe,
         mealNumber:
           updatedMenu[dayIndex][mealIndex][recipeIndex]?.mealNumber ||
-          preferences.meals.find((m) => m.mealNumber === mealIndex + 1)
-            ?.mealNumber ||
           mealIndex + 1,
         plannedServings: defaultPlannedServings,
       };
@@ -85,13 +83,6 @@ function WeeklyMenuView({
     if (!recipeToReplaceInfo) return [];
 
     const { mealIndex } = recipeToReplaceInfo;
-    const mealPreference = preferences.meals.find(
-      (m) => m.mealNumber === mealIndex + 1
-    );
-    const allowedMealTypes = Array.isArray(mealPreference?.types)
-      ? mealPreference.types
-      : [];
-
     const recipesToFilter = [...safeRecipes];
 
     const uniqueRecipeMap = new Map();
@@ -105,19 +96,12 @@ function WeeklyMenuView({
       const nameMatch = recipe.name
         .toLowerCase()
         .includes(searchTermModal.toLowerCase());
-      const recipeMealTypes = Array.isArray(recipe.meal_types)
-        ? recipe.meal_types
-        : [];
-      const typeMatch =
-        allowedMealTypes.length === 0 ||
-        recipeMealTypes.some((rt) => allowedMealTypes.includes(rt));
-      return nameMatch && typeMatch;
+      return nameMatch;
     });
   }, [
     safeRecipes,
     recipeToReplaceInfo,
     searchTermModal,
-    preferences.meals,
   ]);
 
   const totalMenuCost = useMemo(
@@ -126,8 +110,8 @@ function WeeklyMenuView({
   );
 
   const weeklyBudget =
-    preferences.weeklyBudget !== undefined
-      ? preferences.weeklyBudget
+    preferences.weekly_budget !== undefined
+      ? preferences.weekly_budget
       : userProfile?.preferences?.weeklyBudget ?? 0;
   const TOLERANCE = 0.1;
   const maxBudget = weeklyBudget * (1 + TOLERANCE);

--- a/src/pages/MenuPage.jsx
+++ b/src/pages/MenuPage.jsx
@@ -22,6 +22,8 @@ export default function MenuPage({
   weeklyMenu,
   menuName,
   isShared,
+  preferences,
+  updatePreferences,
   setWeeklyMenu,
   updateMenuName,
   deleteMenu,
@@ -64,6 +66,17 @@ export default function MenuPage({
     if (error) {
       console.error('Erreur creation menu:', error);
       return;
+    }
+
+    if (data?.id) {
+      await supabase.from('weekly_menu_preferences').insert({
+        menu_id: data.id,
+        portions_per_meal: 4,
+        daily_calories_limit: 2200,
+        weekly_budget: 35,
+        daily_meal_structure: [],
+        tag_preferences: [],
+      });
     }
 
     if (isShared && Array.isArray(participantIds)) {
@@ -118,6 +131,8 @@ export default function MenuPage({
         setWeeklyMenu={setWeeklyMenu}
         userProfile={userProfile}
         menuName={menuName}
+        preferences={preferences}
+        updatePreferences={updatePreferences}
         onUpdateMenuName={(name) => handleRename(selectedMenuId, name)}
         onDeleteMenu={() => handleDelete(selectedMenuId)}
       />

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,8 @@
+export type WeeklyMenuPreferences = {
+  menu_id: string;
+  portions_per_meal: number;
+  daily_calories_limit: number;
+  weekly_budget: number;
+  daily_meal_structure: string[];
+  tag_preferences: string[];
+};


### PR DESCRIPTION
## Summary
- add new `weekly_menu_preferences` table to docs
- document RLS policy and feature about menu preferences
- expand `useWeeklyMenu` to load and update preferences
- pass preferences from `App` down to `MenuPlanner`
- store preferences when creating a new menu
- redesign preferences panel for new fields
- adjust weekly menu view to use new preference fields
- add TypeScript type for `WeeklyMenuPreferences`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e96b2f1a8832daf34a2c1a34cbcb0