### PR TITLE
Enforce shared menus for participants

### DIFF
--- a/docs/data-model.sql
+++ b/docs/data-model.sql
@@ -34,6 +34,25 @@ create table menu_participants (
   primary key (menu_id, user_id)
 );
 
+-- Prevent adding participants to menus that are not shared
+create function ensure_menu_shared()
+returns trigger
+language plpgsql
+as $$
+begin
+  if not exists (
+    select 1 from weekly_menus wm where wm.id = new.menu_id and wm.is_shared
+  ) then
+    raise exception 'menu % is not shared', new.menu_id;
+  end if;
+  return new;
+end;
+$$;
+
+create trigger check_menu_is_shared
+before insert on menu_participants
+for each row execute function ensure_menu_shared();
+
 create table weekly_menu_preferences (
   menu_id uuid primary key references weekly_menus(id) on delete cascade,
   portions_per_meal integer default 4,

--- a/supabase/migrations/0006_menu_participants_shared_check.sql
+++ b/supabase/migrations/0006_menu_participants_shared_check.sql
@@ -1,0 +1,17 @@
+create function ensure_menu_shared()
+returns trigger
+language plpgsql
+as $$
+begin
+  if not exists (
+    select 1 from weekly_menus wm where wm.id = new.menu_id and wm.is_shared
+  ) then
+    raise exception 'menu % is not shared', new.menu_id;
+  end if;
+  return new;
+end;
+$$;
+
+create trigger check_menu_is_shared
+before insert on menu_participants
+for each row execute function ensure_menu_shared();


### PR DESCRIPTION
## Summary
- add a trigger function and trigger so `menu_participants` can only refer to shared menus
- document the new trigger in `docs/data-model.sql`

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6862d378b710832db9528c34c10c5bab