### PR TITLE
Align enabled defaults and update type

### DIFF
--- a/src/hooks/useUserProfile.js
+++ b/src/hooks/useUserProfile.js
@@ -24,7 +24,7 @@ export function useUserProfile(session) {
         weeklyBudget: 35,
         meals: [],
         tagPreferences: [],
-        commonMenuSettings: { enabled: false, linkedUsers: [] },
+        commonMenuSettings: { enabled: true, linkedUsers: [] },
       },
     };
 
@@ -91,7 +91,7 @@ export function useUserProfile(session) {
         weeklyBudget: 35,
         meals: [],
         tagPreferences: [],
-        commonMenuSettings: { enabled: false, linkedUsers: [] },
+        commonMenuSettings: { enabled: true, linkedUsers: [] },
       };
       finalProfileData.preferences = {
         ...defaultPreferences,

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,5 +20,9 @@ export type WeeklyMenuPreferences = {
   }[];
   /** Camel case tag preferences for generator */
   tagPreferences?: { tag: string; percentage: number }[] | string[];
-  common_menu_settings?: CommonMenuSettings;
+  common_menu_settings?: {
+    enabled: boolean;
+    linkedUsers?: string[];
+    linkedUsersReadOnly?: string[];
+  };
 };


### PR DESCRIPTION
## Summary
- set common menu settings to enabled by default when creating user profile
- extend `WeeklyMenuPreferences` to include `linkedUsers` and `linkedUsersReadOnly`

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_685fee3f1d98832db56a1a2c888109f1