### PR TITLE
feat: favor menu costs near per-slot budget

### DIFF
--- a/src/hooks/useMenuGeneration.js
+++ b/src/hooks/useMenuGeneration.js
@@ -397,7 +397,13 @@ export function useMenuGeneration(
             if (mealCost > weeklyBudget - budgetUsed) {
               score *= 0.5;
             } else {
-              score *= 1 + Math.max(0, avgBudgetPerSlot - mealCost) / avgBudgetPerSlot;
+              const diffRatio =
+                (mealCost - avgBudgetPerSlot) / avgBudgetPerSlot;
+              const budgetScore = Math.exp(-diffRatio * diffRatio);
+              score *= budgetScore;
+              if (mealCost < avgBudgetPerSlot * 0.7) {
+                score *= 0.95;
+              }
             }
           }
 


### PR DESCRIPTION
## Summary
- balance meal scoring around the average budget per slot
- slightly penalize recipes far below the per-meal budget

## Testing
- `npm test` *(fails: useMenus friend visibility ignores menus that are not shared)*

------
https://chatgpt.com/codex/tasks/task_e_6899cd1a58cc832da5da0d42653c23c8