### PR TITLE
Fix tag preferences serialization in create-shared-menu

### DIFF
--- a/api/create-shared-menu.ts
+++ b/api/create-shared-menu.ts
@@ -49,7 +49,18 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       menu_data,
       is_shared: shared,
     });
-    const sanitizedMenuData = Array.isArray(menu_data) ? menu_data : [];
+    const sanitizedMenuData = Array.isArray(menu_data)
+      ? menu_data
+      : {
+          ...menu_data,
+          tag_preferences: JSON.stringify(menu_data?.tag_preferences ?? []),
+          daily_meal_structure: JSON.stringify(
+            menu_data?.daily_meal_structure ?? []
+          ),
+          common_menu_settings: JSON.stringify(
+            menu_data?.common_menu_settings ?? {}
+          ),
+        };
 
     const { data: inserted, error } = await supabaseAdmin
       .from('weekly_menus')


### PR DESCRIPTION
## Summary
- serialize preference fields when creating a shared menu so insertion doesn't fail

## Testing
- `npx vitest run`
- `npm run lint` *(fails: '__dirname' is not defined, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686828be1bf4832da0a201b7d0589e9c