### PR TITLE
Add common menu settings to weekly preferences

### DIFF
--- a/src/hooks/useWeeklyMenu.js
+++ b/src/hooks/useWeeklyMenu.js
@@ -9,6 +9,7 @@ const defaultPrefs = {
   weeklyBudget: 35,
   meals: [],
   tagPreferences: [],
+  commonMenuSettings: { enabled: false, linkedUsers: [], linkedUserRecipes: [] },
 };
 
 function fromDbPrefs(pref) {
@@ -25,6 +26,18 @@ function fromDbPrefs(pref) {
     weeklyBudget: pref.weekly_budget ?? 35,
     meals,
     tagPreferences: pref.tag_preferences || [],
+    commonMenuSettings: {
+      ...defaultPrefs.commonMenuSettings,
+      ...(pref.common_menu_settings || {}),
+      linkedUsers: Array.isArray(pref.common_menu_settings?.linkedUsers)
+        ? pref.common_menu_settings.linkedUsers
+        : [],
+      linkedUserRecipes: Array.isArray(
+        pref.common_menu_settings?.linkedUserRecipes
+      )
+        ? pref.common_menu_settings.linkedUserRecipes
+        : [],
+    },
   };
 }
 
@@ -39,6 +52,8 @@ function toDbPrefs(pref) {
           .map((m) => (m.types && m.types[0] ? m.types[0] : ''))
       : [],
     tag_preferences: pref.tagPreferences || [],
+    common_menu_settings:
+      pref.commonMenuSettings || defaultPrefs.commonMenuSettings,
   };
 }
 

--- a/src/pages/MenuPage.jsx
+++ b/src/pages/MenuPage.jsx
@@ -17,6 +17,11 @@ const mapPrefsToDb = (p) => ({
     ? p.meals.filter((m) => m.enabled).map((m) => (m.types && m.types[0] ? m.types[0] : ''))
     : [],
   tag_preferences: p.tagPreferences || [],
+  common_menu_settings: p.commonMenuSettings || {
+    enabled: false,
+    linkedUsers: [],
+    linkedUserRecipes: [],
+  },
 });
 
 const DEFAULT_PREF = {
@@ -25,6 +30,7 @@ const DEFAULT_PREF = {
   weeklyBudget: 35,
   meals: [],
   tagPreferences: [],
+  commonMenuSettings: { enabled: false, linkedUsers: [], linkedUserRecipes: [] },
 };
 
 export default function MenuPage({


### PR DESCRIPTION
## Summary
- support `commonMenuSettings` when reading/writing weekly menu preferences
- include the field when creating menus via `MenuPage`

## Testing
- `npm run lint` *(fails: `'process' is not defined` among others)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fc0c90908832d90ec16594b5ad77e