### PR TITLE
Fix menu shared status on creation

### DIFF
--- a/src/components/NewMenuModal.jsx
+++ b/src/components/NewMenuModal.jsx
@@ -76,7 +76,9 @@ function NewMenuModal({ onCreate, friends = [], trigger }) {
           <DialogClose asChild>
             <Button variant="outline">Annuler</Button>
           </DialogClose>
-          <Button onClick={handleCreate}>Créer</Button>
+          <Button onClick={handleCreate} disabled={isShared && selectedIds.length === 0}>
+            Créer
+          </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/src/pages/MenuPage.jsx
+++ b/src/pages/MenuPage.jsx
@@ -80,7 +80,7 @@ export default function MenuPage({
     if (!userId) return;
 
     const cleanedIds = Array.isArray(participantIds)
-      ? participantIds.filter((id) => id && id !== userId)
+      ? [...new Set(participantIds.filter((id) => id && id !== userId))]
       : [];
     const isShared = cleanedIds.length > 0;
 


### PR DESCRIPTION
## Summary
- ensure duplicate participant ids are removed when creating a menu
- disable the `Créer` button unless at least one participant is chosen for shared menus

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6863d0f6c040832d948eb87dcd4400c9