### PR TITLE
Add multi-type meal structure support

### DIFF
--- a/docs/data-model.sql
+++ b/docs/data-model.sql
@@ -39,7 +39,7 @@ create table weekly_menu_preferences (
   portions_per_meal integer default 4,
   daily_calories_limit integer default 2200,
   weekly_budget numeric default 0,
-  daily_meal_structure text[],
+  daily_meal_structure text[][],
   tag_preferences text[],
   common_menu_settings jsonb default '{}'::jsonb -- { enabled: boolean, linkedUsers: uuid[], linkedUserRecipes: uuid[] }
 );

--- a/src/hooks/useWeeklyMenu.js
+++ b/src/hooks/useWeeklyMenu.js
@@ -8,12 +8,14 @@ const defaultPrefs = { ...DEFAULT_MENU_PREFS };
 
 export function fromDbPrefs(pref) {
   if (!pref) return { ...defaultPrefs };
-  const meals = (pref.daily_meal_structure || []).map((t, idx) => ({
-    id: idx + 1,
-    mealNumber: idx + 1,
-    types: t ? [t] : [],
-    enabled: true,
-  }));
+  const meals = Array.isArray(pref.daily_meal_structure)
+    ? pref.daily_meal_structure.map((types, idx) => ({
+        id: idx + 1,
+        mealNumber: idx + 1,
+        types: Array.isArray(types) ? types : [],
+        enabled: true,
+      }))
+    : [];
   return {
     servingsPerMeal: pref.portions_per_meal ?? 4,
     maxCalories: pref.daily_calories_limit ?? 2200,
@@ -33,7 +35,7 @@ export function toDbPrefs(pref) {
     daily_meal_structure: Array.isArray(effective.meals)
       ? effective.meals
           .filter((m) => m.enabled)
-          .map((m) => (m.types && m.types[0] ? m.types[0] : ''))
+          .map((m) => (Array.isArray(m.types) ? m.types : []))
       : [],
     tag_preferences: effective.tagPreferences || [],
     common_menu_settings: effective.commonMenuSettings ?? {

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,7 +9,7 @@ export type WeeklyMenuPreferences = {
   portions_per_meal: number;
   daily_calories_limit: number | null;
   weekly_budget: number;
-  daily_meal_structure: string[];
+  daily_meal_structure: string[][];
   tag_preferences: string[];
   /** Client side representation of meals */
   meals?: {

--- a/supabase/migrations/0003_daily_meal_structure_arrays.sql
+++ b/supabase/migrations/0003_daily_meal_structure_arrays.sql
@@ -1,0 +1,8 @@
+ALTER TABLE weekly_menu_preferences
+  ALTER COLUMN daily_meal_structure TYPE text[][]
+  USING (
+    CASE
+      WHEN daily_meal_structure IS NULL THEN ARRAY[]::text[][]
+      ELSE ARRAY(SELECT ARRAY(v) FROM unnest(daily_meal_structure) AS v)
+    END
+  );

--- a/tests/preferences.spec.ts
+++ b/tests/preferences.spec.ts
@@ -8,7 +8,7 @@ describe('preferences conversion', () => {
       maxCalories: 1500,
       weeklyBudget: 20,
       meals: [
-        { id: 1, mealNumber: 1, types: ['petit-dejeuner'], enabled: true },
+        { id: 1, mealNumber: 1, types: ['petit-dejeuner', 'brunch'], enabled: true },
       ],
       tagPreferences: ['vegan'],
       commonMenuSettings: {
@@ -20,6 +20,9 @@ describe('preferences conversion', () => {
 
     const dbShape = toDbPrefs(prefs);
     expect(dbShape.common_menu_settings).toEqual(prefs.commonMenuSettings);
+    expect(dbShape.daily_meal_structure).toEqual([
+      ['petit-dejeuner', 'brunch'],
+    ]);
 
     const restored = fromDbPrefs(dbShape);
     expect(restored).toEqual(prefs);


### PR DESCRIPTION
## Summary
- allow `daily_meal_structure` to store multiple meal types per meal
- handle arrays of types in `useWeeklyMenu`
- adjust DB schema and add migration
- update conversion tests

## Testing
- `npm test -- -w=false`

------
https://chatgpt.com/codex/tasks/task_e_685ffe28a05c832dbdb56e4da6d0aec8