### PR TITLE
Add preferences debug log

### DIFF
--- a/src/pages/MenuPage.jsx
+++ b/src/pages/MenuPage.jsx
@@ -57,6 +57,10 @@ export default function MenuPage({
   const [participantWeights, setParticipantWeights] = useState({});
 
   useEffect(() => {
+    console.log('preferences:', preferences);
+  }, [preferences]);
+
+  useEffect(() => {
     if (participants.length > 0) {
       setParticipantWeights((prev) => {
         const count = participants.length;


### PR DESCRIPTION
## Summary
- add a `useEffect` in `MenuPage` to log the received preferences

## Testing
- `npm run lint` *(fails: react/no-unescaped-entities etc.)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ef48643fc832da494756259af3164