### PR TITLE
Remove alias buy credits endpoint

### DIFF
--- a/api/buy-ia-credits.ts
+++ b/api/buy-ia-credits.ts
@@ -1,1 +1,0 @@
-export { default } from './purchase-credits';

--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -11,5 +11,4 @@ All API routes are under `api/` and are deployed as serverless functions.
 | `api/generate-image` | Generates a DALL·E image, uploads it to Supabase and returns the file path. |
 | `api/update-profile` | Updates fields in `public_user_view` for the current user. |
 | `api/purchase-credits` | Starts a Stripe Checkout session to buy extra AI credits. |
-| `api/buy-ia-credits` | Alias for `api/purchase-credits`. |
 | `api/stripe/webhook` | Deno function that updates subscription metadata after Stripe events. |


### PR DESCRIPTION
## Summary
- remove `api/buy-ia-credits.ts` alias
- update API overview docs

## Testing
- `npm run lint` *(fails: 578 errors)*
- `npm run test` *(starts vitest in watch mode)*

------
https://chatgpt.com/codex/tasks/task_e_6861a63d3294832da8688b3cc770cdf5