### PR TITLE
Fix instruction display after AI formatting

### DIFF
--- a/src/components/RecipeForm.jsx
+++ b/src/components/RecipeForm.jsx
@@ -336,7 +336,10 @@ function RecipeForm({
     try {
       const improved = await formatInstructionsWithAI(text, session);
       if (Array.isArray(improved)) {
-        setFormData((prev) => ({ ...prev, instructions: improved }));
+        const cleaned = improved.map((item) =>
+          item && item.text ? item.text : String(item)
+        );
+        setFormData((prev) => ({ ...prev, instructions: cleaned }));
         if (subscriptionTier === 'vip') {
           setIaUsage((prev) => ({
             ...prev,

--- a/src/components/RecipeFormFields.jsx
+++ b/src/components/RecipeFormFields.jsx
@@ -165,7 +165,9 @@ const RecipeFormFields = ({
         <Textarea
           id="instructions"
           name="instructions"
-          value={formData.instructions.join('\n')}
+          value={formData.instructions
+            .map((item) => (item.text ? item.text : String(item)))
+            .join('\n')}
           onChange={handleInstructionsChange}
           required
           className="min-h-[120px]"

--- a/src/components/form/RecipeInstructionsManager.jsx
+++ b/src/components/form/RecipeInstructionsManager.jsx
@@ -12,7 +12,9 @@ export default function RecipeInstructionsManager({
   iaUsage,
 }) {
   const rawText = Array.isArray(instructions)
-    ? instructions.join('\n')
+    ? instructions
+        .map((item) => (item.text ? item.text : String(item)))
+        .join('\n')
     : instructions || '';
   const disabled =
     isImproving ||


### PR DESCRIPTION
## Summary
- sanitize AI response for recipe instructions before saving
- display instructions correctly in form fields

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6861b124cbd8832db998d132c7177de3