### PR TITLE
Show owner on shared menus

### DIFF
--- a/src/__tests__/menuTabs.test.jsx
+++ b/src/__tests__/menuTabs.test.jsx
@@ -14,7 +14,13 @@ const sharedMenu = [
 ];
 
 const sharedMenuOtherUser = [
-  { id: '1', user_id: 'user2', name: 'Menu ami', is_shared: true },
+  {
+    id: '1',
+    user_id: 'user2',
+    name: 'Menu ami',
+    is_shared: true,
+    owner: { username: 'Ami' },
+  },
 ];
 
 function Wrapper() {
@@ -145,5 +151,9 @@ describe('MenuTabs', () => {
     const tab = screen.getByRole('tab', { name: 'Menu ami' });
     expect(within(tab).queryByLabelText('Supprimer')).toBeNull();
     expect(tab).toHaveClass('shared-menu');
+    expect(
+      within(tab).getByText('(par Ami)', { exact: false })
+    ).toBeInTheDocument();
+    expect(within(tab).getByText('partagé')).toBeInTheDocument();
   });
 });

--- a/src/components/MenuTabs.jsx
+++ b/src/components/MenuTabs.jsx
@@ -47,6 +47,16 @@ export default function MenuTabs({
               )}
             >
               {menu.name || 'Menu'}
+              {menu.is_shared === true && menu.user_id !== currentUserId && (
+                <span className="ml-1 text-xs text-muted-foreground">
+                  (par {menu.owner?.username})
+                </span>
+              )}
+              {menu.is_shared === true && menu.user_id !== currentUserId && (
+                <span className="ml-2 px-1 rounded bg-pastel-mint text-white text-xs">
+                  partagé
+                </span>
+              )}
               {menu.user_id === currentUserId && (
                 <button
                   aria-label="Supprimer"


### PR DESCRIPTION
## Summary
- show menu creator username on shared menu tabs
- add shared badge
- update test to cover shared owner info

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68607bbb5828832db7baad36aed99b18