### PR TITLE
Handle prefs for unshared menus

### DIFF
--- a/src/hooks/useWeeklyMenu.js
+++ b/src/hooks/useWeeklyMenu.js
@@ -128,9 +128,16 @@ export function useWeeklyMenu(session, currentMenuId = null) {
           if (pref) {
             setPreferences(fromDbPrefs(pref));
           } else {
+            const safePrefs = isShared
+              ? toDbPrefs(DEFAULT_MENU_PREFS)
+              : toDbPrefs({
+                  ...DEFAULT_MENU_PREFS,
+                  commonMenuSettings: { enabled: false },
+                });
+
             const { data: inserted, error: insertErr } = await supabase
               .from('weekly_menu_preferences')
-              .insert({ menu_id: data.id, ...toDbPrefs(DEFAULT_MENU_PREFS) })
+              .insert({ menu_id: data.id, ...safePrefs })
               .select('*')
               .single();
             if (!insertErr && inserted) setPreferences(fromDbPrefs(inserted));

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 export interface CommonMenuSettings {
   linkedUsers?: string[];
   linkedUserRecipes?: string[];
+  enabled?: boolean;
 }
 
 export type WeeklyMenuPreferences = {


### PR DESCRIPTION
## Summary
- avoid injecting default preferences when menu is not shared
- extend `CommonMenuSettings` type with optional `enabled` flag

## Testing
- `npm test` *(fails: `npm: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68604a7b4458832dbe79ab262ffea7fb