### PR TITLE
Refactor menu pref helpers

### DIFF
--- a/api/create-shared-menu.ts
+++ b/api/create-shared-menu.ts
@@ -1,6 +1,6 @@
 import { VercelRequest, VercelResponse } from '@vercel/node';
 import { createClient } from '@supabase/supabase-js';
-import { toDbPrefs } from '../src/hooks/useWeeklyMenu.js';
+import { toDbPrefs } from '../src/lib/menuPreferences.js';
 
 const supabaseUrl = process.env.VITE_SUPABASE_URL;
 if (!supabaseUrl) throw new Error('VITE_SUPABASE_URL is not defined');

--- a/src/hooks/useWeeklyMenu.js
+++ b/src/hooks/useWeeklyMenu.js
@@ -3,88 +3,14 @@ import { getSupabase } from '../lib/supabase.js';
 import { useToast } from '../components/ui/use-toast.js';
 import { initialWeeklyMenuState } from '../lib/menu.js';
 import { DEFAULT_MENU_PREFS } from '../lib/defaultPreferences.js';
+import { fromDbPrefs, toDbPrefs } from '../lib/menuPreferences.js';
 
 /** @typedef {import('../types').WeeklyMenuPreferences} WeeklyMenuPreferences */
 /** @typedef {import('../types').CommonMenuSettings} CommonMenuSettings */
 
 const defaultPrefs = { ...DEFAULT_MENU_PREFS };
 
