### PR TITLE
Fix imports for Vercel functions

### DIFF
--- a/api/create-shared-menu.ts
+++ b/api/create-shared-menu.ts
@@ -38,6 +38,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const shared = typeof is_shared === 'boolean' ? is_shared : false;
 
   try {
+    console.log('Inserting weekly menu:', {
+      user_id,
+      name,
+      menu_data,
+      is_shared: shared,
+    });
     const { data: inserted, error } = await supabaseAdmin
       .from('weekly_menus')
       .insert({

--- a/src/hooks/useWeeklyMenu.js
+++ b/src/hooks/useWeeklyMenu.js
@@ -1,11 +1,11 @@
 import { useState, useEffect, useCallback } from 'react';
-import { getSupabase } from '@/lib/supabase';
-import { useToast } from '@/components/ui/use-toast';
-import { initialWeeklyMenuState } from '@/lib/menu';
-import { DEFAULT_MENU_PREFS } from '@/lib/defaultPreferences.js';
+import { getSupabase } from '../lib/supabase.js';
+import { useToast } from '../components/ui/use-toast.js';
+import { initialWeeklyMenuState } from '../lib/menu.js';
+import { DEFAULT_MENU_PREFS } from '../lib/defaultPreferences.js';
 
-/** @typedef {import('@/types').WeeklyMenuPreferences} WeeklyMenuPreferences */
-/** @typedef {import('@/types').CommonMenuSettings} CommonMenuSettings */
+/** @typedef {import('../types').WeeklyMenuPreferences} WeeklyMenuPreferences */
+/** @typedef {import('../types').CommonMenuSettings} CommonMenuSettings */
 
 const defaultPrefs = { ...DEFAULT_MENU_PREFS };
 


### PR DESCRIPTION
## Summary
- ensure Node can import hooks without path aliases
- log data before inserting menu in API

## Testing
- `npm run test` *(fails: Tests failed. Watching for file changes...)*

------
https://chatgpt.com/codex/tasks/task_e_68664d4a70d4832d8349685313721b2e