### PR TITLE
Fix Stripe secret and show IA credits

### DIFF
--- a/api/purchase-credits.ts
+++ b/api/purchase-credits.ts
@@ -2,7 +2,10 @@ import { VercelRequest, VercelResponse } from '@vercel/node';
 import Stripe from 'stripe';
 import { getUserFromRequest } from '../src/utils/auth.js';
 
-const stripeSecret = process.env.VITE_STRIPE_SECRET_KEY as string;
+let stripeSecret = process.env.STRIPE_SECRET_KEY as string | undefined;
+if (!stripeSecret && process.env.NODE_ENV !== 'production') {
+  stripeSecret = process.env.VITE_STRIPE_SECRET_KEY;
+}
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method !== 'POST') {
@@ -10,7 +13,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   }
 
   if (!stripeSecret) {
-    return res.status(500).json({ error: 'Stripe not configured' });
+    return res.status(500).json({ error: 'Stripe secret key not configured' });
   }
 
   const user = await getUserFromRequest(req);

--- a/src/components/AccountPage.jsx
+++ b/src/components/AccountPage.jsx
@@ -54,7 +54,8 @@ export default function AccountPage({ session, userProfile, onProfileUpdate }) {
         />
       </section>
 
-      {userProfile.subscription_tier === 'vip' && (
+      {(userProfile.subscription_tier === 'vip' ||
+        userProfile.subscription_tier === 'standard') && (
         <section className="bg-muted/10 p-6 rounded-xl space-y-6">
           <IACredits session={session} />
         </section>

--- a/src/components/RecipeForm.jsx
+++ b/src/components/RecipeForm.jsx
@@ -86,7 +86,8 @@ function RecipeForm({
   const [iaUsage, setIaUsage] = useState(null);
 
   const fetchIaUsage = useCallback(async () => {
-    if (subscriptionTier !== 'vip' || !session?.access_token) {
+    if (!session?.access_token ||
+        (subscriptionTier !== 'vip' && subscriptionTier !== 'standard')) {
       setIaUsage(null);
       return;
     }

--- a/src/components/RecipeFormAIFeatures.jsx
+++ b/src/components/RecipeFormAIFeatures.jsx
@@ -52,7 +52,7 @@ const RecipeFormAIFeatures = ({
               : 'Premium Description'}
         </Button>
       </div>
-      {subscription_tier === 'vip' && (
+      {(subscription_tier === 'vip' || subscription_tier === 'standard') && (
         <p className="text-xs text-pastel-muted-foreground text-right">
           Crédits restants : {iaUsage?.text_credits ?? 0}
         </p>

--- a/src/components/RecipeFormImageHandler.jsx
+++ b/src/components/RecipeFormImageHandler.jsx
@@ -108,7 +108,7 @@ const RecipeFormImageHandler = ({
                 : 'Premium Image'}
         </Button>
       </div>
-      {subscription_tier === 'vip' && (
+      {(subscription_tier === 'vip' || subscription_tier === 'standard') && (
         <p className="text-xs text-pastel-muted-foreground text-right">
           Crédits restants : {iaUsage?.image_credits ?? 0}
         </p>


### PR DESCRIPTION
## Summary
- read `STRIPE_SECRET_KEY` in purchase-credits API route with dev fallback
- show IA credits section for Standard users
- expose remaining credits for Standard tier in recipe forms

## Testing
- `npx vitest run` *(fails: menuTabs test fails)*

------
https://chatgpt.com/codex/tasks/task_e_68614ec5b074832daacb4384afbbaa06