### PR TITLE
Add debug log for menu insertion

### DIFF
--- a/src/pages/MenuPage.jsx
+++ b/src/pages/MenuPage.jsx
@@ -91,6 +91,8 @@ export default function MenuPage({
       menu_data: initialWeeklyMenuState(),
     };
 
+    console.log('Insert menu:', insertData);
+
     const { data, error } = await supabase
       .from('weekly_menus')
       .insert(insertData)


### PR DESCRIPTION
## Summary
- add console.log in `handleCreate` to inspect menu insertion data

## Testing
- `npm run test` *(fails: stripe webhook handler test)*

------
https://chatgpt.com/codex/tasks/task_e_6864d3fd200c832dbadc54ec0747686b