### PR TITLE
docs: clarify menu participant writers

### DIFF
--- a/src/lib/syncMenuParticipants.ts
+++ b/src/lib/syncMenuParticipants.ts
@@ -13,6 +13,11 @@ export function normalizeWeights(list: MenuParticipant[]) {
   return rows;
 }
 
+/**
+ * Sync participants for a menu on the client side. Note that server-side
+ * creation (e.g. the `create-shared-menu` API route) may also insert rows into
+ * `menu_participants`, so this isn't the only writer to that table.
+ */
 export async function syncMenuParticipants(
   supabase: any,
   menuId: string,


### PR DESCRIPTION
## Summary
- note client-side sync isn't the only menu_participants writer

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: 'global' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689b29deab00832d9129cf21776541af