### PR TITLE
refactor: align preferences tests with array storage

### DIFF
--- a/src/__tests__/friendMenuVisibility.test.jsx
+++ b/src/__tests__/friendMenuVisibility.test.jsx
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
-import { useMenus } from '../hooks/useMenus.js';
 
 let ownerEqCalls = [];
 let participantEqCalls = [];
@@ -66,10 +65,12 @@ beforeEach(() => {
   inCalls = [];
   weeklyMenusData = [];
   participantRowsData = [];
+  vi.resetModules();
 });
 
 describe('useMenus friend visibility', () => {
   it('includes shared menus from friends', async () => {
+    const { useMenus } = await import('../hooks/useMenus.js');
     weeklyMenusData = [
       { id: 'm1', user_id: 'user1', name: 'Menu 1', updated_at: 'now', is_shared: false },
       { id: 'm2', user_id: 'user2', name: 'Menu Ami', updated_at: 'now', is_shared: false },
@@ -94,6 +95,7 @@ describe('useMenus friend visibility', () => {
   });
 
   it('ignores menus that are not shared', async () => {
+    const { useMenus } = await import('../hooks/useMenus.js');
     weeklyMenusData = [
       { id: 'm1', user_id: 'user1', name: 'Menu 1', updated_at: 'now', is_shared: false },
       { id: 'm2', user_id: 'user2', name: 'Menu Ami', updated_at: 'now', is_shared: false },

--- a/src/lib/menuPreferences.ts
+++ b/src/lib/menuPreferences.ts
@@ -70,14 +70,12 @@ export function toDbPrefs(pref: {
     portions_per_meal: effective.servingsPerMeal,
     daily_calories_limit: effective.maxCalories,
     weekly_budget: effective.weeklyBudget,
-    daily_meal_structure: JSON.stringify(
-      Array.isArray(effective.meals)
-        ? effective.meals
-            .filter((m) => m.enabled)
-            .map((m) => (Array.isArray(m.types) ? m.types : []))
-        : []
-    ),
-    tag_preferences: JSON.stringify(effective.tagPreferences || []),
-    common_menu_settings: JSON.stringify(effective.commonMenuSettings ?? {}),
+    daily_meal_structure: Array.isArray(effective.meals)
+      ? effective.meals
+          .filter((m) => m.enabled)
+          .map((m) => (Array.isArray(m.types) ? m.types : []))
+      : [],
+    tag_preferences: effective.tagPreferences || [],
+    common_menu_settings: effective.commonMenuSettings ?? {},
   };
 }

--- a/tests/preferences.integration.spec.jsx
+++ b/tests/preferences.integration.spec.jsx
@@ -133,12 +133,6 @@ describe('useWeeklyMenu.updateMenuPreferences', () => {
 
     const actual = { ...global.__supabaseState.lastUpsert };
     const expectedDb = toDbPrefs(newPrefs);
-    ['daily_meal_structure', 'tag_preferences', 'common_menu_settings'].forEach(
-      (f) => {
-        actual[f] = JSON.parse(actual[f]);
-        expectedDb[f] = JSON.parse(expectedDb[f]);
-      }
-    );
     expect(actual).toEqual({ menu_id: 'menu1', ...expectedDb });
   });
 
@@ -154,12 +148,6 @@ describe('useWeeklyMenu.updateMenuPreferences', () => {
     const expectedDb = toDbPrefs({ ...expected, commonMenuSettings: {} });
 
     const actual = { ...global.__supabaseState.lastUpsert };
-    ['daily_meal_structure', 'tag_preferences', 'common_menu_settings'].forEach(
-      (f) => {
-        actual[f] = JSON.parse(actual[f]);
-        expectedDb[f] = JSON.parse(expectedDb[f]);
-      }
-    );
     expect(actual).toEqual({ menu_id: 'menu1', ...expectedDb });
     expect(result.current.preferences).toEqual(expected);
   });

--- a/tests/preferences.spec.ts
+++ b/tests/preferences.spec.ts
@@ -19,12 +19,11 @@ describe('preferences conversion', () => {
     };
 
     const dbShape = toDbPrefs(prefs);
-    expect(JSON.parse(dbShape.common_menu_settings)).toEqual(
-      prefs.commonMenuSettings
-    );
-    expect(JSON.parse(dbShape.daily_meal_structure)).toEqual([
+    expect(dbShape.common_menu_settings).toEqual(prefs.commonMenuSettings);
+    expect(dbShape.daily_meal_structure).toEqual([
       ['petit-dejeuner', 'brunch'],
     ]);
+    expect(dbShape.tag_preferences).toEqual(['vegan']);
 
     const restored = fromDbPrefs(dbShape);
     expect(restored).toEqual(prefs);


### PR DESCRIPTION
## Summary
- compare DB preference fields directly against arrays without JSON.parse
- drop JSON serialization in toDbPrefs
- isolate supabase mock in friend menu visibility tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899e84d1680832da5314bab8ce83c6f