### PR TITLE
Fix IA credit UI display

### DIFF
--- a/src/components/RecipeFormAIFeatures.jsx
+++ b/src/components/RecipeFormAIFeatures.jsx
@@ -54,8 +54,7 @@ const RecipeFormAIFeatures = ({
       </div>
       {subscription_tier === 'vip' && (
         <p className="text-xs text-pastel-muted-foreground text-right">
-          Descriptions IA : {iaUsage?.text_requests ?? 0} / 20 (crédits :{' '}
-          {iaUsage?.text_credits ?? 0})
+          Crédits restants : {iaUsage?.text_credits ?? 0}
         </p>
       )}
       <Textarea

--- a/src/components/RecipeFormImageHandler.jsx
+++ b/src/components/RecipeFormImageHandler.jsx
@@ -84,8 +84,7 @@ const RecipeFormImageHandler = ({
       </div>
       {subscription_tier === 'vip' && (
         <p className="text-xs text-pastel-muted-foreground text-right">
-          Images IA : {iaUsage?.image_requests ?? 0} / 5 (crédits :{' '}
-          {iaUsage?.image_credits ?? 0})
+          Crédits restants : {iaUsage?.image_credits ?? 0}
         </p>
       )}
       {previewImage && (


### PR DESCRIPTION
## Summary
- adjust recipe form to show remaining IA credits

## Testing
- `npm test`
- `npm run lint` *(fails: 555 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685fe0c6e3e4832db97dd7eb23908475