### PR TITLE
Add missing recipe generation API

### DIFF
--- a/api/generate-recipe.ts
+++ b/api/generate-recipe.ts
@@ -1,0 +1,52 @@
+import { VercelRequest, VercelResponse } from '@vercel/node';
+import OpenAI from 'openai';
+import { getUserFromRequest } from '../src/utils/auth.js';
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.VITE_SUPABASE_URL;
+if (!supabaseUrl) throw new Error('VITE_SUPABASE_URL is not defined');
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!serviceRoleKey) throw new Error('SUPABASE_SERVICE_ROLE_KEY is not defined');
+
+const supabaseAdmin = createClient(supabaseUrl, serviceRoleKey);
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const user = await getUserFromRequest(req);
+  if (!user || user.raw_user_meta_data?.subscription_tier !== 'premium') {
+    return res.status(403).json({ error: 'Premium only' });
+  }
+
+  const { prompt } = req.body || {};
+  if (!prompt || typeof prompt !== 'string') {
+    return res.status(400).json({ error: 'Missing prompt' });
+  }
+
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    return res.status(500).json({ error: 'Missing OpenAI API key' });
+  }
+
+  try {
+    const openai = new OpenAI({ apiKey });
+    const result = await openai.chat.completions.create({
+      model: 'gpt-3.5-turbo',
+      messages: [{ role: 'user', content: prompt }],
+    });
+
+    await supabaseAdmin.rpc('decrement_ia_credit', {
+      user_uuid: user.id,
+      credit_type: 'text',
+    });
+
+    return res.status(200).json(result);
+  } catch (err) {
+    console.error('generate-recipe error:', err);
+    return res
+      .status(500)
+      .json({ error: 'Internal Server Error', details: String(err) });
+  }
+}

--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -6,6 +6,7 @@ All API routes are under `api/` and are deployed as serverless functions.
 |-------|-------------|
 | `api/access-key` | Validates invitation keys and marks them as used. |
 | `api/estimate-cost` | Uses OpenAI to estimate the total cost of a recipe. Requires authentication. |
+| `api/generate-recipe` | Creates a complete recipe with OpenAI. Premium only. |
 | `api/generate-description` | Generates a short recipe description with OpenAI. |
 | `api/format-instructions` | Formats raw cooking instructions into clear steps using OpenAI. Requires authentication. |
 | `api/generate-image` | Generates a DALL·E image, uploads it to Supabase and returns the file path. |


### PR DESCRIPTION
## Summary
- implement `api/generate-recipe.ts` to mirror the Supabase edge function
- document the new route in `docs/api-overview.md`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6861a666b3c0832d920e9fc5987c0efb