### PR TITLE
Add API route for creating shared menus

### DIFF
--- a/api/create-shared-menu.ts
+++ b/api/create-shared-menu.ts
@@ -1,0 +1,73 @@
+import { VercelRequest, VercelResponse } from '@vercel/node';
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.VITE_SUPABASE_URL;
+if (!supabaseUrl) throw new Error('VITE_SUPABASE_URL is not defined');
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!serviceRoleKey) throw new Error('SUPABASE_SERVICE_ROLE_KEY is not defined');
+
+const supabaseAdmin = createClient(supabaseUrl, serviceRoleKey);
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const { user_id, name, menu_data, participant_ids } = req.body || {};
+
+  if (!user_id || typeof user_id !== 'string') {
+    return res.status(400).json({ error: 'user_id required' });
+  }
+
+  if (!name || typeof name !== 'string') {
+    return res.status(400).json({ error: 'name required' });
+  }
+
+  try {
+    const { data: user, error: userErr } = await supabaseAdmin.auth.admin.getUserById(user_id);
+    if (userErr || !user) {
+      console.warn('create-shared-menu invalid user_id:', userErr?.message);
+      return res.status(400).json({ error: 'Invalid user_id' });
+    }
+  } catch (err) {
+    console.error('create-shared-menu user lookup error:', err);
+    return res.status(500).json({ error: 'User lookup failed' });
+  }
+
+  try {
+    const { data: inserted, error } = await supabaseAdmin
+      .from('weekly_menus')
+      .insert({
+        user_id,
+        name,
+        menu_data: menu_data || {},
+        is_shared: true,
+      })
+      .select('id')
+      .single();
+
+    if (error || !inserted) {
+      console.error('create-shared-menu insert error:', error?.message);
+      return res.status(500).json({ error: error?.message || 'Insert failed' });
+    }
+
+    if (Array.isArray(participant_ids) && participant_ids.length > 0) {
+      const rows = participant_ids
+        .filter((id: string) => id && id !== user_id)
+        .map((id: string) => ({ menu_id: inserted.id, user_id: id }));
+      if (rows.length > 0) {
+        const { error: partErr } = await supabaseAdmin
+          .from('menu_participants')
+          .insert(rows);
+        if (partErr) {
+          console.warn('menu_participants insert error:', partErr.message);
+        }
+      }
+    }
+
+    return res.status(200).json({ id: inserted.id });
+  } catch (err) {
+    console.error('create-shared-menu error:', err);
+    return res.status(500).json({ error: 'Internal Server Error' });
+  }
+}


### PR DESCRIPTION
## Summary
- add `/api/create-shared-menu.ts` for inserting shared menus using the service role key

## Testing
- `npm test` *(fails: stripe-webhook.spec.ts)*

------
https://chatgpt.com/codex/tasks/task_e_6864e41c38ac832db42dc2e3bdab5501