### PR TITLE
refactor: tighten menu preference types

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -9,10 +9,8 @@ export type WeeklyMenuPreferences = {
   portions_per_meal: number;
   daily_calories_limit: number | null;
   weekly_budget: number;
-  /** stored as JSON string in DB, parsed as array on client */
-  daily_meal_structure: string[][] | string;
-  /** stored as JSON string in DB, parsed as array on client */
-  tag_preferences: string[] | string;
+  daily_meal_structure: string[][];
+  tag_preferences: string[];
   /** Client side representation of meals */
   meals?: {
     id: number;
@@ -22,7 +20,6 @@ export type WeeklyMenuPreferences = {
   }[];
   /** Camel case tag preferences for generator */
   tagPreferences?: { tag: string; percentage: number }[] | string[];
-  /** stored as JSON string in DB, parsed as object on client */
   common_menu_settings?: CommonMenuSettings | string;
 };
 


### PR DESCRIPTION
## Summary
- store menu `daily_meal_structure` as `string[][]`
- store menu `tag_preferences` as `string[]`
- drop outdated JSON-string comments

## Testing
- `npm test` *(fails: friend menu visibility test)*
- `npm run lint` *(fails: multiple no-undef errors)*

------
https://chatgpt.com/codex/tasks/task_e_6899ebc0af28832d8c9e1073e63e1fb2