### PR TITLE
Validate menu_data length in API

### DIFF
--- a/api/create-shared-menu.ts
+++ b/api/create-shared-menu.ts
@@ -15,6 +15,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
   const { user_id, name, menu_data, participant_ids, is_shared } = req.body || {};
 
+  if (!Array.isArray(menu_data) || menu_data.length !== 7) {
+    return res
+      .status(400)
+      .json({ error: 'menu_data must be an array of 7 days' });
+  }
+
   if (!user_id || typeof user_id !== 'string') {
     return res.status(400).json({ error: 'user_id required' });
   }

--- a/tests/createSharedMenuTrigger.spec.ts
+++ b/tests/createSharedMenuTrigger.spec.ts
@@ -56,7 +56,15 @@ beforeEach(() => {
 describe('create-shared-menu trigger', () => {
   it('inserts default prefs for shared menu', async () => {
     const { default: handler } = await import('../api/create-shared-menu.ts');
-    const req: any = { method: 'POST', body: { user_id: 'u1', name: 'Shared', is_shared: true } };
+    const req: any = {
+      method: 'POST',
+      body: {
+        user_id: 'u1',
+        name: 'Shared',
+        is_shared: true,
+        menu_data: [[], [], [], [], [], [], []],
+      },
+    };
     const res: any = { status(code: number) { this.statusCode = code; return this; }, json(payload: any) { this.body = payload; return this; } };
     await handler(req, res);
 
@@ -68,7 +76,15 @@ describe('create-shared-menu trigger', () => {
 
   it('inserts default prefs for non shared menu', async () => {
     const { default: handler } = await import('../api/create-shared-menu.ts');
-    const req: any = { method: 'POST', body: { user_id: 'u1', name: 'Private', is_shared: false } };
+    const req: any = {
+      method: 'POST',
+      body: {
+        user_id: 'u1',
+        name: 'Private',
+        is_shared: false,
+        menu_data: [[], [], [], [], [], [], []],
+      },
+    };
     const res: any = { status(code: number) { this.statusCode = code; return this; }, json(payload: any) { this.body = payload; return this; } };
     await handler(req, res);
 
@@ -86,6 +102,7 @@ describe('create-shared-menu trigger', () => {
         user_id: 'u1',
         name: 'Shared',
         is_shared: true,
+        menu_data: [[], [], [], [], [], [], []],
         participant_ids: ['u2', 'u3'],
       },
     };
@@ -106,6 +123,7 @@ describe('create-shared-menu trigger', () => {
         user_id: 'u1',
         name: 'Shared',
         is_shared: true,
+        menu_data: [[], [], [], [], [], [], []],
         participant_ids: ['u1', 'u2', null, undefined, '', 'u3'],
       },
     };
@@ -116,5 +134,31 @@ describe('create-shared-menu trigger', () => {
       { menu_id: 'm1', user_id: 'u2' },
       { menu_id: 'm1', user_id: 'u3' },
     ]);
+  });
+
+  it('returns 400 when menu_data is invalid', async () => {
+    const { default: handler } = await import('../api/create-shared-menu.ts');
+    const req: any = {
+      method: 'POST',
+      body: { user_id: 'u1', name: 'Bad', menu_data: ['only'], is_shared: true },
+    };
+    const res: any = {
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        this.body = payload;
+        return this;
+      },
+    };
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({
+      error: 'menu_data must be an array of 7 days',
+    });
+    expect(menuInsertSpy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- validate `menu_data` as array of 7 days in `create-shared-menu`
- update tests for `createSharedMenu` API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867df537f94832dbf8ee3749b0bb0b0