### PR TITLE
Update menu creation and display

### DIFF
--- a/src/__tests__/menuTabs.test.jsx
+++ b/src/__tests__/menuTabs.test.jsx
@@ -133,11 +133,11 @@ describe('MenuTabs', () => {
     );
 
     const tab = screen.getByRole('tab', { name: 'Menu 1' });
-    expect(tab).toHaveClass('shared-menu');
+    expect(tab).toHaveClass('mintStyle');
     expect(tab).toHaveClass('data-[state=active]:bg-pastel-mint');
   });
 
-  it("affiche le nom du propriétaire et le badge 'partagé' pour un menu partagé par un autre utilisateur", () => {
+  it("affiche le badge avec le nom du propriétaire pour un menu partagé par un autre utilisateur", () => {
     render(
       <MenuTabs
         menus={sharedMenuOtherUser}
@@ -148,9 +148,8 @@ describe('MenuTabs', () => {
       />
     );
 
-    const tab = screen.getByRole('tab', { name: 'Menu ami' });
-    expect(within(tab).getByText('(par Ami)', { exact: false })).toBeInTheDocument();
-    expect(within(tab).getByText('partagé')).toBeInTheDocument();
+    const tab = screen.getByRole('tab', { name: /Menu ami/ });
+    expect(within(tab).getByText('Partagé par Ami')).toBeInTheDocument();
   });
 
   it("n'affiche pas le bouton supprimer pour un menu partagé par un autre utilisateur", () => {
@@ -164,12 +163,9 @@ describe('MenuTabs', () => {
       />
     );
 
-    const tab = screen.getByRole('tab', { name: 'Menu ami' });
+    const tab = screen.getByRole('tab', { name: /Menu ami/ });
     expect(within(tab).queryByLabelText('Supprimer')).toBeNull();
-    expect(tab).toHaveClass('shared-menu');
-    expect(
-      within(tab).getByText('(par Ami)', { exact: false })
-    ).toBeInTheDocument();
-    expect(within(tab).getByText('partagé')).toBeInTheDocument();
+    expect(tab).toHaveClass('mintStyleWithBadge');
+    expect(within(tab).getByText('Partagé par Ami')).toBeInTheDocument();
   });
 });

--- a/src/components/MenuTabs.jsx
+++ b/src/components/MenuTabs.jsx
@@ -31,11 +31,15 @@ export default function MenuTabs({
     >
       <TabsList className="flex overflow-x-auto items-center gap-2">
         {menus.map((menu) => {
+          const isOwner = menu.user_id === currentUserId;
           const isShared = menu.is_shared === true;
-          // Shared menus turn mint when active
+
           const colorClasses = isShared
-            ? 'shared-menu data-[state=active]:bg-pastel-mint data-[state=active]:text-white'
-            : 'border-pastel-primary text-pastel-primary hover:bg-pastel-primary/10 data-[state=active]:bg-pastel-primary';
+            ? isOwner
+              ? 'mintStyle data-[state=active]:bg-pastel-mint data-[state=active]:text-white'
+              : 'mintStyleWithBadge data-[state=active]:bg-pastel-mint data-[state=active]:text-white'
+            : 'violetStyle data-[state=active]:bg-pastel-primary';
+
           return (
             <TabsTrigger
               key={menu.id}
@@ -47,17 +51,10 @@ export default function MenuTabs({
               )}
             >
               {menu.name || 'Menu'}
-              {menu.is_shared === true && menu.user_id !== currentUserId && (
-                <span className="ml-1 text-xs text-muted-foreground">
-                  (par {menu.owner?.username})
-                </span>
+              {!isOwner && isShared && (
+                <span className="badge">Partagé par {menu.owner?.username}</span>
               )}
-              {menu.is_shared === true && menu.user_id !== currentUserId && (
-                <span className="ml-2 px-1 rounded bg-pastel-mint text-white text-xs">
-                  partagé
-                </span>
-              )}
-              {menu.user_id === currentUserId && (
+              {isOwner && (
                 <button
                   aria-label="Supprimer"
                   onClick={(e) => {

--- a/src/hooks/useMenuList.js
+++ b/src/hooks/useMenuList.js
@@ -1,8 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
-import { getSupabase } from '@/lib/supabase';
 import { useToast } from '@/components/ui/use-toast';
-
-const supabase = getSupabase();
+import { fetchMenusForUser } from './useMenus.js';
 
 export function useMenuList(session) {
   const [menus, setMenus] = useState([]);
@@ -14,63 +12,8 @@ export function useMenuList(session) {
     if (!userId) return;
     setLoading(true);
     try {
-      const { data: ownerMenus, error: ownerError } = await supabase
-        .from('weekly_menus')
-        .select('id, user_id, name, updated_at, is_shared')
-        .eq('user_id', userId)
-        .order('created_at');
-
-      if (ownerError && ownerError.code !== 'PGRST116') {
-        throw ownerError;
-      }
-
-      const { data: participantRows, error: participantError } = await supabase
-        .from('menu_participants')
-        .select('menu_id')
-        .eq('user_id', userId);
-
-      if (participantError && participantError.code !== 'PGRST116') {
-        throw participantError;
-      }
-
-      const participantIds = (participantRows || []).map((r) => r.menu_id);
-      let participantMenus = [];
-      if (participantIds.length > 0) {
-        const { data, error } = await supabase
-          .from('weekly_menus')
-          .select('id, user_id, name, updated_at, is_shared')
-          .in('id', participantIds);
-        if (error) throw error;
-        participantMenus = data || [];
-      }
-
-      const combined = [...(ownerMenus || []), ...participantMenus];
-      const unique = [];
-      const seen = new Set();
-      for (const m of combined) {
-        if (!seen.has(m.id)) {
-          seen.add(m.id);
-          unique.push(m);
-        }
-      }
-
-      const userIds = [...new Set(unique.map((m) => m.user_id))];
-      let usersMap = {};
-      if (userIds.length > 0) {
-        const { data: users } = await supabase
-          .from('public_user_view')
-          .select('id, username, avatar_url')
-          .in('id', userIds);
-        usersMap = Object.fromEntries((users || []).map((u) => [u.id, u]));
-      }
-
-      // `is_shared` is selected directly from weekly_menus
-      const withOwners = unique.map((m) => ({
-        ...m,
-        owner: usersMap[m.user_id] ?? null,
-      }));
-
-      setMenus(withOwners);
+      const list = await fetchMenusForUser(userId);
+      setMenus(list);
     } catch (err) {
       console.error('Erreur chargement menus:', err);
       toast({

--- a/src/index.css
+++ b/src/index.css
@@ -187,6 +187,23 @@
   .shared-menu {
     @apply border-pastel-mint text-pastel-mint hover:bg-pastel-mint/10;
   }
+
+  /* New menu tab styles */
+  .mintStyle {
+    @apply border-pastel-mint text-pastel-mint hover:bg-pastel-mint/10;
+  }
+
+  .mintStyleWithBadge {
+    @apply border-pastel-mint text-pastel-mint hover:bg-pastel-mint/10;
+  }
+
+  .violetStyle {
+    @apply border-pastel-primary text-pastel-primary hover:bg-pastel-primary/10;
+  }
+
+  .badge {
+    @apply ml-2 px-1 rounded bg-pastel-mint text-white text-xs;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/pages/MenuPage.jsx
+++ b/src/pages/MenuPage.jsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect } from 'react';
 import MenuPlanner from '@/components/MenuPlanner';
 import MenuTabs from '@/components/MenuTabs.jsx';
 import { getSupabase } from '@/lib/supabase';
-import { initialWeeklyMenuState } from '@/lib/menu';
 import { useFriendsList } from '@/hooks/useFriendsList.js';
 import { useMenuParticipants } from '@/hooks/useMenuParticipants.js';
 import { toDbPrefs } from '@/hooks/useWeeklyMenu.js';
@@ -84,8 +83,8 @@ export default function MenuPage({
     const insertData = {
       user_id: userId,
       name: name || 'Menu sans titre',
-      menu_data: initialWeeklyMenuState(),
       is_shared: Boolean(isShared),
+      menu_data: {},
     };
 
     const { data, error } = await supabase
@@ -107,10 +106,9 @@ export default function MenuPage({
         .insert({ menu_id: data.id, ...dbPrefs });
     }
 
-    if (isShared && data?.id) {
-      const ids = Array.from(new Set([userId, ...participantIds]));
-      const rows = ids.map((id) => ({ menu_id: data.id, user_id: id }));
-      await supabase.from('menu_participants').insert(rows);
+    if (isShared) {
+      // Wait for trigger to populate menu_participants
+      await new Promise((r) => setTimeout(r, 500));
     }
 
     await refreshMenus();


### PR DESCRIPTION
## Summary
- enforce `menu_data` when creating a menu and wait for trigger
- adjust shared menu styles and badges
- centralize menu loading logic with `fetchMenusForUser`
- reuse fetch helper inside `useMenuList`
- update tests for new styling

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68614dd1be04832db47007248ff19d87