### PR TITLE
Add product id metadata for credit purchases

### DIFF
--- a/api/credits.ts
+++ b/api/credits.ts
@@ -87,6 +87,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         client_reference_id: user.id,
         metadata: {
           user_id: user.id,
+          product_id: productId,
           credits_type: creditType,
           credits_quantity: creditQuantity,
         },


### PR DESCRIPTION
## Summary
- store product ID in Stripe Checkout session metadata so the webhook can process credit quantity reliably
- ensure purchase calls include `productId`

## Testing
- `npm test` *(fails to exit watch mode; tests ran and then process cancelled)*
- `npm run lint` *(fails: 'global' is not defined, etc.)

------
https://chatgpt.com/codex/tasks/task_e_68639b844e7c832db806c7bf6521fd2f