### PR TITLE
Add Stripe credits webhook

### DIFF
--- a/api/webhooks/stripe.ts
+++ b/api/webhooks/stripe.ts
@@ -1,0 +1,94 @@
+import { VercelRequest, VercelResponse } from '@vercel/node';
+import { buffer } from 'micro';
+import Stripe from 'stripe';
+import { createClient } from '@supabase/supabase-js';
+
+export const config = { api: { bodyParser: false } };
+
+let stripeSecret = process.env.STRIPE_SECRET_KEY as string | undefined;
+if (!stripeSecret && process.env.NODE_ENV !== 'production') {
+  stripeSecret = process.env.VITE_STRIPE_SECRET_KEY;
+}
+
+const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET ?? '';
+const supabaseUrl = process.env.SUPABASE_URL ?? process.env.VITE_SUPABASE_URL;
+if (!supabaseUrl) throw new Error('SUPABASE_URL is not defined');
+const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!supabaseServiceKey) {
+  throw new Error('SUPABASE_SERVICE_ROLE_KEY is not defined');
+}
+
+const stripe = new Stripe(stripeSecret ?? '', { apiVersion: '2022-11-15' });
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).send('Method not allowed');
+  }
+
+  const sig = req.headers['stripe-signature'] as string | undefined;
+  let event: Stripe.Event;
+  try {
+    const buf = await buffer(req);
+    event = stripe.webhooks.constructEvent(buf, sig ?? '', webhookSecret);
+  } catch (err) {
+    console.error('Invalid Stripe signature', err);
+    return res.status(400).send('Invalid signature');
+  }
+
+  const supabase = createClient(supabaseUrl!, supabaseServiceKey!);
+
+  try {
+    if (event.type === 'checkout.session.completed') {
+      const session: any = event.data.object;
+      const userId: string | undefined = session.metadata?.user_id;
+      const productId: string | undefined = session.metadata?.product_id;
+      if (!userId || !productId) {
+        console.error('Missing metadata', session.metadata);
+        return res.status(400).send('Missing metadata');
+      }
+
+      const { data: existingEvent } = await supabase
+        .from('stripe_events')
+        .select('event_id')
+        .eq('event_id', event.id)
+        .maybeSingle();
+      if (existingEvent) {
+        console.log('Stripe event already handled:', event.id);
+        return res.status(200).send('OK');
+      }
+
+      const price = await stripe.prices.retrieve(productId);
+      const creditAmount = Number(price.metadata?.credit_amount || 0);
+      const creditType = price.metadata?.credits_type === 'image' ? 'image' : 'text';
+      const column = creditType === 'text' ? 'text_credits' : 'image_credits';
+
+      const { data: row } = await supabase
+        .from('ia_credits')
+        .select(column)
+        .eq('user_id', userId)
+        .maybeSingle<{ text_credits?: number; image_credits?: number }>();
+      const current = (row as Record<typeof column, number> | null)?.[column] ?? 0;
+
+      await supabase.from('ia_credits').upsert(
+        { user_id: userId, [column]: current + creditAmount, updated_at: new Date().toISOString() },
+        { onConflict: 'user_id' }
+      );
+
+      await supabase.from('ia_credit_purchases').insert({
+        user_id: userId,
+        stripe_session_id: session.id,
+        credits_type: creditType,
+        credits_amount: creditAmount,
+      });
+
+      await supabase.from('stripe_events').insert({ event_id: event.id });
+    } else {
+      console.log(`Unhandled event type: ${event.type}`);
+    }
+  } catch (err) {
+    console.error('Webhook processing error:', err);
+    return res.status(500).send('Internal server error');
+  }
+
+  return res.status(200).send('OK');
+}

--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -10,6 +10,6 @@ All API routes are under `api/` and are deployed as serverless functions.
 | `api/getSignedImageUrl` | Returns a temporary signed URL for images stored in Supabase. |
 | `api/update-profile` | Updates fields in `public_user_view` for the current user. |
 | `api/credits` | `GET` returns remaining AI usage and credits, `POST` starts a Stripe Checkout session. This consolidates the old `get-ia-credits` and `purchase-credits` endpoints. |
-| `api/stripe/webhook` | Deno function that updates subscription metadata after Stripe events and records credit purchases. |
+| `api/webhooks/stripe` | Node function that validates Stripe signatures, updates `ia_credits`, and logs purchases. |
 
-Credit pack quantities are provided via the `credits_quantity` metadata sent when creating the Checkout session. The webhook uses this value to know how many credits to add when a purchase is completed. Each successful purchase is stored in the `ia_credit_purchases` table and processed event IDs are saved in the `stripe_events` table to avoid duplicate handling.
+Credit pack purchases include `user_id` and `product_id` in the session metadata. The webhook fetches the Price metadata to determine the `credit_amount` and `credits_type` values, then upserts the proper column in `ia_credits`. Each successful purchase is stored in the `ia_credit_purchases` table and processed event IDs are saved in the `stripe_events` table to avoid duplicate handling.


### PR DESCRIPTION
## Summary
- implement `api/webhooks/stripe` for handling credit purchases
- document the new webhook route

## Testing
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6863951045d4832da46ad465f85ae2ce