### PR TITLE
Add participant insertion to shared menu API

### DIFF
--- a/api/create-shared-menu.ts
+++ b/api/create-shared-menu.ts
@@ -66,6 +66,25 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
     console.log('Menu created with is_shared:', inserted.is_shared);
 
+    if (
+      inserted.is_shared &&
+      Array.isArray(participant_ids) &&
+      participant_ids.length > 0
+    ) {
+      const rows = participant_ids
+        .filter((id: string) => id && id !== user_id)
+        .map((id: string) => ({ menu_id: inserted.id, user_id: id }));
+
+      if (rows.length > 0) {
+        const { error: partErr } = await supabaseAdmin
+          .from('menu_participants')
+          .insert(rows);
+        if (partErr) {
+          console.warn('🛠 menu_participants insert error:', partErr.message);
+        }
+      }
+    }
+
     return res.status(200).json({ id: inserted.id });
   } catch (err) {
     console.error('🛠 create-shared-menu error:', err);

--- a/tests/createSharedMenuTrigger.spec.ts
+++ b/tests/createSharedMenuTrigger.spec.ts
@@ -97,4 +97,24 @@ describe('create-shared-menu trigger', () => {
       { menu_id: 'm1', user_id: 'u3' },
     ]);
   });
+
+  it('filters out creator and falsy IDs', async () => {
+    const { default: handler } = await import('../api/create-shared-menu.ts');
+    const req: any = {
+      method: 'POST',
+      body: {
+        user_id: 'u1',
+        name: 'Shared',
+        is_shared: true,
+        participant_ids: ['u1', 'u2', null, undefined, '', 'u3'],
+      },
+    };
+    const res: any = { status() { return this; }, json() { return this; } };
+    await handler(req, res);
+
+    expect(participantInsertSpy).toHaveBeenCalledWith([
+      { menu_id: 'm1', user_id: 'u2' },
+      { menu_id: 'm1', user_id: 'u3' },
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary
- insert participants after creating a shared menu
- skip creator and falsy participant IDs
- test participant filtering

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867c5432ba8832d88e6a6dbf04a7379