### PR TITLE
Replace inline defaults with constant

### DIFF
--- a/src/components/MenuPlanner.jsx
+++ b/src/components/MenuPlanner.jsx
@@ -5,6 +5,7 @@ import MenuPreferencesModal from '@/components/menu_planner/MenuPreferencesModal
 import WeeklyMenuView from '@/components/menu_planner/WeeklyMenuView.jsx';
 import { useMenuGeneration } from '@/hooks/useMenuGeneration.js';
 import { initialWeeklyMenuState } from '@/lib/menu';
+import { DEFAULT_MENU_PREFS } from '@/lib/defaultPreferences.js';
 import {
   Dialog,
   DialogContent,
@@ -63,25 +64,11 @@ function MenuPlanner({
   };
 
   const [internalPreferences, setInternalPreferences] = useState(
-    preferences || {
-      servingsPerMeal: 4,
-      maxCalories: 2200,
-      weeklyBudget: 35,
-      meals: [],
-      tagPreferences: [],
-    }
+    preferences || { ...DEFAULT_MENU_PREFS }
   );
 
   useEffect(() => {
-    setInternalPreferences(
-      preferences || {
-        servingsPerMeal: 4,
-        maxCalories: 2200,
-        weeklyBudget: 35,
-        meals: [],
-        tagPreferences: [],
-      }
-    );
+    setInternalPreferences(preferences || { ...DEFAULT_MENU_PREFS });
   }, [preferences]);
 
   const handleSetPreferences = (newPrefs) => {

--- a/src/components/menu_planner/MenuPreferencesPanel.jsx
+++ b/src/components/menu_planner/MenuPreferencesPanel.jsx
@@ -14,6 +14,7 @@ import MealTypeSelector from '@/components/MealTypeSelector.jsx';
 import TagPreferencesForm from '@/components/menu_planner/TagPreferencesForm.jsx';
 import CommonMenuSettings from '@/components/menu_planner/CommonMenuSettings.jsx';
 import { useLinkedUsers } from '@/hooks/useLinkedUsers.js';
+import { DEFAULT_MENU_PREFS } from '@/lib/defaultPreferences.js';
 
 function MenuPreferencesPanel({ preferences, setPreferences, availableTags, userProfile }) {
   const addMeal = () => {
@@ -110,7 +111,9 @@ function MenuPreferencesPanel({ preferences, setPreferences, availableTags, user
           <Input
             id="servingsPerMeal"
             type="number"
-            value={preferences.servingsPerMeal || 4}
+            value={
+              preferences.servingsPerMeal || DEFAULT_MENU_PREFS.servingsPerMeal
+            }
             onChange={handleServingsChange}
             min="1"
             step="1"
@@ -124,8 +127,10 @@ function MenuPreferencesPanel({ preferences, setPreferences, availableTags, user
           <Input
             id="maxCalories"
             type="number"
-            value={preferences.maxCalories || 2200}
-            onChange={(e) => setPreferences({ ...preferences, maxCalories: parseInt(e.target.value) || 0 })}
+            value={preferences.maxCalories || DEFAULT_MENU_PREFS.maxCalories}
+            onChange={(e) =>
+              setPreferences({ ...preferences, maxCalories: parseInt(e.target.value) || 0 })
+            }
             min="500"
             step="50"
             className="max-w-xs"
@@ -138,9 +143,12 @@ function MenuPreferencesPanel({ preferences, setPreferences, availableTags, user
           <Input
             id="weeklyBudget"
             type="number"
-            value={preferences.weeklyBudget || 35}
+            value={preferences.weeklyBudget || DEFAULT_MENU_PREFS.weeklyBudget}
             onChange={(e) =>
-              setPreferences({ ...preferences, weeklyBudget: parseFloat(e.target.value) || 0 })
+              setPreferences({
+                ...preferences,
+                weeklyBudget: parseFloat(e.target.value) || 0,
+              })
             }
             min="0"
             step="0.5"

--- a/tests/default-pref-usage.spec.ts
+++ b/tests/default-pref-usage.spec.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+const COMPONENTS = [
+  '../src/components/MenuPlanner.jsx',
+  '../src/components/menu_planner/MenuPreferencesPanel.jsx',
+];
+
+describe('DEFAULT_MENU_PREFS imports', () => {
+  it('are present in key components', () => {
+    COMPONENTS.forEach((file) => {
+      const content = fs.readFileSync(path.resolve(__dirname, file), 'utf8');
+      expect(content).toMatch(/import\s+\{[^}]*DEFAULT_MENU_PREFS[^}]*\}/);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- use `DEFAULT_MENU_PREFS` in MenuPlanner
- rely on constant in MenuPreferencesPanel
- add test checking components import the constant

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_685ffe2a920c832d9353499525b7ef5d