### PR TITLE
Fix menu shared flag insertion

### DIFF
--- a/src/components/NewMenuModal.jsx
+++ b/src/components/NewMenuModal.jsx
@@ -26,7 +26,7 @@ function NewMenuModal({ onCreate, friends = [], trigger }) {
 
   const handleCreate = () => {
     const participantIds = isShared ? selectedIds : [];
-    onCreate({ name, participantIds });
+    onCreate({ name, participantIds, isShared });
     setName('');
     setIsShared(false);
     setSelectedIds([]);

--- a/src/pages/MenuPage.jsx
+++ b/src/pages/MenuPage.jsx
@@ -75,14 +75,14 @@ export default function MenuPage({
     }
   };
 
-  const handleCreate = async ({ name, participantIds = [] } = {}) => {
+  const handleCreate = async ({ name, participantIds = [], isShared: sharedFlag } = {}) => {
     const userId = session?.user?.id;
     if (!userId) return;
 
     const cleanedIds = Array.isArray(participantIds)
       ? [...new Set(participantIds.filter((id) => id && id !== userId))]
       : [];
-    const isShared = cleanedIds.length > 0;
+    const isShared = sharedFlag || cleanedIds.length > 0;
 
     const insertData = {
       user_id: userId,


### PR DESCRIPTION
## Summary
- ensure new menu modal passes `isShared` flag
- handle menu creation with explicit `isShared` flag

## Testing
- `npm test` *(fails: stripe-webhook.spec.ts & friendMenuVisibility.test.jsx)*
- `npm run lint` *(fails: numerous 'no-undef' errors)*

------
https://chatgpt.com/codex/tasks/task_e_6864c6cad58c832d928fa065e9d53b4e