### PR TITLE
Fix shared flag usage when creating menu

### DIFF
--- a/src/pages/MenuPage.jsx
+++ b/src/pages/MenuPage.jsx
@@ -82,7 +82,7 @@ export default function MenuPage({
     const cleanedIds = Array.isArray(participantIds)
       ? [...new Set(participantIds.filter((id) => id && id !== userId))]
       : [];
-    const isShared = sharedFlag || cleanedIds.length > 0;
+    const isShared = sharedFlag;
 
     const insertData = {
       user_id: userId,


### PR DESCRIPTION
## Summary
- respect `is_shared` flag from `NewMenuModal` instead of recalculating it

## Testing
- `npm run lint` *(fails: 582 errors)*
- `npx vitest run` *(fails: 2 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_6864cd94a698832da5030fef6aa23444