### PR TITLE
Fix image credit enforcement

### DIFF
--- a/api/generate-image.ts
+++ b/api/generate-image.ts
@@ -42,6 +42,21 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return res.status(403).json({ error: 'Forbidden' });
   }
 
+  const { data: creditRow, error: creditErr } = await supabaseAdmin
+    .from('ia_credits')
+    .select('image_credits')
+    .eq('user_id', user.id)
+    .maybeSingle();
+
+  if (creditErr) {
+    console.error('ia_credits fetch error:', creditErr.message);
+  }
+
+  const currentCredits = creditRow?.image_credits ?? 0;
+  if (currentCredits <= 0) {
+    return res.status(402).json({ error: 'Insufficient image credits' });
+  }
+
   const { recipe } = req.body;
   if (!recipe) {
     return res.status(400).json({ error: 'Missing recipe' });

--- a/src/components/RecipeForm.jsx
+++ b/src/components/RecipeForm.jsx
@@ -572,6 +572,19 @@ function RecipeForm({
       return;
     }
 
+    if (
+      subscriptionTier === 'vip' &&
+      type === 'image' &&
+      (iaUsage?.image_credits ?? 0) <= 0
+    ) {
+      toast({
+        title: 'Crédits image insuffisants',
+        description: 'Achetez des crédits pour continuer.',
+        variant: 'destructive',
+      });
+      return;
+    }
+
     if (subscriptionTier === 'vip') {
       const textExceeded = (iaUsage?.text_requests ?? 0) >= 20;
       const imageExceeded = (iaUsage?.image_requests ?? 0) >= 5;


### PR DESCRIPTION
## Summary
- enforce image credit availability before generating images on backend
- block frontend calls if the user lacks image credits
- offer credit purchase when the user clicks the Premium Image button without credits

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68605c219438832dafb389904b627272