### PR TITLE
Migrate menu preferences to TypeScript

### DIFF
--- a/src/hooks/useWeeklyMenu.js
+++ b/src/hooks/useWeeklyMenu.js
@@ -3,14 +3,14 @@ import { getSupabase } from '../lib/supabase.js';
 import { useToast } from '../components/ui/use-toast.js';
 import { initialWeeklyMenuState } from '../lib/menu.js';
 import { DEFAULT_MENU_PREFS } from '../lib/defaultPreferences.js';
-import { fromDbPrefs, toDbPrefs } from '../lib/menuPreferences.js';
+import { fromDbPrefs, toDbPrefs } from '@/lib/menuPreferences';
 
 /** @typedef {import('../types').WeeklyMenuPreferences} WeeklyMenuPreferences */
 /** @typedef {import('../types').CommonMenuSettings} CommonMenuSettings */
 
 const defaultPrefs = { ...DEFAULT_MENU_PREFS };
 
-export { fromDbPrefs, toDbPrefs } from '../lib/menuPreferences.js';
+export { fromDbPrefs, toDbPrefs } from '@/lib/menuPreferences';
 
 function isValidUUID(value) {
   return (

--- a/src/lib/menuPreferences.ts
+++ b/src/lib/menuPreferences.ts
@@ -1,66 +1,71 @@
 import { DEFAULT_MENU_PREFS } from './defaultPreferences.js';
+import type { WeeklyMenuPreferences, CommonMenuSettings } from '@/types';
 
-/**
- * Convert a database row into client preferences.
- * @param {import('../types').WeeklyMenuPreferences | null | undefined} pref
- * @returns {{
- *   servingsPerMeal: number;
- *   maxCalories: number | null;
- *   weeklyBudget: number;
- *   meals: {id:number; mealNumber:number; types:string[]; enabled:boolean;}[];
- *   tagPreferences: string[];
- *   commonMenuSettings: import('../types').CommonMenuSettings;
- * }}
- */
-export function fromDbPrefs(pref) {
+export interface ClientMenuPreferences {
+  servingsPerMeal: number;
+  maxCalories: number | null;
+  weeklyBudget: number;
+  meals: { id: number; mealNumber: number; types: string[]; enabled: boolean }[];
+  tagPreferences: string[];
+  commonMenuSettings: CommonMenuSettings;
+}
+
+export function fromDbPrefs(
+  pref: WeeklyMenuPreferences | null | undefined
+): ClientMenuPreferences {
   if (!pref) return { ...DEFAULT_MENU_PREFS };
+
   const dailyMealStructure =
     typeof pref.daily_meal_structure === 'string'
       ? JSON.parse(pref.daily_meal_structure || '[]')
       : pref.daily_meal_structure;
+
   const tagPreferences =
     typeof pref.tag_preferences === 'string'
       ? JSON.parse(pref.tag_preferences || '[]')
       : pref.tag_preferences;
+
   const commonMenuSettings =
     typeof pref.common_menu_settings === 'string'
       ? JSON.parse(pref.common_menu_settings || '{}')
       : pref.common_menu_settings;
+
   const meals = Array.isArray(dailyMealStructure)
-    ? dailyMealStructure.map((types, idx) => ({
+    ? dailyMealStructure.map((types: unknown, idx: number) => ({
         id: idx + 1,
         mealNumber: idx + 1,
-        types: Array.isArray(types) ? types : [],
+        types: Array.isArray(types) ? (types as string[]) : [],
         enabled: true,
       }))
     : [];
+
   return {
     servingsPerMeal: pref.portions_per_meal ?? 4,
     maxCalories: pref.daily_calories_limit ?? 2200,
     weeklyBudget: pref.weekly_budget ?? 35,
     meals,
-    tagPreferences: tagPreferences || [],
+    tagPreferences: (tagPreferences as string[]) || [],
     commonMenuSettings: {
       ...DEFAULT_MENU_PREFS.commonMenuSettings,
-      ...(commonMenuSettings || {}),
+      ...((commonMenuSettings as CommonMenuSettings) || {}),
     },
   };
 }
 
-/**
- * Convert client preferences into a database row.
- * @param {{
- *   servingsPerMeal?: number;
- *   maxCalories?: number | null;
- *   weeklyBudget?: number;
- *   meals?: {id:number; mealNumber:number; types:string[]; enabled:boolean;}[];
- *   tagPreferences?: string[];
- *   commonMenuSettings?: import('../types').CommonMenuSettings;
- * }} pref
- * @returns {import('../types').WeeklyMenuPreferences}
- */
-export function toDbPrefs(pref) {
-  const effective = { ...DEFAULT_MENU_PREFS, ...(pref || {}) };
+export function toDbPrefs(pref: {
+  servingsPerMeal?: number;
+  maxCalories?: number | null;
+  weeklyBudget?: number;
+  meals?: {
+    id: number;
+    mealNumber: number;
+    types: string[];
+    enabled: boolean;
+  }[];
+  tagPreferences?: string[];
+  commonMenuSettings?: CommonMenuSettings;
+}): Omit<WeeklyMenuPreferences, 'menu_id'> {
+  const effective = { ...DEFAULT_MENU_PREFS, ...(pref || {}) } as ClientMenuPreferences;
   return {
     portions_per_meal: effective.servingsPerMeal,
     daily_calories_limit: effective.maxCalories,
@@ -76,4 +81,3 @@ export function toDbPrefs(pref) {
     common_menu_settings: JSON.stringify(effective.commonMenuSettings ?? {}),
   };
 }
-

--- a/tests/preferences.integration.spec.jsx
+++ b/tests/preferences.integration.spec.jsx
@@ -4,7 +4,7 @@ import { render, fireEvent, waitFor } from '@testing-library/react';
 import { renderHook, act } from '@testing-library/react';
 import MenuPreferencesPanel from '../src/components/menu_planner/MenuPreferencesPanel.jsx';
 import { useWeeklyMenu } from '../src/hooks/useWeeklyMenu.js';
-import { toDbPrefs } from '../src/lib/menuPreferences.js';
+import { toDbPrefs } from '@/lib/menuPreferences';
 import { DEFAULT_MENU_PREFS } from '../src/lib/defaultPreferences.js';
 
 global.scrollTo = vi.fn();

--- a/tests/preferences.spec.ts
+++ b/tests/preferences.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { toDbPrefs, fromDbPrefs } from '../src/lib/menuPreferences.js';
+import { toDbPrefs, fromDbPrefs } from '@/lib/menuPreferences';
 
 describe('preferences conversion', () => {
   it('preserves commonMenuSettings through DB round trip', () => {

--- a/tests/weeklyMenuLoad.spec.jsx
+++ b/tests/weeklyMenuLoad.spec.jsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
 import { useWeeklyMenu } from '../src/hooks/useWeeklyMenu.js';
-import { toDbPrefs } from '../src/lib/menuPreferences.js';
+import { toDbPrefs } from '@/lib/menuPreferences';
 import { initialWeeklyMenuState } from '../src/lib/menu.js';
 import { DEFAULT_MENU_PREFS } from '../src/lib/defaultPreferences.js';
 


### PR DESCRIPTION
## Summary
- move menu preference conversion helpers to `menuPreferences.ts`
- update hooks and tests to import from the new module
- remove the old JavaScript file

## Testing
- `npx vitest run --maxWorkers=1 --minWorkers=1`

------
https://chatgpt.com/codex/tasks/task_e_6867a67e0750832dbeb03dcc32200cb0