### PR TITLE
Implement Stripe credits webhook

### DIFF
--- a/api/purchase-credits.ts
+++ b/api/purchase-credits.ts
@@ -28,8 +28,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   }
 
   const stripe = new Stripe(stripeSecret, { apiVersion: '2022-11-15' });
-  const successUrl = `${req.headers.origin}/paiement?success=true`;
-  const cancelUrl = `${req.headers.origin}/paiement?cancelled=true`;
+  const successUrl = `${req.headers.origin}/credits-confirmed`;
+  const cancelUrl = `${req.headers.origin}/app/account?credits_canceled=true`;
 
   try {
     const session = await stripe.checkout.sessions.create({

--- a/api/stripe-webhook.ts
+++ b/api/stripe-webhook.ts
@@ -1,0 +1,118 @@
+import { VercelRequest, VercelResponse } from '@vercel/node';
+import { createClient } from '@supabase/supabase-js';
+import Stripe from 'stripe';
+
+let stripeSecret = process.env.STRIPE_SECRET_KEY as string | undefined;
+if (!stripeSecret && process.env.NODE_ENV !== 'production') {
+  stripeSecret = process.env.VITE_STRIPE_SECRET_KEY;
+}
+
+const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET as string | undefined;
+const supabaseUrl = process.env.VITE_SUPABASE_URL;
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!stripeSecret) throw new Error('STRIPE_SECRET_KEY is not defined');
+if (!webhookSecret) throw new Error('STRIPE_WEBHOOK_SECRET is not defined');
+if (!supabaseUrl) throw new Error('VITE_SUPABASE_URL is not defined');
+if (!serviceRoleKey) throw new Error('SUPABASE_SERVICE_ROLE_KEY is not defined');
+
+const stripe = new Stripe(stripeSecret, { apiVersion: '2024-04-10' });
+const supabase = createClient(supabaseUrl, serviceRoleKey);
+
+export const config = {
+  api: {
+    bodyParser: false,
+  },
+};
+
+async function readRawBody(req: VercelRequest): Promise<Buffer> {
+  const chunks: Uint8Array[] = [];
+  for await (const chunk of req) {
+    chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk);
+  }
+  return Buffer.concat(chunks);
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const signature = req.headers['stripe-signature'] as string | undefined;
+  if (!signature) {
+    return res.status(400).json({ error: 'Missing Stripe signature' });
+  }
+
+  let event: Stripe.Event;
+  try {
+    const body = await readRawBody(req);
+    event = stripe.webhooks.constructEvent(body, signature, webhookSecret);
+  } catch (err) {
+    console.error('Invalid Stripe signature', err);
+    return res.status(400).json({ error: 'Invalid signature' });
+  }
+
+  try {
+    if (event.type === 'checkout.session.completed' || event.type === 'invoice.paid') {
+      const session: any = event.data.object;
+      const userId: string | undefined = session.client_reference_id;
+      const email: string | undefined = session.customer_email || session.customer_details?.email;
+      let id = userId;
+
+      if (!id && email) {
+        const { data, error } = await supabase
+          .from('public_user_view')
+          .select('id')
+          .eq('email', email)
+          .maybeSingle();
+        if (error) {
+          console.error('Error fetching user:', error.message);
+        }
+        id = data?.id as string | undefined;
+      }
+
+      if (id) {
+        if (session.mode === 'subscription') {
+          const { error } = await supabase.auth.admin.updateUserById(id, {
+            app_metadata: { subscription_tier: 'premium' },
+          });
+          if (error) {
+            console.error('Supabase update error:', error.message);
+            return res.status(500).json({ error: 'Supabase update failed' });
+          }
+        } else if (session.mode === 'payment' && session.metadata?.credits_type) {
+          const column = session.metadata.credits_type === 'text' ? 'text_credits' : 'image_credits';
+          const increment = session.metadata.credits_type === 'text' ? 150 : 50;
+          const { data: row, error: fetchErr } = await supabase
+            .from('ia_credits')
+            .select(column)
+            .eq('user_id', id)
+            .maybeSingle();
+          if (fetchErr) {
+            console.error('ia_credits fetch error:', fetchErr.message);
+          }
+          const current = row?.[column] ?? 0;
+          const { error: upsertErr } = await supabase.from('ia_credits').upsert(
+            {
+              user_id: id,
+              [column]: current + increment,
+              updated_at: new Date().toISOString(),
+            },
+            { onConflict: 'user_id' }
+          );
+          if (upsertErr) {
+            console.error('ia_credits upsert error:', upsertErr.message);
+          }
+        }
+      }
+    } else {
+      console.log(`Unhandled event type: ${event.type}`);
+    }
+  } catch (err) {
+    console.error('Webhook processing error:', err);
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+
+  return res.status(200).json({ received: true });
+}
+

--- a/src/components/AppRoutes.jsx
+++ b/src/components/AppRoutes.jsx
@@ -13,6 +13,7 @@ import UserProfilePage from '@/pages/UserProfilePage';
 import LoadingScreen from '@/components/layout/LoadingScreen';
 import { PlusCircle } from 'lucide-react';
 import LoginPage from '@/pages/Login.jsx';
+import CreditsConfirmedPage from '@/pages/CreditsConfirmed';
 
 export default function AppRoutes({
   session,
@@ -204,6 +205,7 @@ export default function AppRoutes({
           )
         }
       />
+      <Route path="/credits-confirmed" element={<CreditsConfirmedPage />} />
       <Route path="/app/*" element={<Navigate to="/app/recipes" replace />} />
       <Route path="/login" element={<LoginPage />} />
       <Route path="/" element={<Navigate to="/app/recipes" replace />} />

--- a/src/pages/CreditsConfirmed.jsx
+++ b/src/pages/CreditsConfirmed.jsx
@@ -1,0 +1,56 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useToast } from '@/components/ui/use-toast';
+import { getSupabase } from '@/lib/supabase';
+import { Button } from '@/components/ui/button';
+
+const supabase = getSupabase();
+
+export default function CreditsConfirmedPage() {
+  const { toast } = useToast();
+  const navigate = useNavigate();
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const refresh = async () => {
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+      if (!session) {
+        navigate('/login', { replace: true });
+        return;
+      }
+      try {
+        const res = await fetch('/api/get-ia-credits', {
+          headers: {
+            Authorization: `Bearer ${session.access_token}`,
+            apikey: import.meta.env.VITE_SUPABASE_ANON_KEY,
+          },
+        });
+        if (res.ok) {
+          toast.success('Cr\u00e9dits IA ajout\u00e9s \u00e0 votre compte.');
+        }
+      } catch (err) {
+        console.error('refresh credits error:', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    refresh();
+  }, [navigate, toast]);
+
+  return (
+    <div className="flex flex-col items-center justify-center h-screen gap-6">
+      <h1 className="text-2xl font-bold text-pastel-primary">
+        Cr\u00e9dits confirm\u00e9s
+      </h1>
+      {loading ? (
+        <p>V\u00e9rification en cours...</p>
+      ) : (
+        <Button onClick={() => navigate('/app/account')}>
+          Retour au compte
+        </Button>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add API route `/api/stripe-webhook` to handle purchase events
- redirect credit checkout success to new `/credits-confirmed` page
- add confirmation page that refreshes credits on load

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68615731df34832db789fe5de9053b76