### PR TITLE
Add AI instruction improvement button

### DIFF
--- a/src/components/RecipeForm.jsx
+++ b/src/components/RecipeForm.jsx
@@ -68,6 +68,7 @@ function RecipeForm({
   const [suggestedTags, setSuggestedTags] = useState([]);
   const [isGeneratingDescription, setIsGeneratingDescription] = useState(false);
   const [isGeneratingImage, setIsGeneratingImage] = useState(false);
+  const [isImprovingInstructions, setIsImprovingInstructions] = useState(false);
   const [isUploadingImage, setIsUploadingImage] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [selectedFile, setSelectedFile] = useState(null);
@@ -312,6 +313,31 @@ function RecipeForm({
       ...prev,
       instructions: e.target.value.split('\n'),
     }));
+  };
+
+  const handleImproveInstructions = async () => {
+    const text = Array.isArray(formData.instructions)
+      ? formData.instructions.join('\n')
+      : formData.instructions;
+    if (!text) return;
+
+    setIsImprovingInstructions(true);
+
+    try {
+      const res = await fetch('/api/format-instructions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text }),
+      });
+      const data = await res.json();
+      if (Array.isArray(data.instructions)) {
+        setFormData((prev) => ({ ...prev, instructions: data.instructions }));
+      }
+    } catch (err) {
+      console.error('improve instructions error:', err);
+    }
+
+    setIsImprovingInstructions(false);
   };
 
   const handleVisibilityChange = (value) => {
@@ -822,6 +848,8 @@ function RecipeForm({
             <RecipeInstructionsManager
               instructions={formData.instructions}
               handleInstructionsChange={handleInstructionsChange}
+              handleImproveInstructions={handleImproveInstructions}
+              isImproving={isImprovingInstructions}
             />
 
             <RecipeFormAIFeatures

--- a/src/components/form/RecipeInstructionsManager.jsx
+++ b/src/components/form/RecipeInstructionsManager.jsx
@@ -1,19 +1,33 @@
 import React from 'react';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
+import { Button } from '@/components/ui/button';
 
 export default function RecipeInstructionsManager({
   instructions,
   handleInstructionsChange,
+  handleImproveInstructions,
+  isImproving,
 }) {
   return (
     <div className="space-y-2 bg-pastel-card p-5 rounded-xl shadow-pastel-soft">
-      <Label
-        htmlFor="instructions"
-        className="text-lg font-semibold text-pastel-secondary"
-      >
-        Instructions
-      </Label>
+      <div className="flex justify-between items-center">
+        <Label
+          htmlFor="instructions"
+          className="text-lg font-semibold text-pastel-secondary"
+        >
+          Instructions
+        </Label>
+        <Button
+          type="button"
+          size="sm"
+          variant="secondary"
+          onClick={handleImproveInstructions}
+          disabled={isImproving}
+        >
+          {isImproving ? 'Amélioration…' : '✨ Améliorer avec l\u2019IA'}
+        </Button>
+      </div>
       <Textarea
         id="instructions"
         value={Array.isArray(instructions) ? instructions.join('\n') : ''}


### PR DESCRIPTION
## Summary
- add an AI improvement button to recipe instructions manager
- wire button to new handler in `RecipeForm`

## Testing
- `npm run lint` *(fails: 572 errors)*
- `npm test` *(fails: 1 test file, 2 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_68614d934410832d824c6643a424cce3