### PR TITLE
Stop deriving isShared from menu_participants

### DIFF
--- a/src/hooks/useWeeklyMenu.js
+++ b/src/hooks/useWeeklyMenu.js
@@ -113,13 +113,8 @@ export function useWeeklyMenu(session, currentMenuId = null) {
           throw error;
         }
 
-        if (data) {
-          safeSetWeeklyMenu(data);
-          const { count } = await supabase
-            .from('menu_participants')
-            .select('user_id', { count: 'exact', head: false })
-            .eq('menu_id', data.id);
-          if (typeof count === 'number') setIsShared(count > 0);
+          if (data) {
+            safeSetWeeklyMenu(data);
 
           const { data: pref, error: prefError } = await supabase
             .from('weekly_menu_preferences')


### PR DESCRIPTION
## Summary
- fetchWeeklyMenu no longer counts rows from `menu_participants`
- rely on `data.is_shared` when setting local state

## Testing
- `npm test`
- `npm run lint` *(fails: 561 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6860320b50bc832d9dd11e881613a2b6