### PR TITLE
Insert default preferences on menu creation

### DIFF
--- a/api/create-shared-menu.ts
+++ b/api/create-shared-menu.ts
@@ -1,5 +1,6 @@
 import { VercelRequest, VercelResponse } from '@vercel/node';
 import { createClient } from '@supabase/supabase-js';
+import { toDbPrefs } from '@/lib/menuPreferences';
 
 const supabaseUrl = process.env.SUPABASE_URL;
 if (!supabaseUrl) throw new Error('SUPABASE_URL is not defined');
@@ -65,6 +66,14 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   }
 
     console.log('Menu created with is_shared:', inserted.is_shared);
+
+    const { error: prefErr } = await supabaseAdmin
+      .from('weekly_menu_preferences')
+      .insert({ menu_id: inserted.id, ...toDbPrefs({}) });
+
+    if (prefErr) {
+      console.warn('🛠 weekly_menu_preferences insert error:', prefErr.message);
+    }
 
     if (shared && Array.isArray(participant_ids) && participant_ids.length > 0) {
       const rows = participant_ids


### PR DESCRIPTION
## Summary
- store default weekly menu preferences when creating a shared menu
- adjust tests to expect preferences insertion via `weekly_menu_preferences`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867a67f15f8832db4b15749e67df19a