### PR TITLE
Add full data model interfaces

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -22,3 +22,71 @@ export type WeeklyMenuPreferences = {
   tagPreferences?: { tag: string; percentage: number }[] | string[];
   common_menu_settings?: CommonMenuSettings;
 };
+
+export interface Recipe {
+  id: string;
+  user_id: string;
+  name: string;
+  /** Optional text description */
+  description: string | null;
+  servings: number;
+  /** JSON structure of ingredients or null */
+  ingredients: unknown | null;
+  /** May be stored as raw text or JSON array */
+  instructions: string | string[] | null;
+  calories: number | null;
+  meal_types: string[] | null;
+  tags: string[] | null;
+  visibility: string;
+  image_url: string | null;
+  estimated_price: number | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface WeeklyMenu {
+  id: string;
+  user_id: string;
+  name: string;
+  /** 7 day menu array */
+  menu_data: unknown;
+  is_shared: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface MenuParticipant {
+  menu_id: string;
+  user_id: string;
+}
+
+export interface UserRelationship {
+  id: string;
+  requester_id: string;
+  addressee_id: string;
+  status: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface AccessKey {
+  id: string;
+  key: string;
+  grants: unknown | null;
+  used_by: string | null;
+  used_at: string | null;
+}
+
+export interface IaUsage {
+  user_id: string;
+  month: string;
+  text_requests: number;
+  image_requests: number;
+}
+
+export interface IaCredits {
+  user_id: string;
+  text_credits: number;
+  image_credits: number;
+  updated_at: string;
+}


### PR DESCRIPTION
## Summary
- document Recipe/WeeklyMenu and other tables in TypeScript
- cover nullable database fields in comments

## Testing
- `npm test`
- `npm run lint` *(fails: 555 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685ffe3038f4832da13aa111fc7e5234