### PR TITLE
Add test for preference DB conversion

### DIFF
--- a/src/hooks/useWeeklyMenu.js
+++ b/src/hooks/useWeeklyMenu.js
@@ -12,7 +12,7 @@ const defaultPrefs = {
   commonMenuSettings: { enabled: true, linkedUsers: [], linkedUserRecipes: [] },
 };
 
-function fromDbPrefs(pref) {
+export function fromDbPrefs(pref) {
   if (!pref) return { ...defaultPrefs };
   const meals = (pref.daily_meal_structure || []).map((t, idx) => ({
     id: idx + 1,
@@ -30,7 +30,7 @@ function fromDbPrefs(pref) {
   };
 }
 
-function toDbPrefs(pref) {
+export function toDbPrefs(pref) {
   return {
     portions_per_meal: pref.servingsPerMeal,
     daily_calories_limit: pref.maxCalories,
@@ -45,8 +45,6 @@ function toDbPrefs(pref) {
   };
 }
 
-const supabase = getSupabase();
-
 function isValidUUID(value) {
   return (
     typeof value === 'string' &&
@@ -57,6 +55,7 @@ function isValidUUID(value) {
 }
 
 export function useWeeklyMenu(session, currentMenuId = null) {
+  const supabase = getSupabase();
   const [weeklyMenu, setWeeklyMenu] = useState(initialWeeklyMenuState());
   const [menuName, setMenuName] = useState('Menu de la semaine');
   const [menuId, setMenuId] = useState(currentMenuId);

--- a/tests/preferences.spec.ts
+++ b/tests/preferences.spec.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { toDbPrefs, fromDbPrefs } from '../src/hooks/useWeeklyMenu.js';
+
+describe('preferences conversion', () => {
+  it('preserves commonMenuSettings through DB round trip', () => {
+    const prefs = {
+      servingsPerMeal: 3,
+      maxCalories: 1500,
+      weeklyBudget: 20,
+      meals: [
+        { id: 1, mealNumber: 1, types: ['petit-dejeuner'], enabled: true },
+      ],
+      tagPreferences: ['vegan'],
+      commonMenuSettings: {
+        enabled: true,
+        linkedUsers: [{ id: 'u1', name: 'Alice', ratio: 50 }],
+        linkedUserRecipes: [],
+      },
+    };
+
+    const dbShape = toDbPrefs(prefs);
+    expect(dbShape.common_menu_settings).toEqual(prefs.commonMenuSettings);
+
+    const restored = fromDbPrefs(dbShape);
+    expect(restored).toEqual(prefs);
+  });
+});


### PR DESCRIPTION
## Summary
- export `fromDbPrefs` and `toDbPrefs` for testing
- initialize Supabase client inside `useWeeklyMenu` to avoid env access on import
- add new `preferences.spec.ts` verifying round trip of `commonMenuSettings`

## Testing
- `npm run test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_685feb18547c832da2a8893a7a36f2ed