### PR TITLE
Sync menu participants on preference updates

### DIFF
--- a/src/__tests__/friendMenuVisibility.test.jsx
+++ b/src/__tests__/friendMenuVisibility.test.jsx
@@ -9,7 +9,7 @@ let inCalls = [];
 let weeklyMenusData = [];
 let participantRowsData = [];
 
-vi.mock('../lib/supabase', () => {
+vi.mock('@/lib/supabase', () => {
   function applyFilters(data, filters) {
     let result = data;
     filters.forEach(([c, v]) => {


### PR DESCRIPTION
## Summary
- synchronize `menu_participants` when preferences change to add new users and remove those no longer linked
- add integration test verifying menu participant sync

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_6899fbe5e160832d97f59af1acfe0ea2