### PR TITLE
Improve menu insertion logs

### DIFF
--- a/api/create-shared-menu.ts
+++ b/api/create-shared-menu.ts
@@ -47,7 +47,10 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       .single();
 
     if (error || !inserted) {
-      console.error('create-shared-menu insert error:', error?.message);
+      console.error(
+        '🛠 Menu insert error:',
+        error || inserted
+      );
       return res.status(500).json({ error: error?.message || 'Insert failed' });
     }
 
@@ -60,14 +63,17 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           .from('menu_participants')
           .insert(rows);
         if (partErr) {
-          console.warn('menu_participants insert error:', partErr.message);
+          console.warn(
+            '🛠 menu_participants insert error:',
+            partErr.message
+          );
         }
       }
     }
 
     return res.status(200).json({ id: inserted.id });
   } catch (err) {
-    console.error('create-shared-menu error:', err);
+    console.error('🛠 create-shared-menu error:', err);
     return res.status(500).json({ error: 'Internal Server Error' });
   }
 }


### PR DESCRIPTION
## Summary
- add emoji prefix and log details when menu insertion fails

## Testing
- `npm run lint` *(fails: 'global' is not defined)*
- `npm test` *(fails: stripe webhook test fails)*

------
https://chatgpt.com/codex/tasks/task_e_686515516a80832d95a0f23399fd2c61