-/**
- * Convert a database row into client preferences.
- * @param {WeeklyMenuPreferences | null | undefined} pref
- * @returns {{
- *   servingsPerMeal: number;
- *   maxCalories: number | null;
- *   weeklyBudget: number;
- *   meals: {id:number; mealNumber:number; types:string[]; enabled:boolean;}[];
- *   tagPreferences: string[];
- *   commonMenuSettings: CommonMenuSettings;
- * }}
- */
-export function fromDbPrefs(pref) {
-  if (!pref) return { ...defaultPrefs };
-  const dailyMealStructure =
-    typeof pref.daily_meal_structure === 'string'
-      ? JSON.parse(pref.daily_meal_structure || '[]')
-      : pref.daily_meal_structure;
-  const tagPreferences =
-    typeof pref.tag_preferences === 'string'
-      ? JSON.parse(pref.tag_preferences || '[]')
-      : pref.tag_preferences;
-  const commonMenuSettings =
-    typeof pref.common_menu_settings === 'string'
-      ? JSON.parse(pref.common_menu_settings || '{}')
-      : pref.common_menu_settings;
-  const meals = Array.isArray(dailyMealStructure)
-    ? dailyMealStructure.map((types, idx) => ({
-        id: idx + 1,
-        mealNumber: idx + 1,
-        types: Array.isArray(types) ? types : [],
-        enabled: true,
-      }))
-    : [];
-  return {
-    servingsPerMeal: pref.portions_per_meal ?? 4,
-    maxCalories: pref.daily_calories_limit ?? 2200,
-    weeklyBudget: pref.weekly_budget ?? 35,
-    meals,
-    tagPreferences: tagPreferences || [],
-    commonMenuSettings: {
-      ...DEFAULT_MENU_PREFS.commonMenuSettings,
-      ...(commonMenuSettings || {}),
-    },
-  };
-}
-
-/**
- * Convert client preferences into a database row.
- * @param {{
- *   servingsPerMeal?: number;
- *   maxCalories?: number | null;
- *   weeklyBudget?: number;
- *   meals?: {id:number; mealNumber:number; types:string[]; enabled:boolean;}[];
- *   tagPreferences?: string[];
- *   commonMenuSettings?: CommonMenuSettings;
- * }} pref
- * @returns {WeeklyMenuPreferences}
- */
-export function toDbPrefs(pref) {
-  const effective = { ...DEFAULT_MENU_PREFS, ...(pref || {}) };
-  return {
-    portions_per_meal: effective.servingsPerMeal,
-    daily_calories_limit: effective.maxCalories,
-    weekly_budget: effective.weeklyBudget,
-    daily_meal_structure: JSON.stringify(
-      Array.isArray(effective.meals)
-        ? effective.meals
-            .filter((m) => m.enabled)
-            .map((m) => (Array.isArray(m.types) ? m.types : []))
-        : []
-    ),
-    tag_preferences: JSON.stringify(effective.tagPreferences || []),
-    common_menu_settings: JSON.stringify(effective.commonMenuSettings ?? {}),
-  };
-}
+export { fromDbPrefs, toDbPrefs } from '../lib/menuPreferences.js';
 
 function isValidUUID(value) {
   return (

--- a/src/lib/menuPreferences.js
+++ b/src/lib/menuPreferences.js
@@ -1,0 +1,79 @@
+import { DEFAULT_MENU_PREFS } from './defaultPreferences.js';
+
+/**
+ * Convert a database row into client preferences.
+ * @param {import('../types').WeeklyMenuPreferences | null | undefined} pref
+ * @returns {{
+ *   servingsPerMeal: number;
+ *   maxCalories: number | null;
+ *   weeklyBudget: number;
+ *   meals: {id:number; mealNumber:number; types:string[]; enabled:boolean;}[];
+ *   tagPreferences: string[];
+ *   commonMenuSettings: import('../types').CommonMenuSettings;
+ * }}
+ */
+export function fromDbPrefs(pref) {
+  if (!pref) return { ...DEFAULT_MENU_PREFS };
+  const dailyMealStructure =
+    typeof pref.daily_meal_structure === 'string'
+      ? JSON.parse(pref.daily_meal_structure || '[]')
+      : pref.daily_meal_structure;
+  const tagPreferences =
+    typeof pref.tag_preferences === 'string'
+      ? JSON.parse(pref.tag_preferences || '[]')
+      : pref.tag_preferences;
+  const commonMenuSettings =
+    typeof pref.common_menu_settings === 'string'
+      ? JSON.parse(pref.common_menu_settings || '{}')
+      : pref.common_menu_settings;
+  const meals = Array.isArray(dailyMealStructure)
+    ? dailyMealStructure.map((types, idx) => ({
+        id: idx + 1,
+        mealNumber: idx + 1,
+        types: Array.isArray(types) ? types : [],
+        enabled: true,
+      }))
+    : [];
+  return {
+    servingsPerMeal: pref.portions_per_meal ?? 4,
+    maxCalories: pref.daily_calories_limit ?? 2200,
+    weeklyBudget: pref.weekly_budget ?? 35,
+    meals,
+    tagPreferences: tagPreferences || [],
+    commonMenuSettings: {
+      ...DEFAULT_MENU_PREFS.commonMenuSettings,
+      ...(commonMenuSettings || {}),
+    },
+  };
+}
+
+/**
+ * Convert client preferences into a database row.
+ * @param {{
+ *   servingsPerMeal?: number;
+ *   maxCalories?: number | null;
+ *   weeklyBudget?: number;
+ *   meals?: {id:number; mealNumber:number; types:string[]; enabled:boolean;}[];
+ *   tagPreferences?: string[];
+ *   commonMenuSettings?: import('../types').CommonMenuSettings;
+ * }} pref
+ * @returns {import('../types').WeeklyMenuPreferences}
+ */
+export function toDbPrefs(pref) {
+  const effective = { ...DEFAULT_MENU_PREFS, ...(pref || {}) };
+  return {
+    portions_per_meal: effective.servingsPerMeal,
+    daily_calories_limit: effective.maxCalories,
+    weekly_budget: effective.weeklyBudget,
+    daily_meal_structure: JSON.stringify(
+      Array.isArray(effective.meals)
+        ? effective.meals
+            .filter((m) => m.enabled)
+            .map((m) => (Array.isArray(m.types) ? m.types : []))
+        : []
+    ),
+    tag_preferences: JSON.stringify(effective.tagPreferences || []),
+    common_menu_settings: JSON.stringify(effective.commonMenuSettings ?? {}),
+  };
+}
+

--- a/tests/preferences.integration.spec.jsx
+++ b/tests/preferences.integration.spec.jsx
@@ -3,7 +3,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, fireEvent, waitFor } from '@testing-library/react';
 import { renderHook, act } from '@testing-library/react';
 import MenuPreferencesPanel from '../src/components/menu_planner/MenuPreferencesPanel.jsx';
-import { useWeeklyMenu, toDbPrefs } from '../src/hooks/useWeeklyMenu.js';
+import { useWeeklyMenu } from '../src/hooks/useWeeklyMenu.js';
+import { toDbPrefs } from '../src/lib/menuPreferences.js';
 import { DEFAULT_MENU_PREFS } from '../src/lib/defaultPreferences.js';
 
 global.scrollTo = vi.fn();

--- a/tests/preferences.spec.ts
+++ b/tests/preferences.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { toDbPrefs, fromDbPrefs } from '../src/hooks/useWeeklyMenu.js';
+import { toDbPrefs, fromDbPrefs } from '../src/lib/menuPreferences.js';
 
 describe('preferences conversion', () => {
   it('preserves commonMenuSettings through DB round trip', () => {

--- a/tests/weeklyMenuLoad.spec.jsx
+++ b/tests/weeklyMenuLoad.spec.jsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
-import { useWeeklyMenu, toDbPrefs } from '../src/hooks/useWeeklyMenu.js';
+import { useWeeklyMenu } from '../src/hooks/useWeeklyMenu.js';
+import { toDbPrefs } from '../src/lib/menuPreferences.js';
 import { initialWeeklyMenuState } from '../src/lib/menu.js';
 import { DEFAULT_MENU_PREFS } from '../src/lib/defaultPreferences.js';
 


### PR DESCRIPTION
## Summary
- move `toDbPrefs`/`fromDbPrefs` to a new `menuPreferences` utility module
- update API route, hooks and tests to import from the new module
- re-export helpers from `useWeeklyMenu` for compatibility

## Testing
- `npx vitest run tests/preferences.spec.ts tests/preferences.integration.spec.jsx`

------
https://chatgpt.com/codex/tasks/task_e_68665b3dc7c8832d88f78a019dda2874