### PR TITLE
Add credit purchase logging

### DIFF
--- a/api/stripe/webhook.ts
+++ b/api/stripe/webhook.ts
@@ -105,6 +105,18 @@ export default async function handler(req: Request): Promise<Response> {
             if (upsertErr) {
               console.error('ia_credits upsert error:', upsertErr.message);
             }
+
+            const { error: purchaseErr } = await supabase
+              .from('ia_credit_purchases')
+              .insert({
+                user_id: id,
+                stripe_session_id: session.id,
+                credits_type: session.metadata?.credits_type,
+                credits_amount: increment,
+              });
+            if (purchaseErr) {
+              console.error('ia_credit_purchases insert error:', purchaseErr.message);
+            }
           }
         }
         break;

--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -11,6 +11,6 @@ All API routes are under `api/` and are deployed as serverless functions.
 | `api/update-profile` | Updates fields in `public_user_view` for the current user. |
 | `api/credits` | `GET` returns remaining AI usage and credits, `POST` starts a Stripe Checkout session. This consolidates the old `get-ia-credits` and `purchase-credits` endpoints. |
 | `api/purchase-credits` | Alias for `api/credits` kept for backward compatibility. |
-| `api/stripe/webhook` | Deno function that updates subscription metadata after Stripe events. |
+| `api/stripe/webhook` | Deno function that updates subscription metadata after Stripe events and records credit purchases. |
 
-Credit pack quantities are stored as a `credit_amount` metadata field on each Stripe Price. The webhook reads this value to know how many credits to add when a purchase is completed.
+Credit pack quantities are stored as a `credit_amount` metadata field on each Stripe Price. The webhook reads this value to know how many credits to add when a purchase is completed. Each successful purchase is also stored in the `ia_credit_purchases` table.

--- a/docs/data-model.sql
+++ b/docs/data-model.sql
@@ -76,3 +76,12 @@ create table ia_credits (
   updated_at timestamptz default now(),
   primary key (user_id)
 );
+
+create table ia_credit_purchases (
+  id uuid primary key default uuid_generate_v4(),
+  user_id uuid references auth.users(id) on delete cascade,
+  stripe_session_id text unique not null,
+  credits_type text not null,
+  credits_amount integer not null,
+  created_at timestamptz default now()
+);

--- a/docs/features.md
+++ b/docs/features.md
@@ -18,6 +18,7 @@
 - OpenAI integration for recipe generation, description writing, cost estimation and image generation.
 - Usage of these features is limited via the `ia_usage` table based on subscription tier.
 - Additional paid credits are tracked in the `ia_credits` table.
+- Completed purchases are logged in the `ia_credit_purchases` table.
 
 ## Social
 - Friend requests stored in `user_relationships` allow sharing recipes among friends.

--- a/docs/rls-policies.md
+++ b/docs/rls-policies.md
@@ -55,3 +55,7 @@ create policy "allow owner" on weekly_menu_preferences
 
 ## ia_credits
 - Users can read and modify their own credit balance only.
+
+## ia_credit_purchases
+- Rows inserted by server after successful payments.
+- Users may read their own purchase history.

--- a/supabase/migrations/0004_ia_credit_purchases.sql
+++ b/supabase/migrations/0004_ia_credit_purchases.sql
@@ -1,0 +1,8 @@
+create table ia_credit_purchases (
+  id uuid primary key default uuid_generate_v4(),
+  user_id uuid references auth.users(id) on delete cascade,
+  stripe_session_id text unique not null,
+  credits_type text not null,
+  credits_amount integer not null,
+  created_at timestamptz default now()
+);


### PR DESCRIPTION
## Summary
- add `ia_credit_purchases` table migration
- log credit purchases from Stripe webhook
- document new table in data model and policies
- update features and API overview docs

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6861b54186cc832d95382bf92ac5557c