### PR TITLE
Explain Stripe webhook

### DIFF
--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -12,4 +12,12 @@ All API routes are under `api/` and are deployed as serverless functions.
 | `api/credits` | `GET` returns remaining AI usage and credits, `POST` starts a Stripe Checkout session. This consolidates the old `get-ia-credits` and `purchase-credits` endpoints. |
 | `api/webhooks/stripe` | Node function that validates Stripe signatures, updates `ia_credits`, and logs purchases. |
 
-Credit pack purchases include `user_id` and `product_id` in the session metadata. The webhook fetches the Price metadata to determine the `credit_amount` and `credits_type` values, then upserts the proper column in `ia_credits`. Each successful purchase is stored in the `ia_credit_purchases` table and processed event IDs are saved in the `stripe_events` table to avoid duplicate handling.
+## Stripe webhook
+
+The `/api/webhooks/stripe` endpoint handles payment events from Stripe. Credit
+pack checkout sessions **must** include `user_id` and `product_id` metadata
+fields. The webhook retrieves the associated Price record to read the
+`credit_amount` and `credits_type` metadata, then increments the corresponding
+column (`text_credits` or `image_credits`) in `ia_credits`. Each successful
+purchase is stored in the `ia_credit_purchases` table and the event ID is saved
+in `stripe_events` to avoid duplicate processing.


### PR DESCRIPTION
## Summary
- document the `/api/webhooks/stripe` endpoint in the API overview

## Testing
- `npm run test` *(fails: Tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_68639e676714832d908d40885d09b745