### PR TITLE
Fix partial preference update

### DIFF
--- a/src/hooks/useWeeklyMenu.js
+++ b/src/hooks/useWeeklyMenu.js
@@ -277,9 +277,10 @@ export function useWeeklyMenu(session, currentMenuId = null) {
     async (newPrefs, id = menuId) => {
       if (!userId || !id) return false;
       try {
+        const merged = { ...preferences, ...(newPrefs || {}) };
         const { data: updated, error } = await supabase
           .from('weekly_menu_preferences')
-          .upsert({ menu_id: id, ...toDbPrefs(newPrefs) }, { onConflict: 'menu_id' })
+          .upsert({ menu_id: id, ...toDbPrefs(merged) }, { onConflict: 'menu_id' })
           .select('*')
           .single();
 
@@ -298,7 +299,7 @@ export function useWeeklyMenu(session, currentMenuId = null) {
         return false;
       }
     },
-    [userId, menuId, toast]
+    [userId, menuId, toast, preferences]
   );
 
   const deleteWeeklyMenu = useCallback(

--- a/tests/preferences.integration.spec.jsx
+++ b/tests/preferences.integration.spec.jsx
@@ -122,6 +122,20 @@ describe('useWeeklyMenu.updateMenuPreferences', () => {
 
     expect(global.__supabaseState.lastUpsert).toEqual({ menu_id: 'menu1', ...toDbPrefs(newPrefs) });
   });
+
+  it('merges with existing preferences for partial updates', async () => {
+    const session = { user: { id: 'user1' } };
+    const { result } = renderHook(() => useWeeklyMenu(session, 'menu1'));
+
+    await act(async () => {
+      await result.current.updatePreferences({ weeklyBudget: 40 });
+    });
+
+    const expected = { ...DEFAULT_MENU_PREFS, weeklyBudget: 40 };
+
+    expect(global.__supabaseState.lastUpsert).toEqual({ menu_id: 'menu1', ...toDbPrefs(expected) });
+    expect(result.current.preferences).toEqual(expected);
+  });
 });
 
 describe('preferences integration', () => {
@@ -148,6 +162,26 @@ describe('preferences integration', () => {
 
     await waitFor(() => {
       expect(result2.current.preferences).toEqual(updated);
+    });
+  });
+
+  it('reloads merged preferences after partial update', async () => {
+    const session = { user: { id: 'user1' } };
+    const { result, unmount } = renderHook(() => useWeeklyMenu(session, 'menu1'));
+
+    await act(async () => {
+      await result.current.updatePreferences({ servingsPerMeal: 6 });
+    });
+
+    unmount();
+
+    const { result: result2 } = renderHook(() => useWeeklyMenu(session, 'menu1'));
+
+    await waitFor(() => {
+      expect(result2.current.preferences).toEqual({
+        ...DEFAULT_MENU_PREFS,
+        servingsPerMeal: 6,
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary
- merge new menu preferences with existing ones before saving
- ensure partial preference updates keep old values

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_68600a6b8074832da25e4b52239971fe