### PR TITLE
Fix menuPreferences test import

### DIFF
--- a/tests/createSharedMenuTrigger.spec.ts
+++ b/tests/createSharedMenuTrigger.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { toDbPrefs } from '../src/lib/menuPreferences.js';
+import { toDbPrefs } from '@/lib/menuPreferences';
 
 process.env.SUPABASE_URL = 'http://localhost';
 process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role';


### PR DESCRIPTION
## Summary
- update tests/createSharedMenuTrigger.spec.ts to use the alias path for menuPreferences

## Testing
- `npm test` *(fails: friendMenuVisibility.test.jsx assertion error)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6867b06529f4832db2bc83fb4cd28705