### PR TITLE
Remove insert_default_preferences trigger

### DIFF
--- a/docs/data-model.sql
+++ b/docs/data-model.sql
@@ -27,11 +27,7 @@ create table weekly_menus (
   created_at timestamptz default now(),
   updated_at timestamptz default now()
 );
-
--- Automatically create default preferences for each new menu
-create trigger insert_default_preferences
-after insert on weekly_menus
-for each row execute function insert_default_preferences();
+-- Menu preferences are inserted later by the application
 
 create table menu_participants (
   menu_id uuid references weekly_menus(id) on delete cascade,


### PR DESCRIPTION
## Summary
- remove references to the `insert_default_preferences` trigger
- clarify that menu preferences are inserted by the application

## Testing
- `npm run test` *(fails: create-shared-menu trigger inserts participants)*

------
https://chatgpt.com/codex/tasks/task_e_6867c541edec832d8dce95c2c705855b