### PR TITLE
Use array types for menu preference fields

### DIFF
--- a/api/create-shared-menu.ts
+++ b/api/create-shared-menu.ts
@@ -53,10 +53,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       ? menu_data
       : {
           ...menu_data,
-          tag_preferences: JSON.stringify(menu_data?.tag_preferences ?? []),
-          daily_meal_structure: JSON.stringify(
-            menu_data?.daily_meal_structure ?? []
-          ),
+          tag_preferences: menu_data?.tag_preferences ?? [],
+          daily_meal_structure: menu_data?.daily_meal_structure ?? [],
           common_menu_settings: JSON.stringify(
             menu_data?.common_menu_settings ?? {}
           ),

--- a/src/lib/menuPreferences.ts
+++ b/src/lib/menuPreferences.ts
@@ -15,15 +15,9 @@ export function fromDbPrefs(
 ): ClientMenuPreferences {
   if (!pref) return { ...DEFAULT_MENU_PREFS };
 
-  const dailyMealStructure =
-    typeof pref.daily_meal_structure === 'string'
-      ? JSON.parse(pref.daily_meal_structure || '[]')
-      : pref.daily_meal_structure;
+  const dailyMealStructure = pref.daily_meal_structure;
 
-  const tagPreferences =
-    typeof pref.tag_preferences === 'string'
-      ? JSON.parse(pref.tag_preferences || '[]')
-      : pref.tag_preferences;
+  const tagPreferences = pref.tag_preferences;
 
   const commonMenuSettings =
     typeof pref.common_menu_settings === 'string'
@@ -44,7 +38,7 @@ export function fromDbPrefs(
     maxCalories: pref.daily_calories_limit ?? 2200,
     weeklyBudget: pref.weekly_budget ?? 35,
     meals,
-    tagPreferences: (tagPreferences as string[]) || [],
+    tagPreferences: tagPreferences || [],
     commonMenuSettings: {
       ...DEFAULT_MENU_PREFS.commonMenuSettings,
       ...((commonMenuSettings as CommonMenuSettings) || {}),
@@ -70,14 +64,12 @@ export function toDbPrefs(pref: {
     portions_per_meal: effective.servingsPerMeal,
     daily_calories_limit: effective.maxCalories,
     weekly_budget: effective.weeklyBudget,
-    daily_meal_structure: JSON.stringify(
-      Array.isArray(effective.meals)
-        ? effective.meals
-            .filter((m) => m.enabled)
-            .map((m) => (Array.isArray(m.types) ? m.types : []))
-        : []
-    ),
-    tag_preferences: JSON.stringify(effective.tagPreferences || []),
+    daily_meal_structure: Array.isArray(effective.meals)
+      ? effective.meals
+          .filter((m) => m.enabled)
+          .map((m) => (Array.isArray(m.types) ? m.types : []))
+      : [],
+    tag_preferences: effective.tagPreferences || [],
     common_menu_settings: JSON.stringify(effective.commonMenuSettings ?? {}),
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,10 +9,8 @@ export type WeeklyMenuPreferences = {
   portions_per_meal: number;
   daily_calories_limit: number | null;
   weekly_budget: number;
-  /** stored as JSON string in DB, parsed as array on client */
-  daily_meal_structure: string[][] | string;
-  /** stored as JSON string in DB, parsed as array on client */
-  tag_preferences: string[] | string;
+  daily_meal_structure: string[][];
+  tag_preferences: string[];
   /** Client side representation of meals */
   meals?: {
     id: number;
@@ -22,7 +20,6 @@ export type WeeklyMenuPreferences = {
   }[];
   /** Camel case tag preferences for generator */
   tagPreferences?: { tag: string; percentage: number }[] | string[];
-  /** stored as JSON string in DB, parsed as object on client */
   common_menu_settings?: CommonMenuSettings | string;
 };
 

--- a/tests/preferences.integration.spec.jsx
+++ b/tests/preferences.integration.spec.jsx
@@ -133,11 +133,9 @@ describe('useWeeklyMenu.updateMenuPreferences', () => {
 
     const actual = { ...global.__supabaseState.lastUpsert };
     const expectedDb = toDbPrefs(newPrefs);
-    ['daily_meal_structure', 'tag_preferences', 'common_menu_settings'].forEach(
-      (f) => {
-        actual[f] = JSON.parse(actual[f]);
-        expectedDb[f] = JSON.parse(expectedDb[f]);
-      }
+    actual.common_menu_settings = JSON.parse(actual.common_menu_settings);
+    expectedDb.common_menu_settings = JSON.parse(
+      expectedDb.common_menu_settings
     );
     expect(actual).toEqual({ menu_id: 'menu1', ...expectedDb });
   });
@@ -154,11 +152,9 @@ describe('useWeeklyMenu.updateMenuPreferences', () => {
     const expectedDb = toDbPrefs({ ...expected, commonMenuSettings: {} });
 
     const actual = { ...global.__supabaseState.lastUpsert };
-    ['daily_meal_structure', 'tag_preferences', 'common_menu_settings'].forEach(
-      (f) => {
-        actual[f] = JSON.parse(actual[f]);
-        expectedDb[f] = JSON.parse(expectedDb[f]);
-      }
+    actual.common_menu_settings = JSON.parse(actual.common_menu_settings);
+    expectedDb.common_menu_settings = JSON.parse(
+      expectedDb.common_menu_settings
     );
     expect(actual).toEqual({ menu_id: 'menu1', ...expectedDb });
     expect(result.current.preferences).toEqual(expected);

--- a/tests/preferences.spec.ts
+++ b/tests/preferences.spec.ts
@@ -22,7 +22,7 @@ describe('preferences conversion', () => {
     expect(JSON.parse(dbShape.common_menu_settings)).toEqual(
       prefs.commonMenuSettings
     );
-    expect(JSON.parse(dbShape.daily_meal_structure)).toEqual([
+    expect(dbShape.daily_meal_structure).toEqual([
       ['petit-dejeuner', 'brunch'],
     ]);
 


### PR DESCRIPTION
## Summary
- define `daily_meal_structure` and `tag_preferences` as array types instead of JSON strings
- adjust menu preference conversions and API to store arrays directly
- update tests for array-based menu preferences

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899e84bad00832da4c57a22faebcffc