### PR TITLE
Handle null selected menu ID when loading preferences

### DIFF
--- a/src/hooks/useWeeklyMenu.js
+++ b/src/hooks/useWeeklyMenu.js
@@ -94,6 +94,9 @@ export function useWeeklyMenu(session, currentMenuId = null) {
 
   const fetchWeeklyMenu = useCallback(
     async (id = menuId) => {
+      if (!id) {
+        console.warn('Menu ID is null — impossible de charger les préférences');
+      }
       if (!id && !userId) return;
       setLoading(true);
       try {


### PR DESCRIPTION
## Summary
- add warning when fetching preferences without a menu id

## Testing
- `npm test` *(fails: `vitest` not found)*
- `npm run lint` *(fails: ESLint configuration missing)*

------
https://chatgpt.com/codex/tasks/task_e_685eff4a4008832dbc3183aa7f2f7f52