### PR TITLE
Add UI fallback for menu preferences

### DIFF
--- a/src/pages/MenuPage.jsx
+++ b/src/pages/MenuPage.jsx
@@ -44,6 +44,13 @@ export default function MenuPage({
   updateMenuName,
   deleteMenu,
 }) {
+  if (!preferences) {
+    return <div>Chargement des préférences...</div>;
+  }
+
+  if (!preferences?.commonMenuSettings?.enabled) {
+    return <div>Les préférences de ce menu sont désactivées.</div>;
+  }
   const friends = useFriendsList(session);
 
   const participants = useMenuParticipants(isShared ? selectedMenuId : null);


### PR DESCRIPTION
## Summary
- show an explicit message while menu preferences load or are disabled

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685edb4238dc832db9b3e123d4114e1e