### PR TITLE
Fix weekly menu loading with missing data

### DIFF
--- a/src/hooks/useWeeklyMenu.js
+++ b/src/hooks/useWeeklyMenu.js
@@ -85,16 +85,17 @@ export function useWeeklyMenu(session, currentMenuId = null) {
       data.menu_data.length === 7
     ) {
       setWeeklyMenu(data.menu_data);
-      if (data.name) setMenuName(data.name);
-      if (data.id) setMenuId(data.id);
-      if (typeof data.is_shared === 'boolean') setIsShared(data.is_shared);
+      if ('name' in data) setMenuName(data.name);
+      if ('id' in data) setMenuId(data.id);
+      if ('is_shared' in data)
+        setIsShared(typeof data.is_shared === 'boolean' ? data.is_shared : !!data.is_shared);
     } else {
       setWeeklyMenu(initialWeeklyMenuState());
       if (data && typeof data === 'object') {
-        if (data.name) setMenuName(data.name);
-        if (data.id) setMenuId(data.id);
-        if (typeof data.is_shared === 'boolean') {
-          setIsShared(data.is_shared);
+        if ('name' in data) setMenuName(data.name);
+        if ('id' in data) setMenuId(data.id);
+        if ('is_shared' in data) {
+          setIsShared(typeof data.is_shared === 'boolean' ? data.is_shared : !!data.is_shared);
         } else {
           setIsShared(false);
         }

--- a/tests/weeklyMenuLoad.spec.jsx
+++ b/tests/weeklyMenuLoad.spec.jsx
@@ -88,6 +88,13 @@ beforeEach(() => {
   global.__supabaseState.preferences = {
     menu1: { menu_id: 'menu1', ...toDbPrefs(DEFAULT_MENU_PREFS) },
   };
+  global.__supabaseState.menus.menu1 = {
+    id: 'menu1',
+    user_id: 'user1',
+    name: 'Shared Menu',
+    menu_data: [],
+    is_shared: true,
+  };
 });
 
 describe('useWeeklyMenu loading', () => {
@@ -101,6 +108,19 @@ describe('useWeeklyMenu loading', () => {
 
     expect(result.current.weeklyMenu).toEqual(initialWeeklyMenuState());
     expect(result.current.menuName).toBe('Shared Menu');
+    expect(result.current.isShared).toBe(true);
+  });
+
+  it('retains shared status when menu_data is missing', async () => {
+    const session = { user: { id: 'user1' } };
+    delete global.__supabaseState.menus.menu1.menu_data;
+    const { result } = renderHook(() => useWeeklyMenu(session, 'menu1'));
+
+    await waitFor(() => {
+      expect(result.current.menuName).toBe('Shared Menu');
+    });
+
+    expect(result.current.weeklyMenu).toEqual(initialWeeklyMenuState());
     expect(result.current.isShared).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- copy `is_shared`, `name`, and `id` fields when `menu_data` is missing
- reset mocked menu before each test and cover missing `menu_data`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6862882ce0f8832da44aada54c112c87