### PR TITLE
Drop insert_default_preferences function

### DIFF
--- a/docs/migration-notes.md
+++ b/docs/migration-notes.md
@@ -1,0 +1,3 @@
+# Migration Notes
+
+- **0008_remove_default_preferences_function.sql**: drops the `insert_default_preferences()` function now that preferences are created in the application.

--- a/supabase/migrations/0008_remove_default_preferences_function.sql
+++ b/supabase/migrations/0008_remove_default_preferences_function.sql
@@ -1,0 +1,1 @@
+DROP FUNCTION IF EXISTS insert_default_preferences() CASCADE;


### PR DESCRIPTION
## Summary
- add migration to drop insert_default_preferences function
- note migration in docs

## Testing
- `npm test` *(fails: friendMenuVisibility.test.jsx)*
- `npm run lint` *(fails: no-undef errors)*

------
https://chatgpt.com/codex/tasks/task_e_6867df561cd0832db868244d69d92c5d