### PR TITLE
Remove common menu toggle

### DIFF
--- a/src/components/MenuPlanner.jsx
+++ b/src/components/MenuPlanner.jsx
@@ -28,6 +28,7 @@ function MenuPlanner({
   onDeleteMenu,
   preferences,
   updatePreferences,
+  isShared,
 }) {
   const [internalWeeklyMenu, setInternalWeeklyMenu] = useState(
     Array.isArray(propWeeklyMenu) && propWeeklyMenu.length === 7
@@ -166,6 +167,7 @@ function MenuPlanner({
             setPreferences={handleSetPreferences}
             availableTags={availableTags}
             userProfile={userProfile}
+            isShared={isShared}
           />
           <Button
             onClick={handleGenerateMenu}

--- a/src/components/menu_planner/CommonMenuSettings.jsx
+++ b/src/components/menu_planner/CommonMenuSettings.jsx
@@ -3,7 +3,6 @@ import { motion } from 'framer-motion';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Switch } from '@/components/ui/switch';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogTrigger } from '@/components/ui/dialog';
 import { Info, Link, Unlink } from 'lucide-react';
 
@@ -13,39 +12,13 @@ function CommonMenuSettings({
   setNewLinkedUserTag,
   isLinkingUser,
   handleAddLinkedUser,
-  handleToggleCommonMenu,
   handleLinkedUserRatioChange,
   handleRemoveLinkedUser,
+  isShared,
 }) {
   return (
     <div className="space-y-4 pt-4 border-t border-pastel-border/70">
-      <div className="flex items-center space-x-2">
-        <Switch
-          id="common-menu-toggle"
-          checked={preferences.commonMenuSettings?.enabled || false}
-          onCheckedChange={handleToggleCommonMenu}
-        />
-        <Label htmlFor="common-menu-toggle" className="text-base font-medium">
-          Activer le menu commun
-        </Label>
-        <Dialog>
-          <DialogTrigger asChild>
-            <Button variant="ghost" size="icon" className="h-6 w-6 text-pastel-muted-foreground">
-              <Info className="h-4 w-4" />
-            </Button>
-          </DialogTrigger>
-          <DialogContent className="bg-pastel-card border border-pastel-border rounded-lg dark:bg-pastel-card dark:border-pastel-border">
-            <DialogHeader>
-              <DialogTitle>Menu Commun</DialogTitle>
-              <DialogDescription>
-                Le menu commun vous permet de planifier des repas en utilisant les recettes d'autres utilisateurs que vous avez liés. Activez cette option pour lier des utilisateurs et ajuster les ratios de contribution pour la génération de menu.
-              </DialogDescription>
-            </DialogHeader>
-          </DialogContent>
-        </Dialog>
-      </div>
-
-      {preferences.commonMenuSettings?.enabled && (
+      {isShared && (
         <motion.div
           initial={{ opacity: 0, y: -10 }}
           animate={{ opacity: 1, y: 0 }}

--- a/src/components/menu_planner/MenuPreferencesModal.jsx
+++ b/src/components/menu_planner/MenuPreferencesModal.jsx
@@ -21,6 +21,7 @@ function MenuPreferencesModal({
   setPreferences,
   availableTags,
   userProfile,
+  isShared,
 }) {
 
   return (
@@ -47,6 +48,7 @@ function MenuPreferencesModal({
             setPreferences={setPreferences}
             availableTags={availableTags}
             userProfile={userProfile}
+            isShared={isShared}
           />
         </ScrollArea>
         <DialogFooter>

--- a/src/components/menu_planner/MenuPreferencesPanel.jsx
+++ b/src/components/menu_planner/MenuPreferencesPanel.jsx
@@ -16,7 +16,7 @@ import CommonMenuSettings from '@/components/menu_planner/CommonMenuSettings.jsx
 import { useLinkedUsers } from '@/hooks/useLinkedUsers.js';
 import { DEFAULT_MENU_PREFS } from '@/lib/defaultPreferences.js';
 
-function MenuPreferencesPanel({ preferences, setPreferences, availableTags, userProfile }) {
+function MenuPreferencesPanel({ preferences, setPreferences, availableTags, userProfile, isShared }) {
   const addMeal = () => {
     const newMealNumber = (preferences.meals?.length || 0) + 1;
     setPreferences({
@@ -88,10 +88,9 @@ function MenuPreferencesPanel({ preferences, setPreferences, availableTags, user
     setNewLinkedUserTag,
     isLinkingUser,
     handleAddLinkedUser,
-    handleToggleCommonMenu,
     handleLinkedUserRatioChange,
     handleRemoveLinkedUser,
-  } = useLinkedUsers(userProfile, preferences, setPreferences);
+  } = useLinkedUsers(userProfile, preferences, setPreferences, isShared);
 
   return (
     <motion.div
@@ -283,9 +282,9 @@ function MenuPreferencesPanel({ preferences, setPreferences, availableTags, user
         setNewLinkedUserTag={setNewLinkedUserTag}
         isLinkingUser={isLinkingUser}
         handleAddLinkedUser={handleAddLinkedUser}
-        handleToggleCommonMenu={handleToggleCommonMenu}
         handleLinkedUserRatioChange={handleLinkedUserRatioChange}
         handleRemoveLinkedUser={handleRemoveLinkedUser}
+        isShared={isShared}
       />
 
       <TagPreferencesForm preferences={preferences} setPreferences={setPreferences} availableTags={availableTags} />

--- a/src/hooks/useMenuGeneration.js
+++ b/src/hooks/useMenuGeneration.js
@@ -45,8 +45,8 @@ export function useMenuGeneration(
     let baseRecipes = Array.isArray(recipes) ? recipes : [];
 
     if (
-      preferences?.commonMenuSettings?.enabled &&
-      preferences?.commonMenuSettings?.linkedUserRecipes?.length > 0
+      Array.isArray(preferences?.commonMenuSettings?.linkedUserRecipes) &&
+      preferences.commonMenuSettings.linkedUserRecipes.length > 0
     ) {
       const combined = [
         ...baseRecipes.map((r) => ({
@@ -129,9 +129,8 @@ export function useMenuGeneration(
     // Determine participant weights for shared menus
     let participantSchedule = [];
     if (
-      preferences?.commonMenuSettings?.enabled &&
       Array.isArray(preferences?.commonMenuSettings?.linkedUsers) &&
-      preferences?.commonMenuSettings?.linkedUsers?.length > 0
+      preferences.commonMenuSettings.linkedUsers.length > 0
     ) {
       const participants = (preferences?.commonMenuSettings?.linkedUsers || []).map((u) => ({
         userId: u.id,
@@ -382,8 +381,8 @@ export function useMenuGeneration(
           }
 
           if (
-            preferences?.commonMenuSettings?.enabled &&
-            preferences?.commonMenuSettings?.linkedUsers?.length > 0
+            Array.isArray(preferences?.commonMenuSettings?.linkedUsers) &&
+            preferences.commonMenuSettings.linkedUsers.length > 0
           ) {
               const totalRatioSum =
                 preferences?.commonMenuSettings?.linkedUsers?.reduce(

--- a/src/hooks/useWeeklyMenu.js
+++ b/src/hooks/useWeeklyMenu.js
@@ -22,7 +22,10 @@ export function fromDbPrefs(pref) {
     weeklyBudget: pref.weekly_budget ?? 35,
     meals,
     tagPreferences: pref.tag_preferences || [],
-    commonMenuSettings: { enabled: true, ...(pref.common_menu_settings || {}) },
+    commonMenuSettings: {
+      ...DEFAULT_MENU_PREFS.commonMenuSettings,
+      ...(pref.common_menu_settings || {}),
+    },
   };
 }
 
@@ -38,9 +41,7 @@ export function toDbPrefs(pref) {
           .map((m) => (Array.isArray(m.types) ? m.types : []))
       : [],
     tag_preferences: effective.tagPreferences || [],
-    common_menu_settings: effective.commonMenuSettings ?? {
-      enabled: true,
-    },
+    common_menu_settings: effective.commonMenuSettings ?? {},
   };
 }
 

--- a/src/lib/defaultPreferences.js
+++ b/src/lib/defaultPreferences.js
@@ -4,5 +4,5 @@ export const DEFAULT_MENU_PREFS = {
   weeklyBudget: 35,
   meals: [],
   tagPreferences: [],
-  commonMenuSettings: { enabled: true, linkedUsers: [], linkedUserRecipes: [] },
+  commonMenuSettings: { linkedUsers: [], linkedUserRecipes: [] },
 };

--- a/src/pages/MenuPage.jsx
+++ b/src/pages/MenuPage.jsx
@@ -32,11 +32,6 @@ export default function MenuPage({
     return <div>Chargement des préférences...</div>;
   }
 
-  const enabled = preferences.commonMenuSettings?.enabled ?? false;
-
-  if (!enabled) {
-    return <div>Les préférences de ce menu sont désactivées.</div>;
-  }
   const friends = useFriendsList(session);
 
   const participants = useMenuParticipants(isShared ? selectedMenuId : null);
@@ -104,10 +99,7 @@ export default function MenuPage({
     }
 
     if (data?.id) {
-      const dbPrefs = toDbPrefs({
-        ...DEFAULT_MENU_PREFS,
-        commonMenuSettings: { enabled: isShared },
-      });
+      const dbPrefs = toDbPrefs({ ...DEFAULT_MENU_PREFS });
       await supabase
         .from('weekly_menu_preferences')
         .insert({ menu_id: data.id, ...dbPrefs });
@@ -149,6 +141,7 @@ export default function MenuPage({
         menuName={menuName}
         preferences={preferences}
         updatePreferences={updatePreferences}
+        isShared={isShared}
         onUpdateMenuName={(name) => handleRename(selectedMenuId, name)}
         onDeleteMenu={() => handleDelete(selectedMenuId)}
       />

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,4 @@
 export interface CommonMenuSettings {
-  enabled: boolean;
   linkedUsers?: string[];
   linkedUserRecipes?: string[];
 }

--- a/tests/preferences.integration.spec.jsx
+++ b/tests/preferences.integration.spec.jsx
@@ -103,13 +103,12 @@ describe('MenuPreferencesPanel', () => {
         setPreferences={updateSpy}
         availableTags={[]}
         userProfile={{ id: 'user1', username: 'User1' }}
+        isShared={false}
       />
     );
 
     fireEvent.change(getByLabelText(/Portions par repas/), { target: { value: '6' } });
-    fireEvent.click(getByLabelText('Activer le menu commun'));
-
-    expect(updateSpy).toHaveBeenCalledTimes(2);
+    expect(updateSpy).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -124,7 +123,7 @@ describe('useWeeklyMenu.updateMenuPreferences', () => {
       weeklyBudget: 50,
       meals: [{ id: 1, enabled: true, mealNumber: 1, types: ['plat'] }],
       tagPreferences: ['bio'],
-      commonMenuSettings: { enabled: true },
+      commonMenuSettings: {},
     };
 
     await act(async () => {
@@ -160,7 +159,7 @@ describe('preferences integration', () => {
       weeklyBudget: 25,
       meals: [],
       tagPreferences: [],
-      commonMenuSettings: { enabled: false },
+      commonMenuSettings: {},
     };
 
     await act(async () => {
@@ -172,7 +171,10 @@ describe('preferences integration', () => {
     const { result: result2 } = renderHook(() => useWeeklyMenu(session, 'menu1'));
 
     await waitFor(() => {
-      expect(result2.current.preferences).toEqual(updated);
+      expect(result2.current.preferences).toEqual({
+        ...updated,
+        commonMenuSettings: { linkedUsers: [], linkedUserRecipes: [] },
+      });
     });
   });
 

--- a/tests/preferences.spec.ts
+++ b/tests/preferences.spec.ts
@@ -12,7 +12,6 @@ describe('preferences conversion', () => {
       ],
       tagPreferences: ['vegan'],
       commonMenuSettings: {
-        enabled: true,
         linkedUsers: [{ id: 'u1', name: 'Alice', ratio: 50 }],
         linkedUserRecipes: [],
       },
@@ -28,8 +27,8 @@ describe('preferences conversion', () => {
     expect(restored).toEqual(prefs);
   });
 
-  it('defaults enabled=true when DB returns empty common_menu_settings', () => {
+  it('defaults arrays when DB returns empty common_menu_settings', () => {
     const restored = fromDbPrefs({ common_menu_settings: {} });
-    expect(restored.commonMenuSettings).toEqual({ enabled: true });
+    expect(restored.commonMenuSettings).toEqual({ linkedUsers: [], linkedUserRecipes: [] });
   });
 });


### PR DESCRIPTION
## Summary
- drop `enabled` from default preferences and types
- show menu participants only when menu is shared
- remove toggle and update linked user handling
- propagate `isShared` through menu components
- adjust tests for new behaviour

## Testing
- `npx vitest run` *(fails: ENOENT due to environment)*
- `npm run lint` *(fails to run in container)*

------
https://chatgpt.com/codex/tasks/task_e_686045befa0c832d855ce456bc42faa9