### PR TITLE
Align credit purchase query params

### DIFF
--- a/api/credits.ts
+++ b/api/credits.ts
@@ -72,8 +72,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     }
 
     const stripe = new Stripe(stripeSecret, { apiVersion: '2022-11-15' });
-    const successUrl = `${req.headers.origin}/paiement?success=true`;
-    const cancelUrl = `${req.headers.origin}/paiement?cancelled=true`;
+    const successUrl = `${req.headers.origin}/paiement?credits_success=true`;
+    const cancelUrl = `${req.headers.origin}/paiement?credits_canceled=true`;
 
     try {
       const session = await stripe.checkout.sessions.create({


### PR DESCRIPTION
## Summary
- update credit purchase API to emit `credits_success` and `credits_canceled` params
- ensure frontend checks for the same params when returning from Stripe

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6861b2338cf8832dbff6bdcea185563a