### PR TITLE
Update API overview docs

### DIFF
--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -9,7 +9,11 @@ All API routes are under `api/` and are deployed as serverless functions.
 | `api/generate-description` | Generates a short recipe description with OpenAI. |
 | `api/format-instructions` | Formats raw cooking instructions into clear steps using OpenAI. Requires authentication. |
 | `api/generate-image` | Generates a DALL·E image, uploads it to Supabase and returns the file path. |
+| `api/getSignedImageUrl` | Returns a signed URL for an image stored in Supabase. |
+| `api/get-ia-credits` | Retrieves current AI usage and available credits. |
 | `api/update-profile` | Updates fields in `public_user_view` for the current user. |
 | `api/purchase-credits` | Starts a Stripe Checkout session to buy extra AI credits. |
-| `api/buy-ia-credits` | Alias for `api/purchase-credits`. |
-| `api/stripe/webhook` | Deno function that updates subscription metadata after Stripe events. |
+| `api/stripe/webhook` | Node handler that updates subscription metadata after Stripe events. |
+| `api/test-env` | Development endpoint to check environment variables. |
+
+`api/buy-ia-credits` has been consolidated into `api/purchase-credits` and remains only as a backward-compatible alias.


### PR DESCRIPTION
## Summary
- document `getSignedImageUrl` and `get-ia-credits`
- drop deprecated routes and note consolidation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6861a6b9dba0832d8d50e5b410ebdda7