### PR TITLE
Fix shared menu and prefs handling

### DIFF
--- a/api/create-shared-menu.ts
+++ b/api/create-shared-menu.ts
@@ -35,6 +35,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   }
 
   const shared = typeof is_shared === 'boolean' ? is_shared : false;
+  console.log('is_shared received:', shared);
 
   try {
     console.log('Inserting weekly menu:', {
@@ -43,7 +44,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       menu_data,
       is_shared: shared,
     });
-    const sanitizedMenuData = Array.isArray(menu_data) ? menu_data : [];
+    const sanitizedMenuData = menu_data || {};
 
     const { data: inserted, error } = await supabaseAdmin
       .from('weekly_menus')

--- a/scripts/upload-test-image.ts
+++ b/scripts/upload-test-image.ts
@@ -2,11 +2,11 @@ import { createClient } from '@supabase/supabase-js';
 import fs from 'fs';
 import recipeImage from '../tests/fixtures/recipe-image.json' assert { type: 'json' };
 
-const url = process.env.VITE_SUPABASE_URL || process.env.SUPABASE_URL;
+const url = process.env.SUPABASE_URL;
 const serviceRole = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
 if (!url || !serviceRole) {
-  console.error('VITE_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY must be set');
+  console.error('SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY must be set');
   process.exit(1);
 }
 

--- a/src/hooks/useWeeklyMenu.js
+++ b/src/hooks/useWeeklyMenu.js
@@ -3,14 +3,14 @@ import { getSupabase } from '../lib/supabase.js';
 import { useToast } from '../components/ui/use-toast.js';
 import { initialWeeklyMenuState } from '../lib/menu.js';
 import { DEFAULT_MENU_PREFS } from '../lib/defaultPreferences.js';
-import { fromDbPrefs, toDbPrefs } from '../lib/menuPreferences.js';
+import { fromDbPrefs, toDbPrefs } from '../lib/preferences.js';
 
 /** @typedef {import('../types').WeeklyMenuPreferences} WeeklyMenuPreferences */
 /** @typedef {import('../types').CommonMenuSettings} CommonMenuSettings */
 
 const defaultPrefs = { ...DEFAULT_MENU_PREFS };
 
-export { fromDbPrefs, toDbPrefs } from '../lib/menuPreferences.js';
+export { fromDbPrefs, toDbPrefs } from '../lib/preferences.js';
 
 function isValidUUID(value) {
   return (

--- a/supabase/migrations/0007_insert_default_preferences_function.sql
+++ b/supabase/migrations/0007_insert_default_preferences_function.sql
@@ -3,6 +3,7 @@ returns trigger
 language plpgsql
 as $$
 begin
+  raise notice 'insert_default_preferences is_shared=%', new.is_shared;
   insert into weekly_menu_preferences (
     menu_id,
     portions_per_meal,
@@ -16,8 +17,8 @@ begin
     4,
     2200,
     35,
-    array[]::text[][],
-    array[]::text[],
+    '[]'::jsonb,
+    '[]'::jsonb,
     case
       when new.is_shared then '{"enabled": false, "linkedUsers": [], "linkedUserRecipes": []}'::jsonb
       else '{}'::jsonb

--- a/tests/preferences.integration.spec.jsx
+++ b/tests/preferences.integration.spec.jsx
@@ -4,7 +4,7 @@ import { render, fireEvent, waitFor } from '@testing-library/react';
 import { renderHook, act } from '@testing-library/react';
 import MenuPreferencesPanel from '../src/components/menu_planner/MenuPreferencesPanel.jsx';
 import { useWeeklyMenu } from '../src/hooks/useWeeklyMenu.js';
-import { toDbPrefs } from '../src/lib/menuPreferences.js';
+import { toDbPrefs } from '../src/lib/preferences.js';
 import { DEFAULT_MENU_PREFS } from '../src/lib/defaultPreferences.js';
 
 global.scrollTo = vi.fn();

--- a/tests/preferences.spec.ts
+++ b/tests/preferences.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { toDbPrefs, fromDbPrefs } from '../src/lib/menuPreferences.js';
+import { toDbPrefs, fromDbPrefs } from '../src/lib/preferences.js';
 
 describe('preferences conversion', () => {
   it('preserves commonMenuSettings through DB round trip', () => {

--- a/tests/weeklyMenuLoad.spec.jsx
+++ b/tests/weeklyMenuLoad.spec.jsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
 import { useWeeklyMenu } from '../src/hooks/useWeeklyMenu.js';
-import { toDbPrefs } from '../src/lib/menuPreferences.js';
+import { toDbPrefs } from '../src/lib/preferences.js';
 import { initialWeeklyMenuState } from '../src/lib/menu.js';
 import { DEFAULT_MENU_PREFS } from '../src/lib/defaultPreferences.js';
 


### PR DESCRIPTION
## Summary
- use backend env vars and log `is_shared`
- keep raw `menu_data` when creating shared menu
- move preference helpers to new `preferences.ts`
- update imports across code and tests
- log `is_shared` in DB trigger

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866840b3eb8832db705ab0c5674028e