### PR TITLE
fix enabled check for menu preferences

### DIFF
--- a/src/pages/MenuPage.jsx
+++ b/src/pages/MenuPage.jsx
@@ -48,7 +48,9 @@ export default function MenuPage({
     return <div>Chargement des préférences...</div>;
   }
 
-  if (!preferences?.commonMenuSettings?.enabled) {
+  const enabled = preferences.commonMenuSettings?.enabled ?? false;
+
+  if (!enabled) {
     return <div>Les préférences de ce menu sont désactivées.</div>;
   }
   const friends = useFriendsList(session);


### PR DESCRIPTION
## Summary
- ensure menu preferences check doesn't misfire when not loaded yet

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ef477c490832db47978fbd7d09ac2