### PR TITLE
feat: store menu prefs arrays

### DIFF
--- a/tests/preferences.integration.spec.jsx
+++ b/tests/preferences.integration.spec.jsx
@@ -133,12 +133,10 @@ describe('useWeeklyMenu.updateMenuPreferences', () => {
 
     const actual = { ...global.__supabaseState.lastUpsert };
     const expectedDb = toDbPrefs(newPrefs);
-    ['daily_meal_structure', 'tag_preferences', 'common_menu_settings'].forEach(
-      (f) => {
-        actual[f] = JSON.parse(actual[f]);
-        expectedDb[f] = JSON.parse(expectedDb[f]);
-      }
-    );
+    ['common_menu_settings'].forEach((f) => {
+      actual[f] = JSON.parse(actual[f]);
+      expectedDb[f] = JSON.parse(expectedDb[f]);
+    });
     expect(actual).toEqual({ menu_id: 'menu1', ...expectedDb });
   });
 
@@ -154,12 +152,10 @@ describe('useWeeklyMenu.updateMenuPreferences', () => {
     const expectedDb = toDbPrefs({ ...expected, commonMenuSettings: {} });
 
     const actual = { ...global.__supabaseState.lastUpsert };
-    ['daily_meal_structure', 'tag_preferences', 'common_menu_settings'].forEach(
-      (f) => {
-        actual[f] = JSON.parse(actual[f]);
-        expectedDb[f] = JSON.parse(expectedDb[f]);
-      }
-    );
+    ['common_menu_settings'].forEach((f) => {
+      actual[f] = JSON.parse(actual[f]);
+      expectedDb[f] = JSON.parse(expectedDb[f]);
+    });
     expect(actual).toEqual({ menu_id: 'menu1', ...expectedDb });
     expect(result.current.preferences).toEqual(expected);
   });

--- a/tests/preferences.spec.ts
+++ b/tests/preferences.spec.ts
@@ -22,7 +22,7 @@ describe('preferences conversion', () => {
     expect(JSON.parse(dbShape.common_menu_settings)).toEqual(
       prefs.commonMenuSettings
     );
-    expect(JSON.parse(dbShape.daily_meal_structure)).toEqual([
+    expect(dbShape.daily_meal_structure).toEqual([
       ['petit-dejeuner', 'brunch'],
     ]);
 


### PR DESCRIPTION
## Summary
- coerce unknown menu preference input via `asTextArray` and `as2DTextArray`
- persist meal structure and tag preferences as arrays in DB prefs
- adjust preference tests for new array storage

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: 'global' is not defined and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6899e848a4c4832dbb871099699cef74