### PR TITLE
Finalize Stripe credits purchase

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,18 +5,16 @@ VITE_ACCESS_KEYS=BETA2025
 VITE_STRIPE_PUBLISHABLE_KEY=your-publishable-key
 VITE_STANDARD_PRICE_ID=your-standard-price-id
 VITE_PREMIUM_PRICE_ID=your-premium-price-id
+VITE_STRIPE_SECRET_KEY=your-stripe-secret-key
 VITE_STRIPE_PRICE_ID_IMAGE_CREDIT=price_XXXXXX
 VITE_STRIPE_PRICE_ID_TEXT_CREDIT=price_YYYYYY
 
 # Backend (API)
 SUPABASE_URL=https://xxxxx.supabase.co
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
-STRIPE_SECRET_KEY=your-stripe-secret-key
 STRIPE_WEBHOOK_SECRET=your-stripe-webhook-secret
 STRIPE_PUBLISHABLE_KEY=your-stripe-publishable-key
 STRIPE_STANDARD_PRICE_ID=your-standard-price-id
 STRIPE_PREMIUM_PRICE_ID=your-premium-price-id
-STRIPE_TEXT_CREDIT_PRICE_ID=your-text-credit-price-id
-STRIPE_IMAGE_CREDIT_PRICE_ID=your-image-credit-price-id
 
 OPENAI_API_KEY=

--- a/README.md
+++ b/README.md
@@ -9,16 +9,14 @@ VITE_ACCESS_KEYS=BETA2025
 VITE_STRIPE_PUBLISHABLE_KEY=<your-stripe-publishable-key>
 VITE_STANDARD_PRICE_ID=<your-standard-price-id>
 VITE_PREMIUM_PRICE_ID=<your-premium-price-id>
+VITE_STRIPE_SECRET_KEY=<your-stripe-secret-key>
 VITE_STRIPE_PRICE_ID_IMAGE_CREDIT=price_XXXXXX
 VITE_STRIPE_PRICE_ID_TEXT_CREDIT=price_YYYYYY
 SUPABASE_SERVICE_ROLE_KEY=<your-service-role-key>
-STRIPE_SECRET_KEY=<your-stripe-secret-key>
 STRIPE_WEBHOOK_SECRET=<your-stripe-webhook-secret>
 STRIPE_PUBLISHABLE_KEY=<your-stripe-publishable-key>
 STRIPE_STANDARD_PRICE_ID=<your-standard-price-id>
 STRIPE_PREMIUM_PRICE_ID=<your-premium-price-id>
