### PR TITLE
Fix Stripe credits pipeline

### DIFF
--- a/api/credits.ts
+++ b/api/credits.ts
@@ -72,6 +72,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     }
 
     const creditType: 'text' | 'image' = creditsType === 'text' ? 'text' : 'image';
+    const creditQuantity = creditType === 'text' ? 150 : 50;
 
     const stripe = new Stripe(stripeSecret, { apiVersion: '2022-11-15' });
     const successUrl = `${req.headers.origin}/paiement?credits_success=true`;
@@ -84,7 +85,10 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         success_url: successUrl,
         cancel_url: cancelUrl,
         client_reference_id: user.id,
-        metadata: { credits_type: creditType },
+        metadata: {
+          credits_type: creditType,
+          credits_quantity: creditQuantity,
+        },
       });
       return res.status(200).json({ url: session.url });
     } catch (err) {

--- a/api/purchase-credits.ts
+++ b/api/purchase-credits.ts
@@ -1,3 +1,3 @@
 // Keep this endpoint for backward compatibility with older clients.
 // It simply re-exports the unified credits handler.
-export { default } from './credits.js';
+export { default } from './credits';

--- a/api/stripe/webhook.ts
+++ b/api/stripe/webhook.ts
@@ -85,18 +85,7 @@ export default async function handler(req: Request): Promise<Response> {
           } else if (session.mode === 'payment' && session.metadata?.credits_type) {
             const column =
               session.metadata.credits_type === 'text' ? 'text_credits' : 'image_credits';
-            let increment = 0;
-            try {
-              const detailedSession = await stripe.checkout.sessions.retrieve(session.id, {
-                expand: ['line_items.data.price.product'],
-              });
-              const lineItem = (detailedSession as any).line_items?.data?.[0];
-              const meta = lineItem?.price?.metadata || lineItem?.price?.product?.metadata;
-              const amount = parseInt(meta?.credit_amount ?? '0', 10);
-              if (!Number.isNaN(amount)) increment = amount;
-            } catch (err) {
-              console.error('Failed to load credit metadata:', err);
-            }
+            const increment = Number(session.metadata.credits_quantity) || 0;
             const { data: row, error: fetchErr } = await supabase
               .from('ia_credits')
               .select(column)

--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -10,7 +10,6 @@ All API routes are under `api/` and are deployed as serverless functions.
 | `api/getSignedImageUrl` | Returns a temporary signed URL for images stored in Supabase. |
 | `api/update-profile` | Updates fields in `public_user_view` for the current user. |
 | `api/credits` | `GET` returns remaining AI usage and credits, `POST` starts a Stripe Checkout session. This consolidates the old `get-ia-credits` and `purchase-credits` endpoints. |
-| `api/purchase-credits` | Alias for `api/credits` kept for backward compatibility. |
 | `api/stripe/webhook` | Deno function that updates subscription metadata after Stripe events and records credit purchases. |
 
-Credit pack quantities are stored as a `credit_amount` metadata field on each Stripe Price. The webhook reads this value to know how many credits to add when a purchase is completed. Each successful purchase is also stored in the `ia_credit_purchases` table. Processed event IDs are saved in the `stripe_events` table to avoid duplicate handling.
+Credit pack quantities are provided via the `credits_quantity` metadata sent when creating the Checkout session. The webhook uses this value to know how many credits to add when a purchase is completed. Each successful purchase is stored in the `ia_credit_purchases` table and processed event IDs are saved in the `stripe_events` table to avoid duplicate handling.

--- a/src/pages/PaymentResult.jsx
+++ b/src/pages/PaymentResult.jsx
@@ -4,13 +4,13 @@ import { CheckCircle, XCircle } from 'lucide-react';
 
 export default function PaymentResultPage() {
   const [params] = useSearchParams();
-  const success = params.get('success');
-  const cancelled = params.get('cancelled');
+  const success = params.get('credits_success');
+  const cancelled = params.get('credits_canceled');
 
   useEffect(() => {
     const newUrl = new URL(window.location.href);
-    newUrl.searchParams.delete('success');
-    newUrl.searchParams.delete('cancelled');
+    newUrl.searchParams.delete('credits_success');
+    newUrl.searchParams.delete('credits_canceled');
     window.history.replaceState({}, '', newUrl.toString());
   }, []);
 


### PR DESCRIPTION
## Summary
- fix alias route for credits purchase
- send quantity metadata on purchase
- rely on quantity metadata in Stripe webhook
- update payment result parameter names
- refresh Stripe documentation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686276c68be4832d88e7ff8026ec9d04