### PR TITLE
Update API docs

### DIFF
--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -7,7 +7,8 @@ All API routes are under `api/` and are deployed as serverless functions.
 | `api/access-key` | Validates invitation keys and marks them as used. |
 | `api/ai` | Unified AI endpoint. Supports `action` values `cost`, `description`, `format`, and `image`. |
 | `api/generate-recipe` | Generates a recipe from a prompt (Premium only). |
+| `api/getSignedImageUrl` | Returns a temporary signed URL for images stored in Supabase. |
 | `api/update-profile` | Updates fields in `public_user_view` for the current user. |
-| `api/credits` | `GET` returns remaining AI usage and credits. |
-| `api/purchase-credits` | Starts a Stripe Checkout session to buy credit packs. |
+| `api/credits` | `GET` returns remaining AI usage and credits, `POST` starts a Stripe Checkout session. This consolidates the old `get-ia-credits` and `purchase-credits` endpoints. |
+| `api/purchase-credits` | Alias for `api/credits` kept for backward compatibility. |
 | `api/stripe/webhook` | Deno function that updates subscription metadata after Stripe events. |


### PR DESCRIPTION
## Summary
- document `getSignedImageUrl` and consolidated `credits` endpoint
- note alias for `purchase-credits`

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6861b0422300832dbc23c6ad158d23e8