### PR TITLE
Detect shared menus from participants

### DIFF
--- a/src/components/NewMenuModal.jsx
+++ b/src/components/NewMenuModal.jsx
@@ -25,7 +25,8 @@ function NewMenuModal({ onCreate, friends = [], trigger }) {
   };
 
   const handleCreate = () => {
-    onCreate({ name, isShared, participantIds: selectedIds });
+    const shared = selectedIds.length > 0;
+    onCreate({ name, isShared: shared, participantIds: selectedIds });
     setName('');
     setIsShared(false);
     setSelectedIds([]);

--- a/src/hooks/useMenus.js
+++ b/src/hooks/useMenus.js
@@ -19,7 +19,7 @@ export function useMenus(session) {
     try {
       const { data: ownerMenus, error: ownerError } = await supabase
         .from('weekly_menus')
-        .select('id, user_id, name, updated_at, is_shared')
+        .select('id, user_id, name, updated_at')
         .eq('user_id', userId)
         .order('created_at');
 
@@ -41,7 +41,7 @@ export function useMenus(session) {
       if (participantIds.length > 0) {
         const { data, error } = await supabase
           .from('weekly_menus')
-          .select('id, user_id, name, updated_at, is_shared')
+          .select('id, user_id, name, updated_at')
           .in('id', participantIds);
         if (error) throw error;
         participantMenus = data || [];
@@ -50,11 +50,27 @@ export function useMenus(session) {
       const combined = [...(ownerMenus || []), ...participantMenus];
       const unique = [];
       const seen = new Set();
+      const menuIds = [];
       for (const m of combined) {
         if (!seen.has(m.id)) {
           seen.add(m.id);
           unique.push(m);
+          menuIds.push(m.id);
         }
+      }
+
+      if (menuIds.length > 0) {
+        const { data: rows } = await supabase
+          .from('menu_participants')
+          .select('menu_id')
+          .in('menu_id', menuIds);
+        const counts = {};
+        (rows || []).forEach((r) => {
+          counts[r.menu_id] = (counts[r.menu_id] || 0) + 1;
+        });
+        unique.forEach((m) => {
+          m.is_shared = (counts[m.id] || 0) > 0;
+        });
       }
 
       setMenus(unique);

--- a/src/hooks/useWeeklyMenu.js
+++ b/src/hooks/useWeeklyMenu.js
@@ -115,6 +115,12 @@ export function useWeeklyMenu(session, currentMenuId = null) {
 
         if (data) {
           safeSetWeeklyMenu(data);
+          const { count } = await supabase
+            .from('menu_participants')
+            .select('user_id', { count: 'exact', head: false })
+            .eq('menu_id', data.id);
+          if (typeof count === 'number') setIsShared(count > 0);
+
           const { data: pref, error: prefError } = await supabase
             .from('weekly_menu_preferences')
             .select('*')


### PR DESCRIPTION
## Summary
- detect collaborative menus based on participant count when creating
- count participant rows to compute `is_shared` in hooks
- adjust menu listing hooks to derive `is_shared` from `menu_participants`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6860114632f4832da7c142e02e3f96bb