### PR TITLE
Update RecipeForm to refetch IA usage

### DIFF
--- a/src/components/RecipeForm.jsx
+++ b/src/components/RecipeForm.jsx
@@ -670,6 +670,7 @@ function RecipeForm({
           description: 'La description a été mise à jour.',
         });
         if (subscriptionTier === 'vip') {
+          // Update UI optimistically but re-fetch from Supabase for accuracy
           setIaUsage((prev) => ({
             ...prev,
             text_requests:
@@ -682,6 +683,7 @@ function RecipeForm({
                 : prev?.text_credits ?? 0,
           }));
         }
+        fetchIaUsage();
         window.dispatchEvent(new Event('ai-action-complete'));
       } else if (type === 'image') {
         const filePath = data.path;
@@ -693,6 +695,7 @@ function RecipeForm({
           description: "L'image a été mise à jour.",
         });
         if (subscriptionTier === 'vip') {
+          // Update UI optimistically but re-fetch from Supabase for accuracy
           setIaUsage((prev) => ({
             ...prev,
             image_requests:
@@ -705,6 +708,7 @@ function RecipeForm({
                 : prev?.image_credits ?? 0,
           }));
         }
+        fetchIaUsage();
         window.dispatchEvent(new Event('ai-action-complete'));
       }
     } catch (error) {


### PR DESCRIPTION
## Summary
- refetch IA usage from Supabase when AI generation completes

## Testing
- `npm test` *(fails: npm not found)*

------
https://chatgpt.com/codex/tasks/task_e_68601c47b218832d81e83751cca675df