### PR TITLE
test: remove JSON parsing for menu preferences

### DIFF
--- a/api/create-shared-menu.ts
+++ b/api/create-shared-menu.ts
@@ -58,9 +58,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           daily_meal_structure: as2DTextArray(
             menu_data?.daily_meal_structure
           ),
-          common_menu_settings: JSON.stringify(
-            menu_data?.common_menu_settings ?? {}
-          ),
+          common_menu_settings: menu_data?.common_menu_settings ?? {},
         };
 
     const { data: inserted, error } = await supabaseAdmin

--- a/src/lib/menuPreferences.ts
+++ b/src/lib/menuPreferences.ts
@@ -114,6 +114,6 @@ export function toDbPrefs(pref: {
         : []
     ),
     tag_preferences: asTextArray(effective.tagPreferences),
-    common_menu_settings: JSON.stringify(effective.commonMenuSettings ?? {}),
+    common_menu_settings: effective.commonMenuSettings ?? {},
   };
 }

--- a/tests/preferences.integration.spec.jsx
+++ b/tests/preferences.integration.spec.jsx
@@ -133,10 +133,6 @@ describe('useWeeklyMenu.updateMenuPreferences', () => {
 
     const actual = { ...global.__supabaseState.lastUpsert };
     const expectedDb = toDbPrefs(newPrefs);
-    ['common_menu_settings'].forEach((f) => {
-      actual[f] = JSON.parse(actual[f]);
-      expectedDb[f] = JSON.parse(expectedDb[f]);
-    });
     expect(actual).toEqual({ menu_id: 'menu1', ...expectedDb });
   });
 
@@ -152,10 +148,6 @@ describe('useWeeklyMenu.updateMenuPreferences', () => {
     const expectedDb = toDbPrefs({ ...expected, commonMenuSettings: {} });
 
     const actual = { ...global.__supabaseState.lastUpsert };
-    ['common_menu_settings'].forEach((f) => {
-      actual[f] = JSON.parse(actual[f]);
-      expectedDb[f] = JSON.parse(expectedDb[f]);
-    });
     expect(actual).toEqual({ menu_id: 'menu1', ...expectedDb });
     expect(result.current.preferences).toEqual(expected);
   });

--- a/tests/preferences.spec.ts
+++ b/tests/preferences.spec.ts
@@ -19,12 +19,11 @@ describe('preferences conversion', () => {
     };
 
     const dbShape = toDbPrefs(prefs);
-    expect(JSON.parse(dbShape.common_menu_settings)).toEqual(
-      prefs.commonMenuSettings
-    );
+    expect(dbShape.common_menu_settings).toEqual(prefs.commonMenuSettings);
     expect(dbShape.daily_meal_structure).toEqual([
       ['petit-dejeuner', 'brunch'],
     ]);
+    expect(dbShape.tag_preferences).toEqual(['vegan']);
 
     const restored = fromDbPrefs(dbShape);
     expect(restored).toEqual(prefs);


### PR DESCRIPTION
## Summary
- handle `common_menu_settings` as objects in menu preference conversions
- simplify preference tests to compare arrays/objects directly
- remove JSON.parse blocks from integration tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899ebf1d9b0832d9a9275e1401ec3b3