### PR TITLE
Make daily calorie limit optional

### DIFF
--- a/src/components/MenuPlanner.jsx
+++ b/src/components/MenuPlanner.jsx
@@ -65,7 +65,7 @@ function MenuPlanner({
   const [internalPreferences, setInternalPreferences] = useState(
     preferences || {
       portions_per_meal: 4,
-      daily_calories_limit: 2200,
+      daily_calories_limit: 0,
       weekly_budget: 35,
       daily_meal_structure: [],
       tag_preferences: [],
@@ -76,7 +76,7 @@ function MenuPlanner({
     setInternalPreferences(
       preferences || {
         portions_per_meal: 4,
-        daily_calories_limit: 2200,
+        daily_calories_limit: 0,
         weekly_budget: 35,
         daily_meal_structure: [],
         tag_preferences: [],

--- a/src/components/menu_planner/MenuPreferencesPanel.jsx
+++ b/src/components/menu_planner/MenuPreferencesPanel.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Input } from '@/components/ui/input.jsx';
 import { Label } from '@/components/ui/label.jsx';
 import { Button } from '@/components/ui/button.jsx';
+import { Checkbox } from '@/components/ui/Checkbox.jsx';
 
 function MenuPreferencesPanel({ preferences, setPreferences, availableTags }) {
   const update = (field, value) => {
@@ -43,12 +44,36 @@ function MenuPreferencesPanel({ preferences, setPreferences, availableTags }) {
         />
       </div>
       <div className="space-y-2">
+        <div className="flex items-center space-x-2">
+          <Checkbox
+            id="limit-calories"
+            checked={preferences.daily_calories_limit > 0}
+            onChange={(checked) =>
+              update(
+                'daily_calories_limit',
+                checked
+                  ? preferences.daily_calories_limit > 0
+                    ? preferences.daily_calories_limit
+                    : 2200
+                  : 0
+              )
+            }
+          />
+          <Label htmlFor="limit-calories">Limiter les calories ?</Label>
+        </div>
         <Label htmlFor="calories">Calories max par jour</Label>
         <Input
           id="calories"
           type="number"
-          value={preferences.daily_calories_limit ?? 2200}
-          onChange={(e) => update('daily_calories_limit', parseInt(e.target.value) || 0)}
+          disabled={!(preferences.daily_calories_limit > 0)}
+          value={
+            preferences.daily_calories_limit > 0
+              ? preferences.daily_calories_limit
+              : 2200
+          }
+          onChange={(e) =>
+            update('daily_calories_limit', parseInt(e.target.value) || 0)
+          }
         />
       </div>
       <div className="space-y-2">

--- a/src/hooks/useMenuGeneration.js
+++ b/src/hooks/useMenuGeneration.js
@@ -116,7 +116,16 @@ export function useMenuGeneration(
       uniqueRecipeCountsByUser[u] = uniqueRecipeCountsByUser[u].size;
     });
 
-    const dailyCalorieTarget = preferences.maxCalories || 2200;
+    const dailyCalorieTarget =
+      typeof preferences.maxCalories === 'number'
+        ? preferences.maxCalories > 0
+          ? preferences.maxCalories
+          : Infinity
+        : typeof preferences.daily_calories_limit === 'number'
+          ? preferences.daily_calories_limit > 0
+            ? preferences.daily_calories_limit
+            : Infinity
+          : Infinity;
 
     const activeMealsPreferences =
       preferences.meals?.filter((m) => m.enabled) || [];

--- a/src/hooks/useWeeklyMenu.js
+++ b/src/hooks/useWeeklyMenu.js
@@ -5,7 +5,7 @@ import { initialWeeklyMenuState } from '@/lib/menu';
 
 const defaultPrefs = {
   portions_per_meal: 4,
-  daily_calories_limit: 2200,
+  daily_calories_limit: 0,
   weekly_budget: 35,
   daily_meal_structure: [],
   tag_preferences: [],

--- a/src/pages/MenuPage.jsx
+++ b/src/pages/MenuPage.jsx
@@ -72,7 +72,7 @@ export default function MenuPage({
       await supabase.from('weekly_menu_preferences').insert({
         menu_id: data.id,
         portions_per_meal: 4,
-        daily_calories_limit: 2200,
+        daily_calories_limit: 0,
         weekly_budget: 35,
         daily_meal_structure: [],
         tag_preferences: [],


### PR DESCRIPTION
## Summary
- add checkbox in menu preferences to enable daily calorie limit
- default to unlimited calories in weekly menu preferences
- ignore calorie limit in generation when disabled

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e9eac7ea0832dada3f83b64f682d4