### PR TITLE
Allow VIP tier for AI cost estimation

### DIFF
--- a/api/ai.ts
+++ b/api/ai.ts
@@ -167,7 +167,10 @@ Ne termine pas par une formule type “Bon appétit”.
         return res.status(200).json({ path: fileName });
       }
       case 'cost': {
-        if (subscriptionTier !== 'premium') {
+        if (
+          subscriptionTier !== 'premium' &&
+          subscriptionTier !== 'vip'
+        ) {
           return res.status(403).json({ error: 'Premium only' });
         }
 

--- a/src/components/RecipeForm.jsx
+++ b/src/components/RecipeForm.jsx
@@ -530,7 +530,8 @@ function RecipeForm({
       servingsChanged;
 
     let estimated = recipe?.estimated_price ?? null;
-    if (shouldEstimate && subscriptionTier === 'premium') {
+    if (shouldEstimate &&
+        (subscriptionTier === 'premium' || subscriptionTier === 'vip')) {
       estimated = await estimateRecipePrice(
         {
           ingredients: cleanedNewIngredients,

--- a/src/hooks/useRecipes.jsx
+++ b/src/hooks/useRecipes.jsx
@@ -90,7 +90,7 @@ export function useRecipes(session, subscriptionTier) {
 
   useEffect(() => {
     const estimateMissingPrices = async () => {
-      if (subscriptionTier !== 'premium') return;
+      if (subscriptionTier !== 'premium' && subscriptionTier !== 'vip') return;
       for (const recipe of Array.isArray(recipes) ? recipes : []) {
         if (
           recipe &&

--- a/tests/ai-vip.spec.ts
+++ b/tests/ai-vip.spec.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+process.env.SUPABASE_URL = 'http://localhost';
+process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role';
+process.env.OPENAI_API_KEY = 'test-key';
+
+vi.mock('@supabase/supabase-js', () => {
+  return {
+    createClient: vi.fn(() => {
+      return {
+        from(table: string) {
+          if (table === 'public_user_view') {
+            return {
+              select: vi.fn().mockReturnThis(),
+              eq: vi.fn().mockReturnThis(),
+              maybeSingle: vi.fn(() =>
+                Promise.resolve({ data: { subscription_tier: 'vip' }, error: null })
+              ),
+            } as any;
+          }
+          return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis(), maybeSingle: vi.fn(() => Promise.resolve({ data: null, error: null })) } as any;
+        },
+        rpc: vi.fn(() => Promise.resolve({ data: null, error: null })),
+      } as any;
+    }),
+  };
+});
+
+vi.mock('../src/utils/auth.js', () => ({
+  getUserFromRequest: vi.fn(() => Promise.resolve({ id: 'user_1' })),
+}));
+
+class MockOpenAI {
+  chat = {
+    completions: {
+      create: vi.fn(() => Promise.resolve({ choices: [{ message: { content: '8.50' } }] })),
+    },
+  };
+}
+
+vi.mock('openai', () => ({ default: MockOpenAI }));
+
+describe('AI cost handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('allows vip tier for cost estimation', async () => {
+    const { default: handler } = await import('../api/ai.ts');
+    const req: any = {
+      method: 'POST',
+      query: { action: 'cost' },
+      body: { recipe: { name: 'Cake', servings: 2, ingredients: [{ quantity: '1', name: 'flour' }] } },
+    };
+    const res: any = {
+      statusCode: 0,
+      body: null,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        this.body = payload;
+        return this;
+      },
+    };
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ price: 8.5 });
+  });
+});


### PR DESCRIPTION
## Summary
- Permit VIP subscribers to access AI cost estimation endpoint
- Include VIP tier in client-side price estimation logic
- Add test confirming cost estimation works for VIP tier

## Testing
- `npm test` *(fails: useMenus friend visibility > ignores menus that are not shared)*
- `npx vitest run tests/ai-vip.spec.ts`
- `npm run lint` *(fails: 806 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6899cf8948bc832d9cbda18e02155782