### PR TITLE
Add credit purchase logging

### DIFF
--- a/api/stripe/webhook.ts
+++ b/api/stripe/webhook.ts
@@ -71,7 +71,7 @@ export default async function handler(req: Request): Promise<Response> {
             const column =
               session.metadata.credits_type === 'text' ? 'text_credits' : 'image_credits';
             const increment = session.metadata.credits_type === 'text' ? 150 : 50;
-            const { data: row, error: fetchErr } = await supabase
+          const { data: row, error: fetchErr } = await supabase
               .from('ia_credits')
               .select(column)
               .eq('user_id', id)
@@ -93,6 +93,18 @@ export default async function handler(req: Request): Promise<Response> {
             );
             if (upsertErr) {
               console.error('ia_credits upsert error:', upsertErr.message);
+            }
+
+            const { error: insertErr } = await supabase
+              .from('ia_credit_purchases')
+              .insert({
+                user_id: id,
+                stripe_session_id: session.id,
+                credit_type: session.metadata.credits_type,
+                amount: increment,
+              });
+            if (insertErr) {
+              console.error('ia_credit_purchases insert error:', insertErr.message);
             }
           }
         }

--- a/docs/data-model.sql
+++ b/docs/data-model.sql
@@ -76,3 +76,12 @@ create table ia_credits (
   updated_at timestamptz default now(),
   primary key (user_id)
 );
+
+create table ia_credit_purchases (
+  id uuid primary key default uuid_generate_v4(),
+  user_id uuid references auth.users(id) on delete cascade,
+  stripe_session_id text not null,
+  credit_type text not null,
+  amount integer not null,
+  purchased_at timestamptz default now()
+);

--- a/docs/features.md
+++ b/docs/features.md
@@ -18,6 +18,7 @@
 - OpenAI integration for recipe generation, description writing, cost estimation and image generation.
 - Usage of these features is limited via the `ia_usage` table based on subscription tier.
 - Additional paid credits are tracked in the `ia_credits` table.
+- Credit purchases are logged in the `ia_credit_purchases` table for auditing.
 
 ## Social
 - Friend requests stored in `user_relationships` allow sharing recipes among friends.

--- a/docs/rls-policies.md
+++ b/docs/rls-policies.md
@@ -55,3 +55,6 @@ create policy "allow owner" on weekly_menu_preferences
 
 ## ia_credits
 - Users can read and modify their own credit balance only.
+
+## ia_credit_purchases
+- Users may read their own purchase history.

--- a/supabase/migrations/0004_create_ia_credit_purchases.sql
+++ b/supabase/migrations/0004_create_ia_credit_purchases.sql
@@ -1,0 +1,13 @@
+CREATE TABLE ia_credit_purchases (
+  id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+  user_id uuid REFERENCES auth.users(id) ON DELETE CASCADE,
+  stripe_session_id text NOT NULL,
+  credit_type text NOT NULL,
+  amount integer NOT NULL,
+  purchased_at timestamptz DEFAULT now()
+);
+
+-- Basic RLS: users can read their own purchases
+alter table ia_credit_purchases enable row level security;
+create policy "allow read own" on ia_credit_purchases
+  for select using (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- log stripe credit purchases for auditing
- document new table in data model, features and RLS docs
- create migration for `ia_credit_purchases`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6861b2507d4c832d81989929a896e377