### PR TITLE
Fix shared menu display

### DIFF
--- a/src/__tests__/menuTabs.test.jsx
+++ b/src/__tests__/menuTabs.test.jsx
@@ -133,8 +133,8 @@ describe('MenuTabs', () => {
     );
 
     const tab = screen.getByRole('tab', { name: 'Menu 1' });
-    expect(tab).toHaveClass('mintStyle');
-    expect(tab).toHaveClass('data-[state=active]:bg-pastel-mint');
+    expect(tab).toHaveClass('violetStyle');
+    expect(tab).toHaveClass('data-[state=active]:bg-pastel-primary');
   });
 
   it("affiche le badge avec le nom du propriétaire pour un menu partagé par un autre utilisateur", () => {

--- a/src/components/MenuTabs.jsx
+++ b/src/components/MenuTabs.jsx
@@ -32,12 +32,10 @@ export default function MenuTabs({
       <TabsList className="flex overflow-x-auto items-center gap-2">
         {menus.map((menu) => {
           const isOwner = menu.user_id === currentUserId;
-          const isShared = menu.is_shared === true;
+          const isShared = menu.is_shared === true && !isOwner;
 
           const colorClasses = isShared
-            ? isOwner
-              ? 'mintStyle data-[state=active]:bg-pastel-mint data-[state=active]:text-white'
-              : 'mintStyleWithBadge data-[state=active]:bg-pastel-mint data-[state=active]:text-white'
+            ? 'mintStyleWithBadge data-[state=active]:bg-pastel-mint data-[state=active]:text-white'
             : 'violetStyle data-[state=active]:bg-pastel-primary';
 
           return (
@@ -51,7 +49,7 @@ export default function MenuTabs({
               )}
             >
               {menu.name || 'Menu'}
-              {!isOwner && isShared && (
+              {isShared && (
                 <span className="badge">Partagé par {menu.owner?.username}</span>
               )}
               {isOwner && (

--- a/src/hooks/useMenus.js
+++ b/src/hooks/useMenus.js
@@ -60,6 +60,8 @@ export async function fetchMenusForUser(userId) {
   return unique.map((m) => ({
     ...m,
     owner: usersMap[m.user_id] ?? null,
+    shared_by:
+      m.user_id !== userId ? usersMap[m.user_id]?.username || null : null,
   }));
 }
 
@@ -120,11 +122,14 @@ export function useMenus(session) {
     }
   }, [selectedMenuId, storageKey]);
 
+  const selectedMenu = menus.find((m) => m.id === selectedMenuId) || null;
+
   return {
     menus,
     loading,
     selectedMenuId,
     setSelectedMenuId,
+    selectedMenu,
     refreshMenus: fetchMenus,
   };
 }

--- a/src/pages/MenuPage.jsx
+++ b/src/pages/MenuPage.jsx
@@ -104,11 +104,13 @@ export default function MenuPage({
       await supabase
         .from('weekly_menu_preferences')
         .insert({ menu_id: data.id, ...dbPrefs });
-    }
 
-    if (isShared) {
-      // Wait for trigger to populate menu_participants
-      await new Promise((r) => setTimeout(r, 500));
+      if (isShared) {
+        const participants = [userId, ...participantIds];
+        await supabase.from('menu_participants').insert(
+          participants.map((uid) => ({ menu_id: data.id, user_id: uid }))
+        );
+      }
     }
 
     await refreshMenus();


### PR DESCRIPTION
## Summary
- show shared menu owner names in `useMenus`
- expose selected menu in `useMenus`
- apply mint styles only for menus shared by others
- persist participants when creating a shared menu
- update tests for new style rules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686156b48ba0832d9244cdd1ea617c93