### PR TITLE
Fix purchase credits import path

### DIFF
--- a/api/purchase-credits.ts
+++ b/api/purchase-credits.ts
@@ -1,1 +1,3 @@
-export { default } from './credits';
+// Keep this endpoint for backward compatibility with older clients.
+// It simply re-exports the unified credits handler.
+export { default } from './credits.js';


### PR DESCRIPTION
## Summary
- correct incorrect import path in `api/purchase-credits.ts`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68627354d8c8832d8b3d15952d1da3e5