### PR TITLE
Add AI instructions formatter

### DIFF
--- a/src/components/form/RecipeInstructionsManager.jsx
+++ b/src/components/form/RecipeInstructionsManager.jsx
@@ -2,40 +2,61 @@ import React from 'react';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { Button } from '@/components/ui/button';
+import { Loader2 } from 'lucide-react';
 
 export default function RecipeInstructionsManager({
   instructions,
   handleInstructionsChange,
   handleImproveInstructions,
   isImproving,
+  iaUsage,
 }) {
+  const rawText = Array.isArray(instructions)
+    ? instructions.join('\n')
+    : instructions || '';
+  const disabled =
+    isImproving ||
+    rawText.length < 10 ||
+    (iaUsage && (iaUsage.text_credits ?? 0) <= 0);
   return (
     <div className="space-y-2 bg-pastel-card p-5 rounded-xl shadow-pastel-soft">
-      <div className="flex justify-between items-center">
-        <Label
-          htmlFor="instructions"
-          className="text-lg font-semibold text-pastel-secondary"
-        >
-          Instructions
-        </Label>
-        <Button
-          type="button"
-          size="sm"
-          variant="secondary"
-          onClick={handleImproveInstructions}
-          disabled={isImproving}
-        >
-          {isImproving ? 'Amélioration…' : '✨ Améliorer avec l\u2019IA'}
-        </Button>
-      </div>
+      <Label
+        htmlFor="instructions"
+        className="text-lg font-semibold text-pastel-secondary"
+      >
+        Instructions
+      </Label>
       <Textarea
         id="instructions"
-        value={Array.isArray(instructions) ? instructions.join('\n') : ''}
+        value={rawText}
         onChange={handleInstructionsChange}
         placeholder="Listez les étapes de préparation, une par ligne."
         rows={6}
         className="bg-pastel-input border-pastel-input-border focus:border-pastel-input-focus-border"
       />
+      <div className="flex justify-between items-center">
+        {(iaUsage?.text_credits ?? 0) >= 0 && (
+          <p className="text-xs text-pastel-muted-foreground">
+            Crédits restants : {iaUsage?.text_credits ?? 0}
+          </p>
+        )}
+        <Button
+          type="button"
+          size="sm"
+          variant="secondary"
+          onClick={handleImproveInstructions}
+          disabled={disabled}
+          className="ml-auto"
+        >
+          {isImproving ? (
+            <>
+              <Loader2 className="w-4 h-4 mr-2 animate-spin" /> Amélioration…
+            </>
+          ) : (
+            'Améliorer les instructions'
+          )}
+        </Button>
+      </div>
     </div>
   );
 }

--- a/src/lib/openai.js
+++ b/src/lib/openai.js
@@ -1,4 +1,3 @@
-
 export const generateRecipe = async (prompt, subscriptionTier = 'standard') => {
   try {
     const response = await fetch('/api/generate-recipe', {
@@ -56,13 +55,21 @@ export const estimateRecipePrice = async (
   }
 };
 
-export const formatInstructionsWithAI = async (rawText) => {
+export const formatInstructionsWithAI = async (rawText, session) => {
   try {
+    const headers = { 'Content-Type': 'application/json' };
+    const token = session?.access_token ?? session;
+    if (token) {
+      headers.Authorization = `Bearer ${token}`;
+    } else {
+      console.error(
+        'Missing access token for /api/format-instructions request'
+      );
+    }
+
     const response = await fetch('/api/format-instructions', {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
+      headers,
       body: JSON.stringify({ rawText }),
     });
 


### PR DESCRIPTION
## Summary
- check text credits before formatting instructions
- authorize client requests and pass session token
- add Improve Instructions button with loading state
- handle failure with toast error

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68615427f420832db85ab0fa934cd4bf