-STRIPE_TEXT_CREDIT_PRICE_ID=<your-text-credit-price-id>
-STRIPE_IMAGE_CREDIT_PRICE_ID=<your-image-credit-price-id>
 ```
 
 These values are injected by Vite and used by the app at runtime.
@@ -31,9 +29,9 @@ Supabase should import these constants instead of hard coding URLs. The buckets 
 
 `STRIPE_PUBLISHABLE_KEY` is the public key used by the browser to initialize Stripe.
 `STRIPE_STANDARD_PRICE_ID` and `STRIPE_PREMIUM_PRICE_ID` correspond to the price identifiers for your Standard and Premium subscription plans.
-`STRIPE_TEXT_CREDIT_PRICE_ID` and `STRIPE_IMAGE_CREDIT_PRICE_ID` are the price identifiers for packs of AI text and image credits.
-`VITE_STRIPE_PRICE_ID_TEXT_CREDIT` and `VITE_STRIPE_PRICE_ID_IMAGE_CREDIT` are their frontend equivalents used when purchasing credits.
-You can find all three in the Stripe dashboard: the publishable key under **Developers > API keys** and the price IDs on each product's pricing page.
+`VITE_STRIPE_SECRET_KEY` is read server-side to create checkout sessions.
+`VITE_STRIPE_PRICE_ID_TEXT_CREDIT` and `VITE_STRIPE_PRICE_ID_IMAGE_CREDIT` contain the price IDs for packs of AI text and image credits.
+You can find all these values in the Stripe dashboard: the publishable key under **Developers > API keys** and the price IDs on each product's pricing page.
 
 ## Database
 

--- a/api/generate-image.ts
+++ b/api/generate-image.ts
@@ -3,11 +3,7 @@ import OpenAI from 'openai';
 import { getUserFromRequest } from '../src/utils/auth.js';
 import generateRecipeImagePrompt from '../src/lib/recipeImagePrompt.js';
 import { createClient } from '@supabase/supabase-js';
-
-const SUPABASE_BUCKETS = {
-  recipes: 'recipe-images',
-  avatars: 'avatars',
-} as const;
+import { SUPABASE_BUCKETS } from './_shared/constants.js';
 
 const supabaseUrl = process.env.VITE_SUPABASE_URL;
 if (!supabaseUrl) throw new Error('VITE_SUPABASE_URL is not defined');

--- a/api/getSignedImageUrl.ts
+++ b/api/getSignedImageUrl.ts
@@ -1,10 +1,6 @@
 import { VercelRequest, VercelResponse } from '@vercel/node';
 import { createClient } from '@supabase/supabase-js';
-
-const SUPABASE_BUCKETS = {
-  recipes: 'recipe-images',
-  avatars: 'avatars',
-} as const;
+import { SUPABASE_BUCKETS } from './_shared/constants.js';
 
 const supabaseUrl = process.env.VITE_SUPABASE_URL;
 if (!supabaseUrl) throw new Error('VITE_SUPABASE_URL is not defined');

--- a/api/purchase-credits.ts
+++ b/api/purchase-credits.ts
@@ -2,7 +2,7 @@ import { VercelRequest, VercelResponse } from '@vercel/node';
 import Stripe from 'stripe';
 import { getUserFromRequest } from '../src/utils/auth.js';
 
-const stripeSecret = process.env.STRIPE_SECRET_KEY;
+const stripeSecret = process.env.VITE_STRIPE_SECRET_KEY as string;
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method !== 'POST') {
@@ -18,19 +18,19 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return res.status(401).json({ error: 'Unauthorized' });
   }
 
-  const { priceId } = req.body || {};
-  console.log('[purchase-credits] Received priceId:', priceId);
-  if (!/^price_[a-zA-Z0-9]+$/.test(priceId)) {
-    return res.status(400).json({ error: 'Invalid price ID' });
+  const { productId } = req.body;
+  console.log('[purchase-credits] Payload:', req.body);
+  if (!/^price_[a-zA-Z0-9]+$/.test(productId)) {
+    return res.status(400).json({ error: 'Invalid product ID format' });
   }
 
-  const stripe = new Stripe(stripeSecret, { apiVersion: '2024-04-10' });
+  const stripe = new Stripe(stripeSecret, { apiVersion: '2022-11-15' });
   const successUrl = `${req.headers.origin}/paiement?success=true`;
   const cancelUrl = `${req.headers.origin}/paiement?cancelled=true`;
 
   try {
     const session = await stripe.checkout.sessions.create({
-      line_items: [{ price: priceId, quantity: 1 }],
+      line_items: [{ price: productId, quantity: 1 }],
       mode: 'payment',
       success_url: successUrl,
       cancel_url: cancelUrl,

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@radix-ui/react-tabs": "^1.0.4",
         "@radix-ui/react-toast": "^1.1.5",
         "@stripe/stripe-js": "^3.0.0",
+        "stripe": "^12.0.0",
         "@supabase/supabase-js": "^2.39.7",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@radix-ui/react-tabs": "^1.0.4",
     "@radix-ui/react-toast": "^1.1.5",
     "@stripe/stripe-js": "^3.0.0",
+    "stripe": "^12.0.0",
     "@supabase/supabase-js": "^2.39.7",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.0.0",

--- a/src/components/RecipeFormImageHandler.jsx
+++ b/src/components/RecipeFormImageHandler.jsx
@@ -32,8 +32,11 @@ const RecipeFormImageHandler = ({
     try {
       const res = await fetch('/api/purchase-credits', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ priceId: PRICE_ID }),
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${session.access_token}`,
+        },
+        body: JSON.stringify({ productId: PRICE_ID }),
       });
       const data = await res.json();
       if (!res.ok) throw new Error(data.error || 'Request failed');

--- a/src/components/account/IACredits.jsx
+++ b/src/components/account/IACredits.jsx
@@ -76,8 +76,11 @@ export default function IACredits({ session }) {
       const priceId = type === 'text' ? TEXT_PRICE_ID : IMAGE_PRICE_ID;
       const res = await fetch('/api/purchase-credits', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ priceId }),
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${session.access_token}`,
+        },
+        body: JSON.stringify({ productId: priceId }),
       });
       const data = await res.json();
       if (!res.ok) throw new Error(data.error || 'Request failed');


### PR DESCRIPTION
## Summary
- install Stripe backend SDK and configure API key
- validate payload and debug request logging in `/api/purchase-credits.ts`
- import SUPABASE_BUCKETS from a shared file
- send auth header when purchasing credits from the frontend
- document Stripe env vars

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_686070e96868832d99ebe3df60159003