### PR TITLE
Add AI instruction formatter

### DIFF
--- a/api/format-instructions.ts
+++ b/api/format-instructions.ts
@@ -1,0 +1,86 @@
+import { VercelRequest, VercelResponse } from '@vercel/node';
+import OpenAI from 'openai';
+import { getUserFromRequest } from '../src/utils/auth.js';
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.VITE_SUPABASE_URL;
+if (!supabaseUrl) throw new Error('VITE_SUPABASE_URL is not defined');
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!serviceRoleKey) throw new Error('SUPABASE_SERVICE_ROLE_KEY is not defined');
+
+const supabaseAdmin = createClient(supabaseUrl, serviceRoleKey);
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const user = await getUserFromRequest(req);
+  if (!user) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
+  const { data: profile, error: profileError } = await supabaseAdmin
+    .from('public_user_view')
+    .select('subscription_tier')
+    .eq('id', user.id)
+    .maybeSingle();
+
+  if (profileError) {
+    console.error('Subscription fetch error:', profileError.message);
+  }
+
+  const subscriptionTier = profile?.subscription_tier || 'standard';
+
+  if (
+    subscriptionTier !== 'premium' &&
+    subscriptionTier !== 'standard' &&
+    subscriptionTier !== 'vip'
+  ) {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+
+  const { rawText } = req.body || {};
+  if (!rawText || typeof rawText !== 'string') {
+    return res.status(400).json({ error: 'Invalid rawText' });
+  }
+
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    return res.status(500).json({ error: 'Missing OpenAI API key' });
+  }
+
+  try {
+    const openai = new OpenAI({ apiKey });
+    const prompt = `Tu es un assistant culinaire. Reprends ces instructions de recette et transforme-les en une suite d'étapes claires, numérotées si nécessaire. \nChaque étape doit être concise, contenir une seule action ou phase logique, et être formulée de manière naturelle.\nRetourne le tout sous forme d’un tableau JSON, chaque élément représentant une étape.\nN’ajoute pas d’ingrédients, ne déduis pas de quantités, ne change pas l’ordre des étapes.\nVoici les instructions brutes : ${rawText}`;
+
+    const response = await openai.chat.completions.create({
+      model: 'gpt-3.5-turbo',
+      messages: [{ role: 'user', content: prompt }],
+    });
+
+    const content = response.choices[0].message.content || '[]';
+    let instructions: string[] = [];
+    try {
+      const parsed = JSON.parse(content);
+      if (Array.isArray(parsed)) {
+        instructions = parsed.map((s) => String(s));
+      } else {
+        throw new Error('Not an array');
+      }
+    } catch (err) {
+      console.error('Parse error:', err);
+      return res.status(500).json({ error: 'Malformed AI response' });
+    }
+
+    await supabaseAdmin.rpc('decrement_ia_credit', {
+      user_uuid: user.id,
+      credit_type: 'text',
+    });
+
+    return res.status(200).json({ instructions });
+  } catch (err) {
+    console.error('OpenAI error:', err);
+    return res.status(500).json({ error: 'Internal Server Error', details: String(err) });
+  }
+}

--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -7,6 +7,7 @@ All API routes are under `api/` and are deployed as serverless functions.
 | `api/access-key` | Validates invitation keys and marks them as used. |
 | `api/estimate-cost` | Uses OpenAI to estimate the total cost of a recipe. Requires authentication. |
 | `api/generate-description` | Generates a short recipe description with OpenAI. |
+| `api/format-instructions` | Formats raw cooking instructions into clear steps using OpenAI. Requires authentication. |
 | `api/generate-image` | Generates a DALL·E image, uploads it to Supabase and returns the file path. |
 | `api/update-profile` | Updates fields in `public_user_view` for the current user. |
 | `api/purchase-credits` | Starts a Stripe Checkout session to buy extra AI credits. |

--- a/docs/prompt-templates.md
+++ b/docs/prompt-templates.md
@@ -31,3 +31,13 @@ The helper `generateRecipeImagePrompt()` builds an English description such as:
 A delicious and realistic photo of a home-cooked dish: fried eggs with bacon and grilled cheese. It includes: egg, bacon, bread, cheese. Styled simply on a plate or in a pan. Lighting is natural and appetizing. Do not use a restaurant or gourmet aesthetic. Show the food clearly. No people, no logos, no text. Focus on realistic food presentation, homemade style.
 ```
 (see `src/lib/recipeImagePrompt.js`)
+
+## Instruction Formatting
+```
+Tu es un assistant culinaire. Reprends ces instructions de recette et transforme-les en une suite d'étapes claires, numérotées si nécessaire.
+Chaque étape doit être concise, contenir une seule action ou phase logique, et être formulée de manière naturelle.
+Retourne le tout sous forme d’un tableau JSON, chaque élément représentant une étape.
+N’ajoute pas d’ingrédients, ne déduis pas de quantités, ne change pas l’ordre des étapes.
+Voici les instructions brutes : ${rawText}
+```
+(see `api/format-instructions.ts`)

--- a/src/lib/openai.js
+++ b/src/lib/openai.js
@@ -55,3 +55,23 @@ export const estimateRecipePrice = async (
     return null;
   }
 };
+
+export const formatInstructionsWithAI = async (rawText) => {
+  try {
+    const response = await fetch('/api/format-instructions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ rawText }),
+    });
+
+    if (!response.ok) throw new Error('Request failed');
+
+    const { instructions } = await response.json();
+    return Array.isArray(instructions) ? instructions : [];
+  } catch (error) {
+    console.error('Erreur lors du formatage des instructions:', error);
+    return null;
+  }
+};


### PR DESCRIPTION
## Summary
- add /api/format-instructions route for OpenAI-driven step extraction
- expose `formatInstructionsWithAI()` helper in `src/lib/openai.js`
- document new API route and prompt template

## Testing
- `npm run test -- --run` *(fails: MenuTabs and SignedImage tests)*

------
https://chatgpt.com/codex/tasks/task_e_68610f3bcba8832dada2bd287a5f7745