### PR TITLE
Remove toggleMenuShared

### DIFF
--- a/src/hooks/useWeeklyMenu.js
+++ b/src/hooks/useWeeklyMenu.js
@@ -308,62 +308,6 @@ export function useWeeklyMenu(session, currentMenuId = null) {
     [userId, menuId, toast, preferences]
   );
 
-  const toggleMenuShared = useCallback(
-    async (share = true, id = menuId) => {
-      if (!userId || !id) return false;
-      try {
-        const { data: updated, error } = await supabase
-          .from('weekly_menus')
-          .update({ is_shared: share })
-          .eq('id', id)
-          .select('id, is_shared')
-          .single();
-
-        if (error) throw error;
-
-        if (updated && id === menuId) setIsShared(updated.is_shared);
-
-        if (share) {
-          const { data: pref } = await supabase
-            .from('weekly_menu_preferences')
-            .select('*')
-            .eq('menu_id', id)
-            .maybeSingle();
-
-          if (pref) {
-            const prefsObj = fromDbPrefs(pref);
-            prefsObj.commonMenuSettings = {
-              ...(prefsObj.commonMenuSettings || {}),
-              enabled: true,
-            };
-
-            const { data: upserted } = await supabase
-              .from('weekly_menu_preferences')
-              .upsert({ menu_id: id, ...toDbPrefs(prefsObj) }, {
-                onConflict: 'menu_id',
-              })
-              .select('*')
-              .single();
-
-            if (upserted && id === menuId) {
-              setPreferences(fromDbPrefs(upserted));
-            }
-          }
-        }
-
-        return true;
-      } catch (err) {
-        console.error('Error toggling shared state:', err);
-        toast({
-          title: 'Erreur',
-          description: 'Impossible de mettre \xE0 jour le partage du menu: ' + err.message,
-          variant: 'destructive',
-        });
-        return false;
-      }
-    },
-    [userId, menuId, toast]
-  );
 
   const deleteWeeklyMenu = useCallback(
     async (id = menuId) => {
@@ -401,7 +345,6 @@ export function useWeeklyMenu(session, currentMenuId = null) {
     updateMenuName: updateWeeklyMenuName,
     preferences,
     updatePreferences: updateMenuPreferences,
-    toggleMenuShared,
     deleteMenu: deleteWeeklyMenu,
     loading,
   };

--- a/tests/preferences.integration.spec.jsx
+++ b/tests/preferences.integration.spec.jsx
@@ -197,47 +197,4 @@ describe('preferences integration', () => {
   });
 });
 
-describe('useWeeklyMenu.toggleMenuShared', () => {
-  it('shares menu and forces common_menu_settings.enabled', async () => {
-    const session = { user: { id: 'user1' } };
-    global.__supabaseState.preferences.menu1 = {
-      menu_id: 'menu1',
-      ...toDbPrefs({
-        ...DEFAULT_MENU_PREFS,
-        commonMenuSettings: { enabled: false },
-      }),
-    };
-
-    const { result } = renderHook(() => useWeeklyMenu(session, 'menu1'));
-
-    await act(async () => {
-      await result.current.toggleMenuShared(true);
-    });
-
-    expect(global.__supabaseState.menus['menu1'].is_shared).toBe(true);
-    expect(global.__supabaseState.lastUpsert).toEqual({
-      menu_id: 'menu1',
-      ...toDbPrefs({
-        ...DEFAULT_MENU_PREFS,
-        commonMenuSettings: { enabled: true },
-      }),
-    });
-    expect(result.current.isShared).toBe(true);
-  });
-
-  it('unshares menu', async () => {
-    const session = { user: { id: 'user1' } };
-    const { result } = renderHook(() => useWeeklyMenu(session, 'menu1'));
-
-    await act(async () => {
-      await result.current.toggleMenuShared(true);
-    });
-    await act(async () => {
-      await result.current.toggleMenuShared(false);
-    });
-
-    expect(global.__supabaseState.menus['menu1'].is_shared).toBe(false);
-    expect(result.current.isShared).toBe(false);
-  });
-});
 


### PR DESCRIPTION
## Summary
- clean up `useWeeklyMenu` by dropping the `toggleMenuShared` callback
- delete integration tests covering the removed callback

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6860228a6fd4832d86d1c971bc0e0ee4