### PR TITLE
Fix shared menu preferences persistence

### DIFF
--- a/src/hooks/useWeeklyMenu.js
+++ b/src/hooks/useWeeklyMenu.js
@@ -9,7 +9,7 @@ const defaultPrefs = {
   weeklyBudget: 35,
   meals: [],
   tagPreferences: [],
-  commonMenuSettings: { enabled: false, linkedUsers: [], linkedUserRecipes: [] },
+  commonMenuSettings: { enabled: true, linkedUsers: [], linkedUserRecipes: [] },
 };
 
 function fromDbPrefs(pref) {
@@ -26,18 +26,7 @@ function fromDbPrefs(pref) {
     weeklyBudget: pref.weekly_budget ?? 35,
     meals,
     tagPreferences: pref.tag_preferences || [],
-    commonMenuSettings: {
-      ...defaultPrefs.commonMenuSettings,
-      ...(pref.common_menu_settings || {}),
-      linkedUsers: Array.isArray(pref.common_menu_settings?.linkedUsers)
-        ? pref.common_menu_settings.linkedUsers
-        : [],
-      linkedUserRecipes: Array.isArray(
-        pref.common_menu_settings?.linkedUserRecipes
-      )
-        ? pref.common_menu_settings.linkedUserRecipes
-        : [],
-    },
+    commonMenuSettings: pref.common_menu_settings ?? { enabled: true },
   };
 }
 
@@ -52,8 +41,7 @@ function toDbPrefs(pref) {
           .map((m) => (m.types && m.types[0] ? m.types[0] : ''))
       : [],
     tag_preferences: pref.tagPreferences || [],
-    common_menu_settings:
-      pref.commonMenuSettings || defaultPrefs.commonMenuSettings,
+    common_menu_settings: pref.commonMenuSettings ?? { enabled: true },
   };
 }
 


### PR DESCRIPTION
## Summary
- always enable common menu settings by default
- persist `common_menu_settings` when loading and saving weekly menu preferences

## Testing
- `npm test` *(fails: `vitest` not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_685fdbf06e24832dbc52044aef46518f