### PR TITLE
Fix preference tests for JSON fields

### DIFF
--- a/tests/preferences.integration.spec.jsx
+++ b/tests/preferences.integration.spec.jsx
@@ -130,7 +130,15 @@ describe('useWeeklyMenu.updateMenuPreferences', () => {
       await result.current.updatePreferences(newPrefs);
     });
 
-    expect(global.__supabaseState.lastUpsert).toEqual({ menu_id: 'menu1', ...toDbPrefs(newPrefs) });
+    const actual = { ...global.__supabaseState.lastUpsert };
+    const expectedDb = toDbPrefs(newPrefs);
+    ['daily_meal_structure', 'tag_preferences', 'common_menu_settings'].forEach(
+      (f) => {
+        actual[f] = JSON.parse(actual[f]);
+        expectedDb[f] = JSON.parse(expectedDb[f]);
+      }
+    );
+    expect(actual).toEqual({ menu_id: 'menu1', ...expectedDb });
   });
 
   it('merges with existing preferences for partial updates', async () => {
@@ -144,7 +152,14 @@ describe('useWeeklyMenu.updateMenuPreferences', () => {
     const expected = { ...DEFAULT_MENU_PREFS, weeklyBudget: 40 };
     const expectedDb = toDbPrefs({ ...expected, commonMenuSettings: {} });
 
-    expect(global.__supabaseState.lastUpsert).toEqual({ menu_id: 'menu1', ...expectedDb });
+    const actual = { ...global.__supabaseState.lastUpsert };
+    ['daily_meal_structure', 'tag_preferences', 'common_menu_settings'].forEach(
+      (f) => {
+        actual[f] = JSON.parse(actual[f]);
+        expectedDb[f] = JSON.parse(expectedDb[f]);
+      }
+    );
+    expect(actual).toEqual({ menu_id: 'menu1', ...expectedDb });
     expect(result.current.preferences).toEqual(expected);
   });
 });

--- a/tests/preferences.spec.ts
+++ b/tests/preferences.spec.ts
@@ -19,14 +19,12 @@ describe('preferences conversion', () => {
     };
 
     const dbShape = toDbPrefs(prefs);
-    expect(dbShape.common_menu_settings).toEqual(
-      JSON.stringify(prefs.commonMenuSettings)
+    expect(JSON.parse(dbShape.common_menu_settings)).toEqual(
+      prefs.commonMenuSettings
     );
-    expect(dbShape.daily_meal_structure).toEqual(
-      JSON.stringify([
-        ['petit-dejeuner', 'brunch'],
-      ])
-    );
+    expect(JSON.parse(dbShape.daily_meal_structure)).toEqual([
+      ['petit-dejeuner', 'brunch'],
+    ]);
 
     const restored = fromDbPrefs(dbShape);
     expect(restored).toEqual(prefs);


### PR DESCRIPTION
## Summary
- update expectations in `preferences.spec.ts` to parse JSON fields before comparison
- update integration tests to parse JSON fields when verifying upserted data

## Testing
- `npx vitest run tests/preferences.spec.ts tests/preferences.integration.spec.jsx`

------
https://chatgpt.com/codex/tasks/task_e_686578b9384c832dbeb80b9097703997