### PR TITLE
Update default menu sharing settings

### DIFF
--- a/src/lib/defaultPreferences.js
+++ b/src/lib/defaultPreferences.js
@@ -4,5 +4,5 @@ export const DEFAULT_MENU_PREFS = {
   weeklyBudget: 35,
   meals: [],
   tagPreferences: [],
-  commonMenuSettings: { linkedUsers: [], linkedUserRecipes: [] },
+  commonMenuSettings: { enabled: false, linkedUsers: [], linkedUserRecipes: [] },
 };

--- a/tests/preferences.integration.spec.jsx
+++ b/tests/preferences.integration.spec.jsx
@@ -173,7 +173,7 @@ describe('preferences integration', () => {
     await waitFor(() => {
       expect(result2.current.preferences).toEqual({
         ...updated,
-        commonMenuSettings: { linkedUsers: [], linkedUserRecipes: [] },
+        commonMenuSettings: { enabled: false, linkedUsers: [], linkedUserRecipes: [] },
       });
     });
   });

--- a/tests/preferences.spec.ts
+++ b/tests/preferences.spec.ts
@@ -12,6 +12,7 @@ describe('preferences conversion', () => {
       ],
       tagPreferences: ['vegan'],
       commonMenuSettings: {
+        enabled: false,
         linkedUsers: [{ id: 'u1', name: 'Alice', ratio: 50 }],
         linkedUserRecipes: [],
       },
@@ -29,6 +30,6 @@ describe('preferences conversion', () => {
 
   it('defaults arrays when DB returns empty common_menu_settings', () => {
     const restored = fromDbPrefs({ common_menu_settings: {} });
-    expect(restored.commonMenuSettings).toEqual({ linkedUsers: [], linkedUserRecipes: [] });
+    expect(restored.commonMenuSettings).toEqual({ enabled: false, linkedUsers: [], linkedUserRecipes: [] });
   });
 });


### PR DESCRIPTION
## Summary
- disable common menu sharing by default
- update tests for new preferences structure

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_68604a6e7bc0832db2a3585cd5c4c5e8