### PR TITLE
Filter unshared participant menus

### DIFF
--- a/src/hooks/useMenus.js
+++ b/src/hooks/useMenus.js
@@ -32,6 +32,7 @@ export async function fetchMenusForUser(userId) {
     const { data, error } = await supabase
       .from('weekly_menus')
       .select('id, user_id, name, updated_at, is_shared')
+      .eq('is_shared', true)
       .in('id', participantIds);
     if (error) throw error;
     participantMenus = data || [];


### PR DESCRIPTION
## Summary
- only fetch participant menus that are shared
- extend friend menu visibility test to exclude unshared menus

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6862d3738824832db2f72348b9f163f7