### PR TITLE
Add owner badge tests

### DIFF
--- a/src/__tests__/menuTabs.test.jsx
+++ b/src/__tests__/menuTabs.test.jsx
@@ -17,6 +17,16 @@ const sharedMenuOtherUser = [
   { id: '1', user_id: 'user2', name: 'Menu ami', is_shared: true },
 ];
 
+const sharedMenuWithOwner = [
+  {
+    id: '1',
+    user_id: 'user2',
+    name: 'Menu ami',
+    owner: 'Alice',
+    is_shared: true,
+  },
+];
+
 function Wrapper() {
   const [menus, setMenus] = useState(sampleMenus);
   const [activeId, setActiveId] = useState(sampleMenus[0].id);
@@ -142,8 +152,24 @@ describe('MenuTabs', () => {
       />
     );
 
-    const tab = screen.getByRole('tab', { name: 'Menu ami' });
+    const tab = screen.getByRole('tab', { name: /Menu ami/ });
     expect(within(tab).queryByLabelText('Supprimer')).toBeNull();
     expect(tab).toHaveClass('shared-menu');
+  });
+
+  it('affiche le nom du propriétaire et le badge partagé', () => {
+    render(
+      <MenuTabs
+        menus={sharedMenuWithOwner}
+        activeMenuId="1"
+        onSelect={() => {}}
+        currentUserId="user1"
+        friends={[]}
+      />
+    );
+
+    const tab = screen.getByRole('tab', { name: /Menu ami/ });
+    expect(tab).toHaveTextContent('Alice');
+    expect(screen.getByText(/partagé/i)).toBeInTheDocument();
   });
 });

--- a/src/__tests__/signedImage.test.jsx
+++ b/src/__tests__/signedImage.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import SignedImage from '../components/SignedImage.jsx';
 import * as images from '../lib/images.js';
@@ -25,7 +25,7 @@ describe('SignedImage', () => {
     render(<SignedImage bucket={SUPABASE_BUCKETS.recipes} path="image.jpg" alt="image" />);
 
     const img = await screen.findByRole('img');
-    expect(img).toHaveAttribute('src', signedUrl);
+    await waitFor(() => expect(img).toHaveAttribute('src', signedUrl));
     expect(img).toHaveAttribute('loading', 'lazy');
   });
 

--- a/src/components/MenuTabs.jsx
+++ b/src/components/MenuTabs.jsx
@@ -47,6 +47,11 @@ export default function MenuTabs({
               )}
             >
               {menu.name || 'Menu'}
+              {menu.owner && menu.user_id !== currentUserId && (
+                <span className="ml-1 text-xs text-pastel-muted-foreground">
+                  {menu.owner}
+                </span>
+              )}
               {menu.user_id === currentUserId && (
                 <button
                   aria-label="Supprimer"
@@ -60,6 +65,11 @@ export default function MenuTabs({
                 >
                   <X className="w-3 h-3" />
                 </button>
+              )}
+              {menu.user_id !== currentUserId && menu.is_shared && (
+                <span className="ml-2 rounded-md bg-pastel-mint text-white text-xs px-1.5" data-testid="shared-badge">
+                  partagé
+                </span>
               )}
             </TabsTrigger>
           );


### PR DESCRIPTION
## Summary
- add owner data to shared menu in MenuTabs tests
- render owner name and 'partagé' badge in `MenuTabs`
- wait for URL update in `SignedImage` tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68607bbc1318832d9cece71ff087e8fe