### PR TITLE
Update preferences typing

### DIFF
--- a/src/hooks/useWeeklyMenu.js
+++ b/src/hooks/useWeeklyMenu.js
@@ -4,8 +4,23 @@ import { useToast } from '@/components/ui/use-toast';
 import { initialWeeklyMenuState } from '@/lib/menu';
 import { DEFAULT_MENU_PREFS } from '@/lib/defaultPreferences.js';
 
+/** @typedef {import('@/types').WeeklyMenuPreferences} WeeklyMenuPreferences */
+/** @typedef {import('@/types').CommonMenuSettings} CommonMenuSettings */
+
 const defaultPrefs = { ...DEFAULT_MENU_PREFS };
 
+/**
+ * Convert a database row into client preferences.
+ * @param {WeeklyMenuPreferences | null | undefined} pref
+ * @returns {{
+ *   servingsPerMeal: number;
+ *   maxCalories: number | null;
+ *   weeklyBudget: number;
+ *   meals: {id:number; mealNumber:number; types:string[]; enabled:boolean;}[];
+ *   tagPreferences: string[];
+ *   commonMenuSettings: CommonMenuSettings;
+ * }}
+ */
 export function fromDbPrefs(pref) {
   if (!pref) return { ...defaultPrefs };
   const dailyMealStructure =
@@ -41,6 +56,18 @@ export function fromDbPrefs(pref) {
   };
 }
 
+/**
+ * Convert client preferences into a database row.
+ * @param {{
+ *   servingsPerMeal?: number;
+ *   maxCalories?: number | null;
+ *   weeklyBudget?: number;
+ *   meals?: {id:number; mealNumber:number; types:string[]; enabled:boolean;}[];
+ *   tagPreferences?: string[];
+ *   commonMenuSettings?: CommonMenuSettings;
+ * }} pref
+ * @returns {WeeklyMenuPreferences}
+ */
 export function toDbPrefs(pref) {
   const effective = { ...DEFAULT_MENU_PREFS, ...(pref || {}) };
   return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,8 +9,10 @@ export type WeeklyMenuPreferences = {
   portions_per_meal: number;
   daily_calories_limit: number | null;
   weekly_budget: number;
-  daily_meal_structure: string[][];
-  tag_preferences: string[];
+  /** stored as JSON string in DB, parsed as array on client */
+  daily_meal_structure: string[][] | string;
+  /** stored as JSON string in DB, parsed as array on client */
+  tag_preferences: string[] | string;
   /** Client side representation of meals */
   meals?: {
     id: number;
@@ -20,7 +22,8 @@ export type WeeklyMenuPreferences = {
   }[];
   /** Camel case tag preferences for generator */
   tagPreferences?: { tag: string; percentage: number }[] | string[];
-  common_menu_settings?: CommonMenuSettings;
+  /** stored as JSON string in DB, parsed as object on client */
+  common_menu_settings?: CommonMenuSettings | string;
 };
 
 export interface Recipe {


### PR DESCRIPTION
## Summary
- allow db preference fields to accept JSON strings
- document preference conversion helpers with typings

## Testing
- `npm run lint` *(fails: 'global' is not defined)*
- `npm test` *(fails: stripe webhook handler test)*

------
https://chatgpt.com/codex/tasks/task_e_68657808283c832d95daaee50d65db23