### PR TITLE
Fix personal menu preferences ignoring shared fields

### DIFF
--- a/src/hooks/useWeeklyMenu.js
+++ b/src/hooks/useWeeklyMenu.js
@@ -280,6 +280,7 @@ export function useWeeklyMenu(session, currentMenuId = null) {
       if (!userId || !id) return false;
       try {
         const merged = { ...preferences, ...(newPrefs || {}) };
+        if (!isShared) merged.commonMenuSettings = {};
         const { data: updated, error } = await supabase
           .from('weekly_menu_preferences')
           .upsert({ menu_id: id, ...toDbPrefs(merged) }, { onConflict: 'menu_id' })
@@ -301,7 +302,7 @@ export function useWeeklyMenu(session, currentMenuId = null) {
         return false;
       }
     },
-    [userId, menuId, toast, preferences]
+    [userId, menuId, toast, preferences, isShared]
   );
 
 

--- a/src/pages/MenuPage.jsx
+++ b/src/pages/MenuPage.jsx
@@ -99,7 +99,9 @@ export default function MenuPage({
     }
 
     if (data?.id) {
-      const dbPrefs = toDbPrefs({ ...DEFAULT_MENU_PREFS });
+      const basePrefs = { ...DEFAULT_MENU_PREFS };
+      if (!isShared) basePrefs.commonMenuSettings = {};
+      const dbPrefs = toDbPrefs(basePrefs);
       await supabase
         .from('weekly_menu_preferences')
         .insert({ menu_id: data.id, ...dbPrefs });

--- a/tests/preferences.integration.spec.jsx
+++ b/tests/preferences.integration.spec.jsx
@@ -142,8 +142,9 @@ describe('useWeeklyMenu.updateMenuPreferences', () => {
     });
 
     const expected = { ...DEFAULT_MENU_PREFS, weeklyBudget: 40 };
+    const expectedDb = toDbPrefs({ ...expected, commonMenuSettings: {} });
 
-    expect(global.__supabaseState.lastUpsert).toEqual({ menu_id: 'menu1', ...toDbPrefs(expected) });
+    expect(global.__supabaseState.lastUpsert).toEqual({ menu_id: 'menu1', ...expectedDb });
     expect(result.current.preferences).toEqual(expected);
   });
 });


### PR DESCRIPTION
## Summary
- ensure weekly menu preferences omit shared data for personal menus
- clear shared settings in the hook when menu isn't shared
- update integration test expectations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686049ff1858832d9efe4e0683a6f5c5