### PR TITLE
Fix commonMenuSettings default

### DIFF
--- a/src/hooks/useWeeklyMenu.js
+++ b/src/hooks/useWeeklyMenu.js
@@ -22,7 +22,7 @@ export function fromDbPrefs(pref) {
     weeklyBudget: pref.weekly_budget ?? 35,
     meals,
     tagPreferences: pref.tag_preferences || [],
-    commonMenuSettings: pref.common_menu_settings ?? { enabled: true },
+    commonMenuSettings: { enabled: true, ...(pref.common_menu_settings || {}) },
   };
 }
 

--- a/tests/preferences.spec.ts
+++ b/tests/preferences.spec.ts
@@ -27,4 +27,9 @@ describe('preferences conversion', () => {
     const restored = fromDbPrefs(dbShape);
     expect(restored).toEqual(prefs);
   });
+
+  it('defaults enabled=true when DB returns empty common_menu_settings', () => {
+    const restored = fromDbPrefs({ common_menu_settings: {} });
+    expect(restored.commonMenuSettings).toEqual({ enabled: true });
+  });
 });


### PR DESCRIPTION
## Summary
- ensure `fromDbPrefs` enforces enabled in commonMenuSettings
- add a regression test for empty DB common_menu_settings

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68600a69703c832db69f25388bad8c4b