### PR TITLE
Remove manual preferences insertion

### DIFF
--- a/src/pages/MenuPage.jsx
+++ b/src/pages/MenuPage.jsx
@@ -5,8 +5,6 @@ import { getSupabase } from '@/lib/supabase';
 import { createSharedMenu } from '@/lib/sharedMenu.js';
 import { useFriendsList } from '@/hooks/useFriendsList.js';
 import { useMenuParticipants } from '@/hooks/useMenuParticipants.js';
-import { toDbPrefs } from '@/hooks/useWeeklyMenu.js';
-import { DEFAULT_MENU_PREFS } from '@/lib/defaultPreferences.js';
 import { initialWeeklyMenuState } from '@/lib/menu';
 import ParticipantWeights from '@/components/ParticipantWeights.jsx';
 
@@ -117,12 +115,6 @@ export default function MenuPage({
     }
 
     if (createdId) {
-      const basePrefs = { ...DEFAULT_MENU_PREFS };
-      if (!sharedFlag) basePrefs.commonMenuSettings = {};
-      const dbPrefs = toDbPrefs(basePrefs);
-      await supabase
-        .from('weekly_menu_preferences')
-        .insert({ menu_id: createdId, ...dbPrefs });
       await refreshMenus();
       setSelectedMenuId(createdId);
     }


### PR DESCRIPTION
## Summary
- remove default preferences creation from `MenuPage`
- clean up unused imports

## Testing
- `npm test` *(fails: stripe webhook handler test)*
- `npm run lint` *(fails with many React prop-type errors)*

------
https://chatgpt.com/codex/tasks/task_e_6865522c9cd4832d923b63143c176c1a