### PR TITLE
Update API docs with current routes

### DIFF
--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -9,6 +9,9 @@ All API routes are under `api/` and are deployed as serverless functions.
 | `api/generate-description` | Generates a short recipe description with OpenAI. |
 | `api/format-instructions` | Formats raw cooking instructions into clear steps using OpenAI. Requires authentication. |
 | `api/generate-image` | Generates a DALL·E image, uploads it to Supabase and returns the file path. |
+| `api/getSignedImageUrl` | Returns a signed Supabase Storage URL for a given image path. |
 | `api/update-profile` | Updates fields in `public_user_view` for the current user. |
-| `api/credits` | `GET` returns remaining AI usage and credits. `POST` starts a Stripe Checkout session to buy credit packs. |
+| `api/credits` | `GET` returns remaining AI usage and credits. `POST` starts a Stripe Checkout session to buy credit packs. Consolidates the former `get-ia-credits` and `purchase-credits` endpoints. |
 | `api/stripe/webhook` | Deno function that updates subscription metadata after Stripe events. |
+
+`api/buy-ia-credits` is kept as an alias to `api/credits` for backward compatibility.


### PR DESCRIPTION
## Summary
- add missing `getSignedImageUrl` route
- note consolidation of credit endpoints into `api/credits`

## Testing
- `npm run lint` *(fails: 578 errors)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6861aad21880832d9d06d670f52f5ff0