### PR TITLE
Fix common menu settings interface

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 export interface CommonMenuSettings {
   enabled: boolean;
-  linkedUsers: any[];
-  linkedUserRecipes?: any[];
+  linkedUsers?: string[];
+  linkedUserRecipes?: string[];
 }
 
 export type WeeklyMenuPreferences = {
@@ -20,9 +20,5 @@ export type WeeklyMenuPreferences = {
   }[];
   /** Camel case tag preferences for generator */
   tagPreferences?: { tag: string; percentage: number }[] | string[];
-  common_menu_settings?: {
-    enabled: boolean;
-    linkedUsers?: string[];
-    linkedUsersReadOnly?: string[];
-  };
+  common_menu_settings?: CommonMenuSettings;
 };


### PR DESCRIPTION
## Summary
- update `WeeklyMenuPreferences` to use the exported `CommonMenuSettings`
- add `linkedUserRecipes` and drop the unused `linkedUsersReadOnly`

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_685ff68ea69c832dbc93cdba61c7d9e5