### PR TITLE
Add ts-node and validation script docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,14 @@ Once uploaded, the image will be publicly available at
 Its location is referenced in `tests/fixtures/recipe-image.json` and used by the
 `SignedImage` tests.
 
+## Validate configuration
+
+Check for hard-coded Supabase URLs outside of `src/config/constants.client.ts`:
+
+```bash
+npm run validate-config
+```
+
 ## Price estimation
 
 Recipe prices are estimated with OpenAI only when required. A new estimate is

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,8 @@
         "tailwindcss": "^3.3.3",
         "terser": "^5.39.0",
         "vite": "^4.4.5",
-        "vitest": "^3.2.3"
+        "vitest": "^3.2.3",
+        "ts-node": "^10.9.2"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -12284,6 +12285,7 @@
       "license": "MIT",
       "optional": true,
       "peer": true,
+      "dev": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "preview": "vite preview",
     "test": "vitest",
     "lint": "eslint --config eslint.config.js .",
-    "format": "prettier --write \"src/**/*.{js,jsx,json,css}\""
+    "format": "prettier --write \"src/**/*.{js,jsx,json,css}\"",
+    "validate-config": "ts-node scripts/validate-config.ts"
   },
   "dependencies": {
     "@emotion/is-prop-valid": "^1.2.1",
@@ -60,6 +61,7 @@
     "tailwindcss": "^3.3.3",
     "terser": "^5.39.0",
     "vite": "^4.4.5",
-    "vitest": "^3.2.3"
+    "vitest": "^3.2.3",
+    "ts-node": "^10.9.2"
   }
 }


### PR DESCRIPTION
## Summary
- add `ts-node` dev dependency and script for validating config
- document how to run the validator in README

## Testing
- `npm run test`
- `npm run lint` *(fails: 'global' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_686798c3fa04832d8f36f3a9be2d20be