### PR TITLE
Fix initial menu prefs for new menus

### DIFF
--- a/src/pages/MenuPage.jsx
+++ b/src/pages/MenuPage.jsx
@@ -104,16 +104,13 @@ export default function MenuPage({
     }
 
     if (data?.id) {
-      const prefs = {
+      const dbPrefs = toDbPrefs({
         ...DEFAULT_MENU_PREFS,
-        commonMenuSettings: {
-          ...DEFAULT_MENU_PREFS.commonMenuSettings,
-          enabled: isShared,
-        },
-      };
+        commonMenuSettings: { enabled: isShared },
+      });
       await supabase
         .from('weekly_menu_preferences')
-        .insert({ menu_id: data.id, ...toDbPrefs(prefs) });
+        .insert({ menu_id: data.id, ...dbPrefs });
     }
 
     if (isShared && data?.id) {


### PR DESCRIPTION
## Summary
- ensure personal menus start with disabled sharing settings
- use `toDbPrefs` when inserting defaults in MenuPage

## Testing
- `CI=1 npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68603cee20e4832da481abe6c66fc534