### PR TITLE
Add generate recipe API

### DIFF
--- a/api/generate-recipe.ts
+++ b/api/generate-recipe.ts
@@ -1,0 +1,63 @@
+import { VercelRequest, VercelResponse } from '@vercel/node';
+import { createClient } from '@supabase/supabase-js';
+import OpenAI from 'openai';
+import { getUserFromRequest } from '../src/utils/auth.js';
+
+const supabaseUrl = process.env.VITE_SUPABASE_URL;
+if (!supabaseUrl) throw new Error('VITE_SUPABASE_URL is not defined');
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!serviceRoleKey) throw new Error('SUPABASE_SERVICE_ROLE_KEY is not defined');
+
+const supabaseAdmin = createClient(supabaseUrl, serviceRoleKey);
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const user = await getUserFromRequest(req);
+  if (!user) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
+  const { data: profile, error: profileError } = await supabaseAdmin
+    .from('public_user_view')
+    .select('subscription_tier')
+    .eq('id', user.id)
+    .maybeSingle();
+  if (profileError) {
+    console.error('Subscription fetch error:', profileError.message);
+  }
+  const subscriptionTier = profile?.subscription_tier || 'standard';
+  if (subscriptionTier !== 'premium') {
+    return res.status(403).json({ error: 'Premium only' });
+  }
+
+  const { prompt } = req.body || {};
+  if (!prompt || typeof prompt !== 'string') {
+    return res.status(400).json({ error: 'Missing prompt' });
+  }
+
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    return res.status(500).json({ error: 'Missing OpenAI API key' });
+  }
+  const openai = new OpenAI({ apiKey });
+
+  try {
+    const result = await openai.chat.completions.create({
+      model: 'gpt-3.5-turbo',
+      messages: [{ role: 'user', content: prompt }],
+    });
+
+    await supabaseAdmin.rpc('decrement_ia_credit', {
+      user_uuid: user.id,
+      credit_type: 'text',
+    });
+
+    return res.status(200).json(result);
+  } catch (err) {
+    console.error('generate-recipe error:', err);
+    return res.status(500).json({ error: 'Internal Server Error' });
+  }
+}

--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -6,6 +6,7 @@ All API routes are under `api/` and are deployed as serverless functions.
 |-------|-------------|
 | `api/access-key` | Validates invitation keys and marks them as used. |
 | `api/ai` | Unified AI endpoint. Supports `action` values `cost`, `description`, `format`, and `image`. |
+| `api/generate-recipe` | Generates a recipe from a prompt (Premium only). |
 | `api/update-profile` | Updates fields in `public_user_view` for the current user. |
 | `api/credits` | `GET` returns remaining AI usage and credits. |
 | `api/purchase-credits` | Starts a Stripe Checkout session to buy credit packs. |


### PR DESCRIPTION
## Summary
- create `api/generate-recipe.ts` serverless endpoint
- document the new API route

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6861ad741004832db92a359ce73c333f